### PR TITLE
feat(microwave): add TerminalWavePort for terminal-based S-parameter extraction

### DIFF
--- a/changelog.d/3238.added.md
+++ b/changelog.d/3238.added.md
@@ -1,0 +1,1 @@
+Added `TerminalWavePort` for terminal-driven modal excitation in transmission line simulations. Added `reference_impedance` field on both `WavePort` and `TerminalWavePort` to allow user-specified reference impedance for S-parameter calculations.

--- a/docs/api/microwave/component_modeler.rst
+++ b/docs/api/microwave/component_modeler.rst
@@ -27,7 +27,7 @@ The :class:`~tidy3d.rf.TerminalComponentModeler` is the core simulation object f
 The key parts of a :class:`~tidy3d.rf.TerminalComponentModeler` are:
 
 * The :class:`~tidy3d.Simulation` field defines the underlying Tidy3D `Simulation object <../simulation.html>`_. This base :class:`~tidy3d.Simulation` object contains information about the simulation domain such as structures, boundary conditions, grid specifications, and monitors. Note that sources should not be included in the base simulation, but rather in the ``ports`` field instead.
-* The ``ports`` field defines the list of source excitations. These are commonly of type :class:`~tidy3d.rf.LumpedPort` or :class:`~tidy3d.rf.WavePort`. The number of ports determines the number of batch jobs in the :class:`~tidy3d.rf.TerminalComponentModeler` and the dimensionality of the S-parameter matrix. **Note:** Port names cannot contain the '@' symbol (reserved for internal indexing).
+* The ``ports`` field defines the list of source excitations. These are commonly of type :class:`~tidy3d.rf.LumpedPort`, :class:`~tidy3d.rf.WavePort`, or :class:`~tidy3d.rf.TerminalWavePort`. The number of ports determines the number of batch jobs in the :class:`~tidy3d.rf.TerminalComponentModeler` and the dimensionality of the S-parameter matrix. **Note:** Port names cannot contain the '@' symbol (reserved for internal indexing).
 * The ``freqs`` field defines the list of frequency points for the simulation.
 
 More information and explanation for additional fields can be found in the documentation page for the :class:`~tidy3d.rf.TerminalComponentModeler`.

--- a/docs/api/microwave/index.rst
+++ b/docs/api/microwave/index.rst
@@ -40,7 +40,7 @@ The following sections discuss:
 * `Impedance Calculator`_: Post-processing tool for impedance calculation from electromagnetic fields
 * `RF Mode Analysis`_: Performing RF-specific mode analysis, like computing the characteristic impedance of transmission line modes
 * `Lumped Port & Elements`_: Lumped excitations and circuit elements
-* `Wave Port`_: Port excitation based on modal fields
+* `Wave Port`_: Port excitation based on modal fields or terminal modal fields
 * `Radiation & Scattering`_: Useful features for antenna and scattering problems
 * `RF Output Data`_: Data containers for microwave simulation results
 

--- a/docs/api/microwave/output_data.rst
+++ b/docs/api/microwave/output_data.rst
@@ -47,6 +47,7 @@ Datasets and Data Arrays
    :template: module.rst
 
    tidy3d.components.microwave.data.dataset.TransmissionLineDataset
+   tidy3d.components.microwave.data.dataset.TransmissionLineTerminalDataset
 
 **Data Arrays**
 
@@ -54,15 +55,26 @@ Datasets and Data Arrays
    :toctree: ../_autosummary/
    :template: module.rst
 
+   tidy3d.components.data.data_array.ModeDataArray
+   tidy3d.components.data.data_array.TerminalDataArray
+   tidy3d.components.data.data_array.FreqTerminalDataArray
+   tidy3d.components.data.data_array.FreqTerminalModeDataArray
+   tidy3d.components.data.data_array.FreqTerminalTerminalDataArray
    tidy3d.components.data.data_array.VoltageTimeDataArray
    tidy3d.components.data.data_array.VoltageFreqDataArray
    tidy3d.components.data.data_array.VoltageFreqModeDataArray
+   tidy3d.components.data.data_array.VoltageFreqTerminalModeDataArray
    tidy3d.components.data.data_array.CurrentTimeDataArray
    tidy3d.components.data.data_array.CurrentFreqDataArray
    tidy3d.components.data.data_array.CurrentFreqModeDataArray
+   tidy3d.components.data.data_array.CurrentFreqTerminalDataArray
+   tidy3d.components.data.data_array.CurrentFreqTerminalModeDataArray
+   tidy3d.components.data.data_array.ImpedanceModeDataArray
+   tidy3d.components.data.data_array.ImpedanceTerminalDataArray
    tidy3d.components.data.data_array.ImpedanceTimeDataArray
    tidy3d.components.data.data_array.ImpedanceFreqDataArray
    tidy3d.components.data.data_array.ImpedanceFreqModeDataArray
+   tidy3d.components.data.data_array.ImpedanceFreqTerminalTerminalDataArray
    tidy3d.components.microwave.data.data_array.PropagationConstantArray
    tidy3d.components.microwave.data.data_array.PhaseConstantArray
    tidy3d.components.microwave.data.data_array.AttenuationConstantArray

--- a/docs/api/microwave/ports/lumped.rst
+++ b/docs/api/microwave/ports/lumped.rst
@@ -27,7 +27,7 @@ The :class:`~tidy3d.rf.LumpedPort` must be planar (exactly one zero-size dimensi
 
 .. note::
 
-   Lumped ports and elements are fundamentally approximations and thus should only be used when the port/element size is much smaller than the wavelength of interest (typically ``lambda/10``). For more accurate results, especially when the port is adjacent to an intentional waveguide or transmission line, consider using the :class:`~tidy3d.rf.WavePort` excitation instead.
+   Lumped ports and elements are fundamentally approximations and thus should only be used when the port/element size is much smaller than the wavelength of interest (typically ``lambda/10``). For more accurate results, especially when the port is adjacent to an intentional waveguide or transmission line, consider using the :class:`~tidy3d.rf.WavePort` or :class:`~tidy3d.rf.TerminalWavePort` excitation instead.
 
 The ``CoaxialLumpedPort`` represents an analytical coaxial field source.
 

--- a/docs/api/microwave/ports/wave.rst
+++ b/docs/api/microwave/ports/wave.rst
@@ -8,6 +8,7 @@ Wave Port
    :template: module.rst
 
    tidy3d.rf.WavePort
+   tidy3d.rf.TerminalWavePort
 
 The :class:`~tidy3d.rf.WavePort` represents a modal source port for RF and microwave simulations. The port mode is first calculated in the 2D mode solver with automatic characteristic impedance calculation, then injected into the 3D simulation. The :class:`~tidy3d.rf.WavePort` is also automatically terminated with a modal absorbing boundary :class:`~tidy3d.ModeABCBoundary` that perfectly absorbs the outgoing mode. Any non-matching modes are subject to PEC reflection.
 
@@ -128,5 +129,20 @@ Alternatively, use the port's ``get_port_impedance()`` method:
    + `Differential stripline benchmark <../../notebooks/DifferentialStripline.html>`_
    + `Coplanar waveguide RF photonics <../../notebooks/CPWRFPhotonics1.html>`_
    + `Through silicon via <../../notebooks/ThroughSiliconVia.html>`_
+
+**Terminal Wave Port**
+
+The :class:`~tidy3d.rf.TerminalWavePort` is a terminal-driven wave port that supports
+single-ended and differential terminal excitations.
+
+.. code-block:: python
+
+   my_terminal_wave_port = TerminalWavePort(
+       center=(0, 0, 0),
+       size=(4, 4, 0),
+       name='My Terminal Wave Port',
+       direction='+',
+       differential_pairs=(("T0", "T1"),),
+   )
 
 ~~~~

--- a/docs/api/plugins/smatrix.rst
+++ b/docs/api/plugins/smatrix.rst
@@ -49,6 +49,7 @@ For RF and microwave applications, use the **TerminalComponentModeler** (availab
    tidy3d.plugins.smatrix.LumpedPort
    tidy3d.plugins.smatrix.CoaxialLumpedPort
    tidy3d.rf.WavePort
+   tidy3d.rf.TerminalWavePort
    tidy3d.rf.MicrowaveSMatrixData
    tidy3d.rf.TerminalPortDataArray
    tidy3d.rf.PortDataArray

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -8038,9 +8038,17 @@
           "default": null
         },
         "num_modes": {
-          "default": 1,
-          "exclusiveMinimum": 0,
-          "type": "integer"
+          "anyOf": [
+            {
+              "const": "auto",
+              "type": "string"
+            },
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          ],
+          "default": 1
         },
         "num_pml": {
           "default": [
@@ -8121,6 +8129,213 @@
       },
       "type": "object"
     },
+    "MicrowaveTerminalModeSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "angle_phi": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "angle_rotation": {
+          "default": false,
+          "type": "boolean"
+        },
+        "angle_theta": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "bend_axis": {
+          "anyOf": [
+            {
+              "enum": [
+                0,
+                1
+              ],
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bend_radius": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": null
+        },
+        "filter_pol": {
+          "anyOf": [
+            {
+              "enum": [
+                "te",
+                "tm"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "group_index_step": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": false
+        },
+        "impedance_specs": {
+          "additionalProperties": {
+            "$ref": "#/$defs/CustomImpedanceSpec"
+          },
+          "type": "object"
+        },
+        "interp_spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModeInterpSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "num_modes": {
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        "num_pml": {
+          "default": [
+            0,
+            0
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "minimum": 0,
+              "type": "integer"
+            }
+          ],
+          "type": "array"
+        },
+        "precision": {
+          "default": "double",
+          "enum": [
+            "auto",
+            "double",
+            "single"
+          ],
+          "type": "string"
+        },
+        "qtem_polarization_threshold": {
+          "default": 0.95,
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "type": "number"
+        },
+        "sort_spec": {
+          "$ref": "#/$defs/ModeSortSpec"
+        },
+        "target_neff": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "tem_polarization_threshold": {
+          "default": 0.995,
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "type": "number"
+        },
+        "terminals_mapping": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "prefixItems": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "type": "array"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "track_freq": {
+          "anyOf": [
+            {
+              "enum": [
+                "central",
+                "highest",
+                "lowest"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "MicrowaveTerminalModeSpec",
+          "default": "MicrowaveTerminalModeSpec",
+          "type": "string"
+        }
+      },
+      "required": [
+        "impedance_specs",
+        "num_modes"
+      ],
+      "type": "object"
+    },
     "ModeABCBoundary": {
       "additionalProperties": false,
       "properties": {
@@ -8185,6 +8400,7 @@
           "discriminator": {
             "mapping": {
               "MicrowaveModeSpec": "#/$defs/MicrowaveModeSpec",
+              "MicrowaveTerminalModeSpec": "#/$defs/MicrowaveTerminalModeSpec",
               "ModeSpec": "#/$defs/ModeSpec"
             },
             "propertyName": "type"
@@ -8192,6 +8408,9 @@
           "oneOf": [
             {
               "$ref": "#/$defs/MicrowaveModeSpec"
+            },
+            {
+              "$ref": "#/$defs/MicrowaveTerminalModeSpec"
             },
             {
               "$ref": "#/$defs/ModeSpec"

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -7525,9 +7525,17 @@
           "default": null
         },
         "num_modes": {
-          "default": 1,
-          "exclusiveMinimum": 0,
-          "type": "integer"
+          "anyOf": [
+            {
+              "const": "auto",
+              "type": "string"
+            },
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          ],
+          "default": 1
         },
         "num_pml": {
           "default": [
@@ -7608,6 +7616,213 @@
       },
       "type": "object"
     },
+    "MicrowaveTerminalModeSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "angle_phi": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "angle_rotation": {
+          "default": false,
+          "type": "boolean"
+        },
+        "angle_theta": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "bend_axis": {
+          "anyOf": [
+            {
+              "enum": [
+                0,
+                1
+              ],
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bend_radius": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": null
+        },
+        "filter_pol": {
+          "anyOf": [
+            {
+              "enum": [
+                "te",
+                "tm"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "group_index_step": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": false
+        },
+        "impedance_specs": {
+          "additionalProperties": {
+            "$ref": "#/$defs/CustomImpedanceSpec"
+          },
+          "type": "object"
+        },
+        "interp_spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModeInterpSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "num_modes": {
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        "num_pml": {
+          "default": [
+            0,
+            0
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "minimum": 0,
+              "type": "integer"
+            }
+          ],
+          "type": "array"
+        },
+        "precision": {
+          "default": "double",
+          "enum": [
+            "auto",
+            "double",
+            "single"
+          ],
+          "type": "string"
+        },
+        "qtem_polarization_threshold": {
+          "default": 0.95,
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "type": "number"
+        },
+        "sort_spec": {
+          "$ref": "#/$defs/ModeSortSpec"
+        },
+        "target_neff": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "tem_polarization_threshold": {
+          "default": 0.995,
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "type": "number"
+        },
+        "terminals_mapping": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "prefixItems": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "type": "array"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "track_freq": {
+          "anyOf": [
+            {
+              "enum": [
+                "central",
+                "highest",
+                "lowest"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "MicrowaveTerminalModeSpec",
+          "default": "MicrowaveTerminalModeSpec",
+          "type": "string"
+        }
+      },
+      "required": [
+        "impedance_specs",
+        "num_modes"
+      ],
+      "type": "object"
+    },
     "ModeABCBoundary": {
       "additionalProperties": false,
       "properties": {
@@ -7672,6 +7887,7 @@
           "discriminator": {
             "mapping": {
               "MicrowaveModeSpec": "#/$defs/MicrowaveModeSpec",
+              "MicrowaveTerminalModeSpec": "#/$defs/MicrowaveTerminalModeSpec",
               "ModeSpec": "#/$defs/ModeSpec"
             },
             "propertyName": "type"
@@ -7679,6 +7895,9 @@
           "oneOf": [
             {
               "$ref": "#/$defs/MicrowaveModeSpec"
+            },
+            {
+              "$ref": "#/$defs/MicrowaveTerminalModeSpec"
             },
             {
               "$ref": "#/$defs/ModeSpec"
@@ -8204,6 +8423,7 @@
           "discriminator": {
             "mapping": {
               "MicrowaveModeSpec": "#/$defs/MicrowaveModeSpec",
+              "MicrowaveTerminalModeSpec": "#/$defs/MicrowaveTerminalModeSpec",
               "ModeSpec": "#/$defs/ModeSpec"
             },
             "propertyName": "type"
@@ -8211,6 +8431,9 @@
           "oneOf": [
             {
               "$ref": "#/$defs/MicrowaveModeSpec"
+            },
+            {
+              "$ref": "#/$defs/MicrowaveTerminalModeSpec"
             },
             {
               "$ref": "#/$defs/ModeSpec"
@@ -12204,6 +12427,7 @@
       "discriminator": {
         "mapping": {
           "MicrowaveModeSpec": "#/$defs/MicrowaveModeSpec",
+          "MicrowaveTerminalModeSpec": "#/$defs/MicrowaveTerminalModeSpec",
           "ModeSpec": "#/$defs/ModeSpec"
         },
         "propertyName": "type"
@@ -12211,6 +12435,9 @@
       "oneOf": [
         {
           "$ref": "#/$defs/MicrowaveModeSpec"
+        },
+        {
+          "$ref": "#/$defs/MicrowaveTerminalModeSpec"
         },
         {
           "$ref": "#/$defs/ModeSpec"

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -10398,7 +10398,14 @@
           "type": "array"
         },
         "mode_spec": {
-          "$ref": "#/$defs/MicrowaveModeSpec"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MicrowaveModeSpec"
+            },
+            {
+              "$ref": "#/$defs/MicrowaveTerminalModeSpec"
+            }
+          ]
         },
         "name": {
           "minLength": 1,
@@ -10542,7 +10549,14 @@
           "type": "array"
         },
         "mode_spec": {
-          "$ref": "#/$defs/MicrowaveModeSpec"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MicrowaveModeSpec"
+            },
+            {
+              "$ref": "#/$defs/MicrowaveTerminalModeSpec"
+            }
+          ]
         },
         "name": {
           "minLength": 1,
@@ -10696,9 +10710,17 @@
           "default": null
         },
         "num_modes": {
-          "default": 1,
-          "exclusiveMinimum": 0,
-          "type": "integer"
+          "anyOf": [
+            {
+              "const": "auto",
+              "type": "string"
+            },
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          ],
+          "default": 1
         },
         "num_pml": {
           "default": [
@@ -10779,6 +10801,345 @@
       },
       "type": "object"
     },
+    "MicrowaveTerminalModeSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "angle_phi": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "angle_rotation": {
+          "default": false,
+          "type": "boolean"
+        },
+        "angle_theta": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "bend_axis": {
+          "anyOf": [
+            {
+              "enum": [
+                0,
+                1
+              ],
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bend_radius": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": null
+        },
+        "filter_pol": {
+          "anyOf": [
+            {
+              "enum": [
+                "te",
+                "tm"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "group_index_step": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": false
+        },
+        "impedance_specs": {
+          "additionalProperties": {
+            "$ref": "#/$defs/CustomImpedanceSpec"
+          },
+          "type": "object"
+        },
+        "interp_spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModeInterpSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "num_modes": {
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        "num_pml": {
+          "default": [
+            0,
+            0
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "minimum": 0,
+              "type": "integer"
+            }
+          ],
+          "type": "array"
+        },
+        "precision": {
+          "default": "double",
+          "enum": [
+            "auto",
+            "double",
+            "single"
+          ],
+          "type": "string"
+        },
+        "qtem_polarization_threshold": {
+          "default": 0.95,
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "type": "number"
+        },
+        "sort_spec": {
+          "$ref": "#/$defs/ModeSortSpec"
+        },
+        "target_neff": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "tem_polarization_threshold": {
+          "default": 0.995,
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "type": "number"
+        },
+        "terminals_mapping": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "prefixItems": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "type": "array"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "track_freq": {
+          "anyOf": [
+            {
+              "enum": [
+                "central",
+                "highest",
+                "lowest"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "MicrowaveTerminalModeSpec",
+          "default": "MicrowaveTerminalModeSpec",
+          "type": "string"
+        }
+      },
+      "required": [
+        "impedance_specs",
+        "num_modes"
+      ],
+      "type": "object"
+    },
+    "MicrowaveTerminalSource": {
+      "additionalProperties": false,
+      "properties": {
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "center": {
+          "anyOf": [
+            {
+              "maxItems": 3,
+              "minItems": 3,
+              "prefixItems": [
+                {},
+                {},
+                {}
+              ],
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "direction": {
+          "enum": [
+            "+",
+            "-"
+          ],
+          "type": "string"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PECFrame"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "mode_spec": {
+          "$ref": "#/$defs/MicrowaveTerminalModeSpec"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": null
+        },
+        "num_freqs": {
+          "default": 1,
+          "maximum": 20,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "size": {
+          "maxItems": 3,
+          "minItems": 3,
+          "prefixItems": [
+            {},
+            {},
+            {}
+          ],
+          "type": "array"
+        },
+        "source_time": {
+          "discriminator": {
+            "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
+              "BroadbandPulse": "#/$defs/BroadbandPulse",
+              "ContinuousWave": "#/$defs/ContinuousWave",
+              "CustomSourceTime": "#/$defs/CustomSourceTime",
+              "GaussianPulse": "#/$defs/GaussianPulse"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
+            {
+              "$ref": "#/$defs/BroadbandPulse"
+            },
+            {
+              "$ref": "#/$defs/ContinuousWave"
+            },
+            {
+              "$ref": "#/$defs/CustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/GaussianPulse"
+            }
+          ]
+        },
+        "terminal_label": {
+          "type": "string"
+        },
+        "type": {
+          "const": "MicrowaveTerminalSource",
+          "default": "MicrowaveTerminalSource",
+          "type": "string"
+        }
+      },
+      "required": [
+        "direction",
+        "mode_spec",
+        "size",
+        "source_time",
+        "terminal_label"
+      ],
+      "type": "object"
+    },
     "ModeABCBoundary": {
       "additionalProperties": false,
       "properties": {
@@ -10843,6 +11204,7 @@
           "discriminator": {
             "mapping": {
               "MicrowaveModeSpec": "#/$defs/MicrowaveModeSpec",
+              "MicrowaveTerminalModeSpec": "#/$defs/MicrowaveTerminalModeSpec",
               "ModeSpec": "#/$defs/ModeSpec"
             },
             "propertyName": "type"
@@ -10850,6 +11212,9 @@
           "oneOf": [
             {
               "$ref": "#/$defs/MicrowaveModeSpec"
+            },
+            {
+              "$ref": "#/$defs/MicrowaveTerminalModeSpec"
             },
             {
               "$ref": "#/$defs/ModeSpec"
@@ -11375,6 +11740,7 @@
           "discriminator": {
             "mapping": {
               "MicrowaveModeSpec": "#/$defs/MicrowaveModeSpec",
+              "MicrowaveTerminalModeSpec": "#/$defs/MicrowaveTerminalModeSpec",
               "ModeSpec": "#/$defs/ModeSpec"
             },
             "propertyName": "type"
@@ -11382,6 +11748,9 @@
           "oneOf": [
             {
               "$ref": "#/$defs/MicrowaveModeSpec"
+            },
+            {
+              "$ref": "#/$defs/MicrowaveTerminalModeSpec"
             },
             {
               "$ref": "#/$defs/ModeSpec"
@@ -16092,6 +16461,7 @@
             "CustomCurrentSource": "#/$defs/CustomCurrentSource",
             "CustomFieldSource": "#/$defs/CustomFieldSource",
             "GaussianBeam": "#/$defs/GaussianBeam",
+            "MicrowaveTerminalSource": "#/$defs/MicrowaveTerminalSource",
             "ModeSource": "#/$defs/ModeSource",
             "PlaneWave": "#/$defs/PlaneWave",
             "PointDipole": "#/$defs/PointDipole",
@@ -16112,6 +16482,9 @@
           },
           {
             "$ref": "#/$defs/GaussianBeam"
+          },
+          {
+            "$ref": "#/$defs/MicrowaveTerminalSource"
           },
           {
             "$ref": "#/$defs/ModeSource"

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -10665,7 +10665,14 @@
           "type": "array"
         },
         "mode_spec": {
-          "$ref": "#/$defs/MicrowaveModeSpec"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MicrowaveModeSpec"
+            },
+            {
+              "$ref": "#/$defs/MicrowaveTerminalModeSpec"
+            }
+          ]
         },
         "name": {
           "minLength": 1,
@@ -10809,7 +10816,14 @@
           "type": "array"
         },
         "mode_spec": {
-          "$ref": "#/$defs/MicrowaveModeSpec"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MicrowaveModeSpec"
+            },
+            {
+              "$ref": "#/$defs/MicrowaveTerminalModeSpec"
+            }
+          ]
         },
         "name": {
           "minLength": 1,
@@ -10963,9 +10977,17 @@
           "default": null
         },
         "num_modes": {
-          "default": 1,
-          "exclusiveMinimum": 0,
-          "type": "integer"
+          "anyOf": [
+            {
+              "const": "auto",
+              "type": "string"
+            },
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            }
+          ],
+          "default": 1
         },
         "num_pml": {
           "default": [
@@ -11046,6 +11068,345 @@
       },
       "type": "object"
     },
+    "MicrowaveTerminalModeSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "angle_phi": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "angle_rotation": {
+          "default": false,
+          "type": "boolean"
+        },
+        "angle_theta": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "bend_axis": {
+          "anyOf": [
+            {
+              "enum": [
+                0,
+                1
+              ],
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "bend_radius": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": null
+        },
+        "filter_pol": {
+          "anyOf": [
+            {
+              "enum": [
+                "te",
+                "tm"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "group_index_step": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": false
+        },
+        "impedance_specs": {
+          "additionalProperties": {
+            "$ref": "#/$defs/CustomImpedanceSpec"
+          },
+          "type": "object"
+        },
+        "interp_spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModeInterpSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "num_modes": {
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        "num_pml": {
+          "default": [
+            0,
+            0
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "minimum": 0,
+              "type": "integer"
+            }
+          ],
+          "type": "array"
+        },
+        "precision": {
+          "default": "double",
+          "enum": [
+            "auto",
+            "double",
+            "single"
+          ],
+          "type": "string"
+        },
+        "qtem_polarization_threshold": {
+          "default": 0.95,
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "type": "number"
+        },
+        "sort_spec": {
+          "$ref": "#/$defs/ModeSortSpec"
+        },
+        "target_neff": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "tem_polarization_threshold": {
+          "default": 0.995,
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "type": "number"
+        },
+        "terminals_mapping": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "prefixItems": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "type": "array"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "track_freq": {
+          "anyOf": [
+            {
+              "enum": [
+                "central",
+                "highest",
+                "lowest"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "MicrowaveTerminalModeSpec",
+          "default": "MicrowaveTerminalModeSpec",
+          "type": "string"
+        }
+      },
+      "required": [
+        "impedance_specs",
+        "num_modes"
+      ],
+      "type": "object"
+    },
+    "MicrowaveTerminalSource": {
+      "additionalProperties": false,
+      "properties": {
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "center": {
+          "anyOf": [
+            {
+              "maxItems": 3,
+              "minItems": 3,
+              "prefixItems": [
+                {},
+                {},
+                {}
+              ],
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "direction": {
+          "enum": [
+            "+",
+            "-"
+          ],
+          "type": "string"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PECFrame"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "mode_spec": {
+          "$ref": "#/$defs/MicrowaveTerminalModeSpec"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": null
+        },
+        "num_freqs": {
+          "default": 1,
+          "maximum": 20,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "size": {
+          "maxItems": 3,
+          "minItems": 3,
+          "prefixItems": [
+            {},
+            {},
+            {}
+          ],
+          "type": "array"
+        },
+        "source_time": {
+          "discriminator": {
+            "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
+              "BroadbandPulse": "#/$defs/BroadbandPulse",
+              "ContinuousWave": "#/$defs/ContinuousWave",
+              "CustomSourceTime": "#/$defs/CustomSourceTime",
+              "GaussianPulse": "#/$defs/GaussianPulse"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
+            {
+              "$ref": "#/$defs/BroadbandPulse"
+            },
+            {
+              "$ref": "#/$defs/ContinuousWave"
+            },
+            {
+              "$ref": "#/$defs/CustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/GaussianPulse"
+            }
+          ]
+        },
+        "terminal_label": {
+          "type": "string"
+        },
+        "type": {
+          "const": "MicrowaveTerminalSource",
+          "default": "MicrowaveTerminalSource",
+          "type": "string"
+        }
+      },
+      "required": [
+        "direction",
+        "mode_spec",
+        "size",
+        "source_time",
+        "terminal_label"
+      ],
+      "type": "object"
+    },
     "ModeABCBoundary": {
       "additionalProperties": false,
       "properties": {
@@ -11110,6 +11471,7 @@
           "discriminator": {
             "mapping": {
               "MicrowaveModeSpec": "#/$defs/MicrowaveModeSpec",
+              "MicrowaveTerminalModeSpec": "#/$defs/MicrowaveTerminalModeSpec",
               "ModeSpec": "#/$defs/ModeSpec"
             },
             "propertyName": "type"
@@ -11117,6 +11479,9 @@
           "oneOf": [
             {
               "$ref": "#/$defs/MicrowaveModeSpec"
+            },
+            {
+              "$ref": "#/$defs/MicrowaveTerminalModeSpec"
             },
             {
               "$ref": "#/$defs/ModeSpec"
@@ -11642,6 +12007,7 @@
           "discriminator": {
             "mapping": {
               "MicrowaveModeSpec": "#/$defs/MicrowaveModeSpec",
+              "MicrowaveTerminalModeSpec": "#/$defs/MicrowaveTerminalModeSpec",
               "ModeSpec": "#/$defs/ModeSpec"
             },
             "propertyName": "type"
@@ -11649,6 +12015,9 @@
           "oneOf": [
             {
               "$ref": "#/$defs/MicrowaveModeSpec"
+            },
+            {
+              "$ref": "#/$defs/MicrowaveTerminalModeSpec"
             },
             {
               "$ref": "#/$defs/ModeSpec"
@@ -14875,6 +15244,7 @@
                 "CustomCurrentSource": "#/$defs/CustomCurrentSource",
                 "CustomFieldSource": "#/$defs/CustomFieldSource",
                 "GaussianBeam": "#/$defs/GaussianBeam",
+                "MicrowaveTerminalSource": "#/$defs/MicrowaveTerminalSource",
                 "ModeSource": "#/$defs/ModeSource",
                 "PlaneWave": "#/$defs/PlaneWave",
                 "PointDipole": "#/$defs/PointDipole",
@@ -14895,6 +15265,9 @@
               },
               {
                 "$ref": "#/$defs/GaussianBeam"
+              },
+              {
+                "$ref": "#/$defs/MicrowaveTerminalSource"
               },
               {
                 "$ref": "#/$defs/ModeSource"
@@ -15948,6 +16321,159 @@
       ],
       "type": "object"
     },
+    "TerminalWavePort": {
+      "additionalProperties": false,
+      "properties": {
+        "absorber": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ABCBoundary"
+            },
+            {
+              "$ref": "#/$defs/ModeABCBoundary"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": false
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "center": {
+          "anyOf": [
+            {
+              "maxItems": 3,
+              "minItems": 3,
+              "prefixItems": [
+                {},
+                {},
+                {}
+              ],
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "conjugated_dot_product": {
+          "default": false,
+          "type": "boolean"
+        },
+        "differential_pairs": {
+          "default": [],
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "direction": {
+          "enum": [
+            "+",
+            "-"
+          ],
+          "type": "string"
+        },
+        "extrude_structures": {
+          "default": false,
+          "type": "boolean"
+        },
+        "frame": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PECFrame"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "length": 2,
+            "type": "PECFrame"
+          }
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "num_grid_cells": {
+          "anyOf": [
+            {
+              "minimum": 3,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 5
+        },
+        "reference_impedance": {
+          "anyOf": [
+            {
+              "const": "Z0",
+              "type": "string"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": 50
+        },
+        "size": {
+          "maxItems": 3,
+          "minItems": 3,
+          "prefixItems": [
+            {},
+            {},
+            {}
+          ],
+          "type": "array"
+        },
+        "terminal_specs": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AutoImpedanceSpec"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/CustomImpedanceSpec"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "type": {
+          "const": "TerminalWavePort",
+          "default": "TerminalWavePort",
+          "type": "string"
+        }
+      },
+      "required": [
+        "direction",
+        "name",
+        "size"
+      ],
+      "type": "object"
+    },
     "TetrahedralGridDataset": {
       "additionalProperties": false,
       "properties": {
@@ -16633,6 +17159,24 @@
           ],
           "default": 5
         },
+        "reference_impedance": {
+          "anyOf": [
+            {
+              "const": "Z0",
+              "type": "string"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "Z0"
+        },
         "size": {
           "maxItems": 3,
           "minItems": 3,
@@ -16772,6 +17316,9 @@
           },
           {
             "$ref": "#/$defs/LumpedPort"
+          },
+          {
+            "$ref": "#/$defs/TerminalWavePort"
           },
           {
             "$ref": "#/$defs/WavePort"

--- a/tests/test_components/test_IO.py
+++ b/tests/test_components/test_IO.py
@@ -374,6 +374,26 @@ def test_data_array_to_hdf5(tmp_path):
     flux.to_hdf5(fname=path, group_path="test")
 
 
+def test_data_array_to_hdf5_string_coords(tmp_path):
+    """Test HDF5 round-trip for DataArray with string coordinates."""
+    from tidy3d.components.data.data_array import FreqTerminalTerminalDataArray
+
+    f = [1e9, 2e9]
+    terminal_label_out = ["t0", "t1"]
+    terminal_label_in = ["t0", "t1"]
+    coords = {
+        "f": f,
+        "terminal_label_out": terminal_label_out,
+        "terminal_label_in": terminal_label_in,
+    }
+    data = FreqTerminalTerminalDataArray((1 + 1j) * np.random.random((2, 2, 2)), coords=coords)
+
+    path = str(tmp_path / "terminal.hdf5")
+    data.to_hdf5(fname=path, group_path="test")
+    loaded = FreqTerminalTerminalDataArray.from_hdf5(fname=path, group_path="test")
+    assert data == loaded
+
+
 def test_inf_attrs(tmp_path):
     """But if infinity added to attrs."""
 

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -32,6 +32,7 @@ from tidy3d.components.geometry.utils import (
     SnappingSpec,
     flatten_groups,
     flatten_shapely_geometries,
+    merging_geometries_on_plane,
     snap_box_to_grid,
     traverse_geometries,
 )
@@ -1797,6 +1798,44 @@ def test_flatten_shapely_geometries():
     # Test 13: Edge case - single empty geometry
     result = flatten_shapely_geometries(empty_polygon)
     assert len(result) == 0
+
+
+def test_merging_geometries_on_plane_overlapping_lines():
+    """Test merging_geometries_on_plane with overlapping zero-area (LineString) geometries."""
+    # Two thin (zero-thickness in y) boxes that overlap along x.
+    # Box A: x in [-0.75, 0.25], Box B: x in [-0.25, 0.75]  =>  overlap in [-0.25, 0.25]
+    geo_a = td.Box(center=(-0.25, 1, 0), size=(1, 0, 2))
+    geo_b = td.Box(center=(0.25, 1, 0), size=(1, 0, 2))
+
+    # XY cross-section plane at z=0
+    plane = td.Box(center=(0, 1, 0), size=(4, 4, 0))
+
+    # Same property => shapes should be merged into a single LineString
+    prop = "PEC"
+    results = merging_geometries_on_plane(
+        geometries=[geo_a, geo_b],
+        plane=plane,
+        property_list=[prop, prop],
+        interior_disjoint_geometries=True,
+    )
+    assert len(results) == 1
+    result_prop, result_shape = results[0]
+    assert result_prop == prop
+    assert result_shape.geom_type == "LineString"
+    minx, _, maxx, _ = result_shape.bounds
+    assert minx == pytest.approx(-0.75)
+    assert maxx == pytest.approx(0.75)
+
+    # Different properties => two separate results, each unmodified
+    results = merging_geometries_on_plane(
+        geometries=[geo_a, geo_b],
+        plane=plane,
+        property_list=["PEC", "copper"],
+        interior_disjoint_geometries=True,
+    )
+    assert len(results) == 2
+    props_returned = {r[0] for r in results}
+    assert props_returned == {"PEC", "copper"}
 
 
 # ======================= GeometryArray Tests =======================

--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -26,11 +26,13 @@ from tidy3d.components.microwave.formulas.circuit_parameters import (
 from tidy3d.components.microwave.path_integrals.factory import (
     make_current_integral,
     make_path_integrals,
+    make_path_integrals_for_terminal,
     make_voltage_integral,
 )
 from tidy3d.components.microwave.path_integrals.mode_plane_analyzer import (
     ModePlaneAnalyzer,
 )
+from tidy3d.components.microwave.source import MicrowaveTerminalSource
 from tidy3d.components.mode.mode_solver import ModeSolver
 from tidy3d.constants import EPSILON_0
 from tidy3d.exceptions import DataError, SetupError, ValidationError
@@ -1149,6 +1151,132 @@ def test_path_integral_factory_mixed_specs():
     assert current_integrals[1] is not None  # Second mode has current spec
 
 
+def test_make_path_integrals_for_terminal_basic():
+    """Test make_path_integrals_for_terminal with a single terminal having both V+I specs."""
+    from tidy3d.components.microwave.mode_spec import MicrowaveTerminalModeSpec
+
+    v_spec = td.AxisAlignedVoltageIntegralSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
+    i_spec = td.AxisAlignedCurrentIntegralSpec(center=(1, 2, 3), size=(0, 1, 1), sign="-")
+    impedance_spec = td.CustomImpedanceSpec(voltage_spec=v_spec, current_spec=i_spec)
+
+    terminal_spec = MicrowaveTerminalModeSpec(
+        num_modes=1,
+        impedance_specs={"T0": impedance_spec},
+    )
+
+    result = make_path_integrals_for_terminal(terminal_spec)
+    assert len(result) == 1
+    assert "T0" in result
+    v_integral, i_integral = result["T0"]
+    assert v_integral is not None
+    assert i_integral is not None
+
+
+def test_make_path_integrals_for_terminal_multi():
+    """Test make_path_integrals_for_terminal with two terminals, both having V+I specs."""
+    from tidy3d.components.microwave.mode_spec import MicrowaveTerminalModeSpec
+
+    v_spec1 = td.AxisAlignedVoltageIntegralSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
+    i_spec1 = td.AxisAlignedCurrentIntegralSpec(center=(1, 2, 3), size=(0, 1, 1), sign="-")
+    v_spec2 = td.AxisAlignedVoltageIntegralSpec(center=(2, 2, 3), size=(0, 0, 1), sign="+")
+    i_spec2 = td.AxisAlignedCurrentIntegralSpec(center=(2, 2, 3), size=(0, 1, 1), sign="+")
+
+    impedance_spec1 = td.CustomImpedanceSpec(voltage_spec=v_spec1, current_spec=i_spec1)
+    impedance_spec2 = td.CustomImpedanceSpec(voltage_spec=v_spec2, current_spec=i_spec2)
+
+    terminal_spec = MicrowaveTerminalModeSpec(
+        num_modes=2,
+        impedance_specs={"T0": impedance_spec1, "T1": impedance_spec2},
+    )
+
+    result = make_path_integrals_for_terminal(terminal_spec)
+    assert len(result) == 2
+    for label in ("T0", "T1"):
+        assert label in result
+        v_integral, i_integral = result[label]
+        assert v_integral is not None
+        assert i_integral is not None
+
+
+def test_make_path_integrals_for_terminal_voltage_only():
+    """Test make_path_integrals_for_terminal with voltage-only (PV) terminals."""
+    from tidy3d.components.microwave.mode_spec import MicrowaveTerminalModeSpec
+
+    v_spec1 = td.AxisAlignedVoltageIntegralSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
+    v_spec2 = td.AxisAlignedVoltageIntegralSpec(center=(2, 2, 3), size=(0, 0, 1), sign="+")
+
+    impedance_spec1 = td.CustomImpedanceSpec(voltage_spec=v_spec1, current_spec=None)
+    impedance_spec2 = td.CustomImpedanceSpec(voltage_spec=v_spec2, current_spec=None)
+
+    terminal_spec = MicrowaveTerminalModeSpec(
+        num_modes=2,
+        impedance_specs={"T0": impedance_spec1, "T1": impedance_spec2},
+    )
+
+    result = make_path_integrals_for_terminal(terminal_spec)
+    assert len(result) == 2
+    for label in ("T0", "T1"):
+        v_integral, i_integral = result[label]
+        assert v_integral is not None
+        assert i_integral is None
+
+
+def test_make_path_integrals_for_terminal_construction_errors(monkeypatch):
+    """Test that make_path_integrals_for_terminal raises SetupError with terminal label on failure."""
+    from tidy3d.components.microwave.mode_spec import MicrowaveTerminalModeSpec
+
+    v_spec = td.AxisAlignedVoltageIntegralSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
+    impedance_spec = td.CustomImpedanceSpec(voltage_spec=v_spec, current_spec=None)
+
+    terminal_spec = MicrowaveTerminalModeSpec(
+        num_modes=1,
+        impedance_specs={"MyTerminal": impedance_spec},
+    )
+
+    def mock_make_voltage_integral(path_spec):
+        raise RuntimeError("Intentional construction failure")
+
+    monkeypatch.setattr(
+        "tidy3d.components.microwave.path_integrals.factory.make_voltage_integral",
+        mock_make_voltage_integral,
+    )
+
+    with pytest.raises(SetupError, match="MyTerminal"):
+        make_path_integrals_for_terminal(terminal_spec)
+
+
+def test_make_path_integrals_for_terminal_custom_2d_specs():
+    """Test make_path_integrals_for_terminal with Custom2D voltage and current specs."""
+    from tidy3d.components.microwave.mode_spec import MicrowaveTerminalModeSpec
+    from tidy3d.components.microwave.path_integrals.integrals.current import (
+        Custom2DCurrentIntegral,
+    )
+    from tidy3d.components.microwave.path_integrals.integrals.voltage import (
+        Custom2DVoltageIntegral,
+    )
+
+    v_spec = td.Custom2DVoltageIntegralSpec(axis=2, position=0.5, vertices=[(0, 0), (0, 1)])
+    i_spec = td.Custom2DCurrentIntegralSpec(
+        axis=2, position=0.5, vertices=[(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]
+    )
+    impedance_spec = td.CustomImpedanceSpec(voltage_spec=v_spec, current_spec=i_spec)
+
+    terminal_spec = MicrowaveTerminalModeSpec(
+        num_modes=1,
+        impedance_specs={"T0": impedance_spec},
+    )
+
+    result = make_path_integrals_for_terminal(terminal_spec)
+    assert len(result) == 1
+    v_integral, i_integral = result["T0"]
+    assert isinstance(v_integral, Custom2DVoltageIntegral)
+    assert isinstance(i_integral, Custom2DCurrentIntegral)
+    assert v_integral.axis == 2
+    assert v_integral.position == 0.5
+    assert i_integral.axis == 2
+    assert i_integral.position == 0.5
+
+
 def test_mode_spec_with_microwave_mode_spec():
     """Test that the number of impedance specs is validated against the number of modes in MicrowaveModeSpec."""
 
@@ -1502,6 +1630,169 @@ def test_mode_solver_with_microwave_group_index():
     assert np.allclose(tl_freqs_current, original_freqs), (
         f"current_coeffs frequencies {tl_freqs_current} should match original {original_freqs}"
     )
+
+
+def test_group_index_post_process_with_terminal_data():
+    """Test that _group_index_post_process correctly filters terminal data frequencies."""
+    from tidy3d.components.data.data_array import (
+        CurrentFreqTerminalModeDataArray,
+        FreqModeDataArray,
+        ImpedanceFreqTerminalTerminalDataArray,
+        ModeIndexDataArray,
+        ScalarModeFieldDataArray,
+        VoltageFreqTerminalModeDataArray,
+    )
+    from tidy3d.components.microwave.data.dataset import TransmissionLineTerminalDataset
+
+    # Setup: 2 original frequencies, each expanded to a triplet (back, center, forward)
+    # giving 6 total frequencies
+    step = 0.005
+    original_freqs = [1e9, 5e9]
+    triplet_freqs = []
+    for freq in original_freqs:
+        triplet_freqs.extend([freq * (1 - step), freq, freq * (1 + step)])
+    triplet_freqs = np.array(triplet_freqs)
+
+    x = [-1, 1, 3]
+    y = [-2, 0]
+    z = [-3, -1, 1, 3, 5]
+    mode_index = np.arange(2)
+    n_f = len(triplet_freqs)
+    n_m = len(mode_index)
+
+    grid = td.Grid(boundaries=td.Coords(x=x, y=y, z=z))
+    field_coords = {
+        "x": x[:-1],
+        "y": y[:-1],
+        "z": z[:-1],
+        "f": triplet_freqs,
+        "mode_index": mode_index,
+    }
+    index_coords = {"f": triplet_freqs, "mode_index": mode_index}
+
+    # Create field and index data
+    field_values = np.ones((2, 1, 4, n_f, n_m), dtype=complex)
+    field = ScalarModeFieldDataArray(field_values, coords=field_coords)
+
+    index_values = np.ones((n_f, n_m), dtype=complex) * (1.5 + 0.01j)
+    for f_idx in range(n_f):
+        for m_idx in range(n_m):
+            index_values[f_idx, m_idx] = 1.5 + (triplet_freqs[f_idx] / 1e9) * 0.01 + m_idx * 0.1
+    index_data = ModeIndexDataArray(index_values, coords=index_coords)
+
+    # Create terminal data with frequency-dependent values
+    terminal_labels = ["t0", "t1"]
+    n_t = len(terminal_labels)
+
+    terminal_z0_coords = {
+        "f": triplet_freqs,
+        "terminal_label_out": terminal_labels,
+        "terminal_label_in": terminal_labels,
+    }
+    terminal_coords = {
+        "f": triplet_freqs,
+        "terminal_label": terminal_labels,
+        "mode_index": mode_index,
+    }
+
+    terminal_z0_values = np.zeros((n_f, n_t, n_t))
+    terminal_voltage_values = np.zeros((n_f, n_t, n_m), dtype=complex)
+    terminal_current_values = np.zeros((n_f, n_t, n_m), dtype=complex)
+
+    for f_idx in range(n_f):
+        for t_idx in range(n_t):
+            terminal_z0_values[f_idx, t_idx, t_idx] = 50 + triplet_freqs[f_idx] / 1e8 + t_idx * 10
+            for m_idx in range(n_m):
+                terminal_voltage_values[f_idx, t_idx, m_idx] = (
+                    triplet_freqs[f_idx] / 1e9 + t_idx + m_idx
+                ) * (2 + 1j)
+                terminal_current_values[f_idx, t_idx, m_idx] = (
+                    triplet_freqs[f_idx] / 1e9 + t_idx + m_idx
+                ) * (0.1 + 0.05j)
+
+    terminal_z0_data = ImpedanceFreqTerminalTerminalDataArray(
+        terminal_z0_values, coords=terminal_z0_coords
+    )
+    terminal_voltage_data = VoltageFreqTerminalModeDataArray(
+        terminal_voltage_values, coords=terminal_coords
+    )
+    terminal_current_data = CurrentFreqTerminalModeDataArray(
+        terminal_current_values, coords=terminal_coords
+    )
+
+    tl_terminal_data = TransmissionLineTerminalDataset(
+        Z0=terminal_z0_data,
+        voltage_transform=terminal_voltage_data,
+        current_transform=terminal_current_data,
+    )
+
+    # Create monitor with triplet frequencies
+    monitor = td.MicrowaveModeSolverMonitor(
+        center=(0, 0, 0),
+        size=(2, 0, 6),
+        freqs=triplet_freqs,
+        mode_spec=td.MicrowaveModeSpec(num_modes=n_m, impedance_specs=td.AutoImpedanceSpec()),
+        name="microwave_mode_solver",
+    )
+
+    # Grid correction factors need to be DataArrays with freq dimension for isel to work
+    grid_correction = FreqModeDataArray(np.ones((n_f, n_m)), coords=index_coords)
+
+    data = td.MicrowaveModeSolverData(
+        monitor=monitor,
+        Ex=field,
+        Ey=field,
+        Ez=field,
+        Hx=field,
+        Hy=field,
+        Hz=field,
+        n_complex=index_data,
+        grid_expanded=grid,
+        grid_primal_correction=grid_correction,
+        grid_dual_correction=grid_correction,
+        transmission_line_terminal_data=tl_terminal_data,
+    )
+
+    # Apply group index post-processing
+    result = data._group_index_post_process(step)
+
+    # Verify terminal data frequencies are filtered to center frequencies only
+    assert result.transmission_line_terminal_data is not None, (
+        "transmission_line_terminal_data should be preserved"
+    )
+
+    result_z0_freqs = result.transmission_line_terminal_data.Z0.coords["f"].values
+    result_v_freqs = result.transmission_line_terminal_data.voltage_transform.coords["f"].values
+    result_c_freqs = result.transmission_line_terminal_data.current_transform.coords["f"].values
+
+    assert len(result_z0_freqs) == len(original_freqs), (
+        f"Z0 should have {len(original_freqs)} frequencies, got {len(result_z0_freqs)}"
+    )
+    assert len(result_v_freqs) == len(original_freqs), (
+        f"voltage_transform should have {len(original_freqs)} frequencies, got {len(result_v_freqs)}"
+    )
+    assert len(result_c_freqs) == len(original_freqs), (
+        f"current_transform should have {len(original_freqs)} frequencies, got {len(result_c_freqs)}"
+    )
+
+    assert np.allclose(result_z0_freqs, original_freqs)
+    assert np.allclose(result_v_freqs, original_freqs)
+    assert np.allclose(result_c_freqs, original_freqs)
+
+    # Verify values match the center-frequency slices (indices 1, 4 from the triplet)
+    center_inds = [1, 4]
+    assert np.allclose(
+        result.transmission_line_terminal_data.Z0.values,
+        terminal_z0_values[center_inds],
+    ), "Z0 values should match center-frequency slices"
+    assert np.allclose(
+        result.transmission_line_terminal_data.voltage_transform.values,
+        terminal_voltage_values[center_inds],
+    ), "voltage_transform values should match center-frequency slices"
+    assert np.allclose(
+        result.transmission_line_terminal_data.current_transform.values,
+        terminal_current_values[center_inds],
+    ), "current_transform values should match center-frequency slices"
 
 
 @pytest.mark.parametrize("axis", [0, 1, 2])
@@ -2074,6 +2365,36 @@ def test_impedance_calculator_compute_impedance_with_return_extras():
     assert current_c is not None
 
 
+def test_compute_voltage_current_none_semantics():
+    """Test that compute_voltage_current returns None for undefined integrals."""
+
+    voltage_integral = td.AxisAlignedVoltageIntegral(
+        center=(0, 0, 0), size=(0, 0.5, 0), sign="+", extrapolate_to_endpoints=True
+    )
+    current_integral = td.AxisAlignedCurrentIntegral(center=(0, 0, 0), size=(0.5, 0.5, 0), sign="+")
+    field_data = SIM_Z_DATA["field"]
+
+    # Both integrals defined: neither result is None
+    calc_both = td.ImpedanceCalculator(
+        voltage_integral=voltage_integral, current_integral=current_integral
+    )
+    voltage, current = calc_both.compute_voltage_current(field_data)
+    assert voltage is not None
+    assert current is not None
+
+    # Voltage-only: current is None
+    calc_v = td.ImpedanceCalculator(voltage_integral=voltage_integral)
+    voltage, current = calc_v.compute_voltage_current(field_data)
+    assert voltage is not None
+    assert current is None
+
+    # Current-only: voltage is None
+    calc_i = td.ImpedanceCalculator(current_integral=current_integral)
+    voltage, current = calc_i.compute_voltage_current(field_data)
+    assert voltage is None
+    assert current is not None
+
+
 def test_composite_current_integral_freq_mode_data():
     """Test CompositeCurrentIntegral works correctly with FreqModeDataArray."""
 
@@ -2134,15 +2455,22 @@ def test_impedance_calculator_mode_direction_handling():
 
 
 def test_microwave_mode_data_reordering_with_transmission_line_data():
-    """Test that transmission_line_data is correctly reordered when modes are reordered."""
+    """Test that transmission_line_data and transmission_line_terminal_data are correctly
+    reordered when modes are reordered."""
     from tidy3d.components.data.data_array import (
         CurrentFreqModeDataArray,
+        CurrentFreqTerminalModeDataArray,
         ImpedanceFreqModeDataArray,
+        ImpedanceFreqTerminalTerminalDataArray,
         ModeIndexDataArray,
         ScalarModeFieldDataArray,
         VoltageFreqModeDataArray,
+        VoltageFreqTerminalModeDataArray,
     )
-    from tidy3d.components.microwave.data.dataset import TransmissionLineDataset
+    from tidy3d.components.microwave.data.dataset import (
+        TransmissionLineDataset,
+        TransmissionLineTerminalDataset,
+    )
 
     # Setup coordinates
     x = [-1, 1, 3]
@@ -2188,6 +2516,49 @@ def test_microwave_mode_data_reordering_with_transmission_line_data():
         Z0=impedance_data, voltage_coeffs=voltage_data, current_coeffs=current_data
     )
 
+    # Create transmission line terminal data with distinct values for each terminal/mode
+    terminal_labels = ["t0", "t1", "t2"]
+    terminal_z0_coords = {
+        "f": f,
+        "terminal_label_out": terminal_labels,
+        "terminal_label_in": terminal_labels,
+    }
+    terminal_coords = {"f": f, "terminal_label": terminal_labels, "mode_index": mode_index}
+
+    n_t = len(terminal_labels)
+    n_m = len(mode_index)
+    n_f = len(f)
+
+    terminal_z0_values = np.zeros((n_f, n_t, n_t))
+    terminal_voltage_values = np.zeros((n_f, n_t, n_m), dtype=complex)
+    terminal_current_values = np.zeros((n_f, n_t, n_m), dtype=complex)
+
+    for t_idx in range(n_t):
+        terminal_z0_values[:, t_idx, t_idx] = 75 * (t_idx + 1)
+        for m_idx in range(n_m):
+            terminal_voltage_values[:, t_idx, m_idx] = (m_idx + 1) * (3 + 1.5j) + t_idx * (
+                0.5 + 0.25j
+            )
+            terminal_current_values[:, t_idx, m_idx] = (m_idx + 1) * (0.3 + 0.15j) + t_idx * (
+                0.05 + 0.025j
+            )
+
+    terminal_z0_data = ImpedanceFreqTerminalTerminalDataArray(
+        terminal_z0_values, coords=terminal_z0_coords
+    )
+    terminal_voltage_data = VoltageFreqTerminalModeDataArray(
+        terminal_voltage_values, coords=terminal_coords
+    )
+    terminal_current_data = CurrentFreqTerminalModeDataArray(
+        terminal_current_values, coords=terminal_coords
+    )
+
+    tl_terminal_data = TransmissionLineTerminalDataset(
+        Z0=terminal_z0_data,
+        voltage_transform=terminal_voltage_data,
+        current_transform=terminal_current_data,
+    )
+
     # Create monitor
     monitor = td.MicrowaveModeSolverMonitor(
         center=(0, 0, 0),
@@ -2209,6 +2580,7 @@ def test_microwave_mode_data_reordering_with_transmission_line_data():
         n_complex=index_data,
         grid_expanded=grid,
         transmission_line_data=tl_data,
+        transmission_line_terminal_data=tl_terminal_data,
     )
 
     # Define a reordering: reverse the mode order for each frequency
@@ -2279,6 +2651,58 @@ def test_microwave_mode_data_reordering_with_transmission_line_data():
     assert np.allclose(reordered_data.n_complex.isel(mode_index=0).values, 3 * 1.5 + 0.1j), (
         "n_complex not reordered correctly"
     )
+
+    # Verify that transmission_line_terminal_data is also reordered correctly
+    assert reordered_data.transmission_line_terminal_data is not None, (
+        "transmission_line_terminal_data should not be None"
+    )
+
+    # Z0 has no mode_index dimension (it's terminal_label_out x terminal_label_in),
+    # so it should be unchanged by mode reordering
+    assert np.allclose(
+        reordered_data.transmission_line_terminal_data.Z0.values,
+        tl_terminal_data.Z0.values,
+    ), "transmission_line_terminal_data.Z0 should be unchanged (no mode_index dim)"
+
+    # voltage_transform has mode_index dim: check reordering
+    # Original mode 2 (value = 3*(3+1.5j) + t_idx*(0.5+0.25j)) should now be at index 0
+    for t_idx in range(n_t):
+        original_mode_2_voltage = 3 * (3 + 1.5j) + t_idx * (0.5 + 0.25j)
+        assert np.allclose(
+            reordered_data.transmission_line_terminal_data.voltage_transform.isel(
+                mode_index=0, terminal_label=t_idx
+            ).values,
+            original_mode_2_voltage,
+        ), f"voltage_transform not reordered correctly for terminal {t_idx}"
+
+        # Original mode 0 (value = 1*(3+1.5j) + t_idx*(0.5+0.25j)) should now be at index 2
+        original_mode_0_voltage = 1 * (3 + 1.5j) + t_idx * (0.5 + 0.25j)
+        assert np.allclose(
+            reordered_data.transmission_line_terminal_data.voltage_transform.isel(
+                mode_index=2, terminal_label=t_idx
+            ).values,
+            original_mode_0_voltage,
+        ), f"voltage_transform not reordered correctly for terminal {t_idx}"
+
+    # current_transform has mode_index dim: check reordering
+    # Original mode 2 (value = 3*(0.3+0.15j) + t_idx*(0.05+0.025j)) should now be at index 0
+    for t_idx in range(n_t):
+        original_mode_2_current = 3 * (0.3 + 0.15j) + t_idx * (0.05 + 0.025j)
+        assert np.allclose(
+            reordered_data.transmission_line_terminal_data.current_transform.isel(
+                mode_index=0, terminal_label=t_idx
+            ).values,
+            original_mode_2_current,
+        ), f"current_transform not reordered correctly for terminal {t_idx}"
+
+        # Original mode 0 (value = 1*(0.3+0.15j) + t_idx*(0.05+0.025j)) should now be at index 2
+        original_mode_0_current = 1 * (0.3 + 0.15j) + t_idx * (0.05 + 0.025j)
+        assert np.allclose(
+            reordered_data.transmission_line_terminal_data.current_transform.isel(
+                mode_index=2, terminal_label=t_idx
+            ).values,
+            original_mode_0_current,
+        ), f"current_transform not reordered correctly for terminal {t_idx}"
 
 
 def test_microwave_mode_data_interpolation():
@@ -2912,3 +3336,42 @@ def test_transmission_line_Z0_matrix():
                         f"Off-diagonal element at f={f}, mode_out={m_out}, mode_in={m_in} "
                         f"should be 0, got {off_diag_value}"
                     )
+
+
+def test_microwave_terminal_source_creation():
+    """Test direct construction of MicrowaveTerminalSource."""
+    from tidy3d.components.microwave.mode_spec import MicrowaveTerminalModeSpec
+
+    current_spec = td.AxisAlignedCurrentIntegralSpec(center=(0, 0, 0), size=(2, 1, 0), sign="+")
+    impedance_spec = td.CustomImpedanceSpec(current_spec=current_spec)
+    terminal_spec = MicrowaveTerminalModeSpec(
+        num_modes=1, impedance_specs={"port1": impedance_spec}
+    )
+    source = MicrowaveTerminalSource(
+        size=(10, 10, 0),
+        source_time=td.GaussianPulse(freq0=10e9, fwidth=1e9),
+        mode_spec=terminal_spec,
+        terminal_label="port1",
+        direction="+",
+    )
+    assert source.terminal_label == "port1"
+    assert isinstance(source.mode_spec, MicrowaveTerminalModeSpec)
+
+
+def test_microwave_terminal_source_invalid_label():
+    """Test that invalid terminal_label raises ValidationError."""
+    from tidy3d.components.microwave.mode_spec import MicrowaveTerminalModeSpec
+
+    current_spec = td.AxisAlignedCurrentIntegralSpec(center=(0, 0, 0), size=(2, 1, 0), sign="+")
+    impedance_spec = td.CustomImpedanceSpec(current_spec=current_spec)
+    terminal_spec = MicrowaveTerminalModeSpec(
+        num_modes=1, impedance_specs={"port1": impedance_spec}
+    )
+    with pytest.raises(pd.ValidationError):
+        MicrowaveTerminalSource(
+            size=(10, 10, 0),
+            source_time=td.GaussianPulse(freq0=10e9, fwidth=1e9),
+            mode_spec=terminal_spec,
+            terminal_label="nonexistent",
+            direction="+",
+        )

--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -1164,6 +1164,88 @@ def test_mode_spec_with_microwave_mode_spec():
         td.MicrowaveModeSpec(num_modes=2, impedance_specs=impedance_specs)
 
 
+def test_mode_spec_preserved_in_mode_solver_data_roundtrip():
+    """Test that MicrowaveModeSpec fields survive the ModeSolverData -> MicrowaveModeSolverData conversion.
+
+    The mode solver internally creates a ModeSolverData (whose monitor field is typed as
+    ModeSolverMonitor) then converts it to MicrowaveModeSolverData. Pydantic v2 serializes
+    nested models based on the declared field type, so model_dump() on ModeSolverData drops
+    subclass-specific fields like impedance_specs. This test verifies the fix preserves them.
+    """
+    from tidy3d.components.data.data_array import ModeIndexDataArray, ScalarModeFieldDataArray
+    from tidy3d.components.microwave.data.monitor_data import MicrowaveModeSolverData
+
+    custom_spec = td.CustomImpedanceSpec(
+        current_spec=td.AxisAlignedCurrentIntegralSpec(center=(0, 0, 0), size=(2, 1, 0), sign="+")
+    )
+
+    # -- MicrowaveModeSpec --
+    mw_spec = td.MicrowaveModeSpec(num_modes=1, impedance_specs=custom_spec)
+    mw_mon = td.MicrowaveModeSolverMonitor(
+        center=(0, 0, 0), size=(2, 0, 6), freqs=[2e14], mode_spec=mw_spec, name="test"
+    )
+
+    x, y, z = [-1, 1, 3], [-2, 0], [-3, -1, 1, 3, 5]
+    grid = td.Grid(boundaries=td.Coords(x=x, y=y, z=z))
+    field_coords = {"x": x[:-1], "y": y[:-1], "z": z[:-1], "f": [2e14], "mode_index": np.arange(1)}
+    field = ScalarModeFieldDataArray(
+        (1 + 1j) * np.random.random((2, 1, 4, 1, 1)), coords=field_coords
+    )
+    n_complex = ModeIndexDataArray(
+        (1 + 1j) * np.random.random((1, 1)), coords={"f": [2e14], "mode_index": np.arange(1)}
+    )
+
+    data = td.ModeSolverData(
+        monitor=mw_mon,
+        Ex=field,
+        Ey=field,
+        Ez=field,
+        Hx=field,
+        Hy=field,
+        Hz=field,
+        n_complex=n_complex,
+        grid_expanded=grid,
+    )
+
+    # This is the conversion pattern used in ModeSolver.data_raw
+    converted = MicrowaveModeSolverData(
+        **data.model_dump(exclude={"type", "monitor"}), monitor=data.monitor
+    )
+    assert isinstance(converted.monitor.mode_spec.impedance_specs, td.CustomImpedanceSpec)
+
+    # -- MicrowaveTerminalModeSpec --
+    from tidy3d.components.microwave.mode_spec import MicrowaveTerminalModeSpec
+
+    terminal_spec = MicrowaveTerminalModeSpec(
+        num_modes=1,
+        impedance_specs={"T0": custom_spec},
+    )
+    terminal_mon = td.MicrowaveModeSolverMonitor(
+        center=(0, 0, 0), size=(2, 0, 6), freqs=[2e14], mode_spec=terminal_spec, name="test"
+    )
+
+    data_terminal = td.ModeSolverData(
+        monitor=terminal_mon,
+        Ex=field,
+        Ey=field,
+        Ez=field,
+        Hx=field,
+        Hy=field,
+        Hz=field,
+        n_complex=n_complex,
+        grid_expanded=grid,
+    )
+
+    converted_terminal = MicrowaveModeSolverData(
+        **data_terminal.model_dump(exclude={"type", "monitor"}), monitor=data_terminal.monitor
+    )
+    assert isinstance(converted_terminal.monitor.mode_spec, MicrowaveTerminalModeSpec)
+    assert "T0" in converted_terminal.monitor.mode_spec.impedance_specs
+    assert isinstance(
+        converted_terminal.monitor.mode_spec.impedance_specs["T0"], td.CustomImpedanceSpec
+    )
+
+
 def test_mode_solver_with_microwave_mode_spec():
     """Test running the mode locally and see if impedance is close to correct."""
 
@@ -1218,6 +1300,10 @@ def test_mode_solver_with_microwave_mode_spec():
     )
     mms = mms.updated_copy(mode_spec=microwave_spec_custom)
     mms_data: td.MicrowaveModeSolverData = mms.data
+
+    # Verify that CustomImpedanceSpec survives the ModeSolverData -> MicrowaveModeSolverData roundtrip
+    stored_specs = mms_data.monitor.mode_spec.impedance_specs
+    assert isinstance(stored_specs[0], td.CustomImpedanceSpec)
 
     # _, ax = plt.subplots(1, 1, tight_layout=True, figsize=(15, 15))
     # mms_data.field_components["Ez"].isel(mode_index=0, f=0).real.plot(ax=ax)
@@ -2199,12 +2285,18 @@ def test_microwave_mode_data_interpolation():
     """Test that MicrowaveModeSolverData interpolation correctly handles transmission_line_data."""
     from tidy3d.components.data.data_array import (
         CurrentFreqModeDataArray,
+        CurrentFreqTerminalModeDataArray,
         ImpedanceFreqModeDataArray,
+        ImpedanceFreqTerminalTerminalDataArray,
         ModeIndexDataArray,
         ScalarModeFieldDataArray,
         VoltageFreqModeDataArray,
+        VoltageFreqTerminalModeDataArray,
     )
-    from tidy3d.components.microwave.data.dataset import TransmissionLineDataset
+    from tidy3d.components.microwave.data.dataset import (
+        TransmissionLineDataset,
+        TransmissionLineTerminalDataset,
+    )
 
     # Setup coordinates with sparse frequencies
     x = [-1, 1, 3]
@@ -2258,6 +2350,55 @@ def test_microwave_mode_data_interpolation():
         Z0=impedance_data, voltage_coeffs=voltage_data, current_coeffs=current_data
     )
 
+    # Create transmission line terminal data with frequency dependence
+    terminal_labels = [f"t{i}" for i in range(len(mode_index))]
+    terminal_coords = {
+        "f": f_sparse,
+        "terminal_label": terminal_labels,
+        "mode_index": mode_index,
+    }
+    terminal_z0_coords = {
+        "f": f_sparse,
+        "terminal_label_out": terminal_labels,
+        "terminal_label_in": terminal_labels,
+    }
+
+    n_t = len(terminal_labels)
+    n_m = len(mode_index)
+    n_f = len(f_sparse)
+
+    terminal_z0_values = np.zeros((n_f, n_t, n_t))
+    terminal_voltage_values = np.zeros((n_f, n_t, n_m), dtype=complex)
+    terminal_current_values = np.zeros((n_f, n_t, n_m), dtype=complex)
+
+    for f_idx, freq in enumerate(f_sparse):
+        for t_idx in range(n_t):
+            # Diagonal Z0 matrix varying with frequency
+            terminal_z0_values[f_idx, t_idx, t_idx] = 50 + (freq / 1e14) * 5 + t_idx * 10
+            for m_idx in range(n_m):
+                terminal_voltage_values[f_idx, t_idx, m_idx] = ((freq / 1e14) + t_idx + m_idx) * (
+                    2 + 1j
+                )
+                terminal_current_values[f_idx, t_idx, m_idx] = ((freq / 1e14) + t_idx + m_idx) * (
+                    0.1 + 0.05j
+                )
+
+    terminal_z0_data = ImpedanceFreqTerminalTerminalDataArray(
+        terminal_z0_values, coords=terminal_z0_coords
+    )
+    terminal_voltage_data = VoltageFreqTerminalModeDataArray(
+        terminal_voltage_values, coords=terminal_coords
+    )
+    terminal_current_data = CurrentFreqTerminalModeDataArray(
+        terminal_current_values, coords=terminal_coords
+    )
+
+    tl_terminal_data = TransmissionLineTerminalDataset(
+        Z0=terminal_z0_data,
+        voltage_transform=terminal_voltage_data,
+        current_transform=terminal_current_data,
+    )
+
     # Create monitor
     monitor = td.MicrowaveModeSolverMonitor(
         center=(0, 0, 0),
@@ -2279,6 +2420,7 @@ def test_microwave_mode_data_interpolation():
         n_complex=index_data,
         grid_expanded=grid,
         transmission_line_data=tl_data,
+        transmission_line_terminal_data=tl_terminal_data,
     )
 
     # Interpolate to denser frequency grid
@@ -2378,6 +2520,83 @@ def test_microwave_mode_data_interpolation():
     expected_Z0_end_mode1 = 50 + 2 * 10 + 1 * 20
     assert np.allclose(Z0_at_end_mode1, expected_Z0_end_mode1, rtol=1e-6), (
         f"Z0 at endpoint should match original: expected {expected_Z0_end_mode1}, got {Z0_at_end_mode1}"
+    )
+
+    # Verify that transmission_line_terminal_data is also interpolated
+    assert data_interp_linear.transmission_line_terminal_data is not None, (
+        "transmission_line_terminal_data should be interpolated"
+    )
+    assert len(data_interp_linear.transmission_line_terminal_data.Z0.coords["f"]) == len(f_dense), (
+        "terminal Z0 should be interpolated to new frequencies"
+    )
+    assert len(
+        data_interp_linear.transmission_line_terminal_data.voltage_transform.coords["f"]
+    ) == len(f_dense), "terminal voltage_transform should be interpolated to new frequencies"
+    assert len(
+        data_interp_linear.transmission_line_terminal_data.current_transform.coords["f"]
+    ) == len(f_dense), "terminal current_transform should be interpolated to new frequencies"
+
+    # Check terminal Z0 interpolation accuracy at midpoint
+    # At f=1.5e14, terminal 0: Z0[0,0] = 50 + 1.5*5 + 0*10 = 57.5
+    terminal_Z0_mid = (
+        data_interp_linear.transmission_line_terminal_data.Z0.sel(f=f_mid, method="nearest")
+        .sel(terminal_label_out="t0", terminal_label_in="t0")
+        .values
+    )
+    expected_terminal_Z0 = 50 + 1.5 * 5 + 0 * 10
+    assert np.allclose(terminal_Z0_mid, expected_terminal_Z0, rtol=0.01), (
+        f"Terminal Z0 interpolation: expected {expected_terminal_Z0}, got {terminal_Z0_mid}"
+    )
+
+    # Check terminal voltage_transform interpolation accuracy at midpoint
+    # At f=1.5e14, terminal 0, mode 0: (1.5 + 0 + 0) * (2+1j) = 1.5*(2+1j)
+    terminal_v_mid = (
+        data_interp_linear.transmission_line_terminal_data.voltage_transform.sel(
+            f=f_mid, method="nearest"
+        )
+        .sel(terminal_label="t0", mode_index=0)
+        .values
+    )
+    expected_terminal_v = 1.5 * (2 + 1j)
+    assert np.allclose(terminal_v_mid, expected_terminal_v, rtol=0.01), (
+        f"Terminal voltage_transform interpolation: expected {expected_terminal_v}, got {terminal_v_mid}"
+    )
+
+    # Check terminal current_transform interpolation accuracy at midpoint
+    # At f=1.5e14, terminal 0, mode 0: (1.5 + 0 + 0) * (0.1+0.05j) = 1.5*(0.1+0.05j)
+    terminal_i_mid = (
+        data_interp_linear.transmission_line_terminal_data.current_transform.sel(
+            f=f_mid, method="nearest"
+        )
+        .sel(terminal_label="t0", mode_index=0)
+        .values
+    )
+    expected_terminal_i = 1.5 * (0.1 + 0.05j)
+    assert np.allclose(terminal_i_mid, expected_terminal_i, rtol=0.01), (
+        f"Terminal current_transform interpolation: expected {expected_terminal_i}, got {terminal_i_mid}"
+    )
+
+    # Test at endpoints to ensure terminal data matches original values
+    # At f=1e14, terminal 1: Z0[1,1] = 50 + 1*5 + 1*10 = 65
+    terminal_Z0_start = (
+        data_interp_linear.transmission_line_terminal_data.Z0.sel(f=1e14, method="nearest")
+        .sel(terminal_label_out="t1", terminal_label_in="t1")
+        .values
+    )
+    expected_terminal_Z0_start = 50 + 1 * 5 + 1 * 10
+    assert np.allclose(terminal_Z0_start, expected_terminal_Z0_start, rtol=1e-6), (
+        f"Terminal Z0 at endpoint: expected {expected_terminal_Z0_start}, got {terminal_Z0_start}"
+    )
+
+    # At f=2e14, terminal 1: Z0[1,1] = 50 + 2*5 + 1*10 = 70
+    terminal_Z0_end = (
+        data_interp_linear.transmission_line_terminal_data.Z0.sel(f=2e14, method="nearest")
+        .sel(terminal_label_out="t1", terminal_label_in="t1")
+        .values
+    )
+    expected_terminal_Z0_end = 50 + 2 * 5 + 1 * 10
+    assert np.allclose(terminal_Z0_end, expected_terminal_Z0_end, rtol=1e-6), (
+        f"Terminal Z0 at endpoint: expected {expected_terminal_Z0_end}, got {terminal_Z0_end}"
     )
 
 
@@ -2609,3 +2828,87 @@ def test_baseband_source_plot():
     _, ax = plt.subplots()
     cst.plot(times, ax=ax)
     plt.close()
+
+
+def test_transmission_line_Z0_matrix():
+    """Test that TransmissionLineDataset.Z0_matrix correctly converts diagonal Z0 to full matrix."""
+    from tidy3d.components.data.data_array import (
+        CurrentFreqModeDataArray,
+        ImpedanceFreqModeDataArray,
+        VoltageFreqModeDataArray,
+    )
+    from tidy3d.components.microwave.data.dataset import TransmissionLineDataset
+
+    # Create test data with 2 frequencies and 3 modes
+    freqs = [1e14, 2e14]
+    mode_indices = [0, 1, 2]
+
+    # Create Z0 with unique values for each (freq, mode) pair
+    Z0_values = np.array(
+        [
+            [50.0, 75.0, 100.0],  # freq 0: mode 0 = 50, mode 1 = 75, mode 2 = 100
+            [60.0, 80.0, 110.0],  # freq 1: mode 0 = 60, mode 1 = 80, mode 2 = 110
+        ]
+    )
+    Z0_data = ImpedanceFreqModeDataArray(Z0_values, coords={"f": freqs, "mode_index": mode_indices})
+
+    # Create dummy voltage and current data
+    voltage_data = VoltageFreqModeDataArray(
+        np.ones((2, 3), dtype=complex), coords={"f": freqs, "mode_index": mode_indices}
+    )
+    current_data = CurrentFreqModeDataArray(
+        np.ones((2, 3), dtype=complex), coords={"f": freqs, "mode_index": mode_indices}
+    )
+
+    # Create TransmissionLineDataset
+    tl_data = TransmissionLineDataset(
+        Z0=Z0_data, voltage_coeffs=voltage_data, current_coeffs=current_data
+    )
+
+    # Get the Z0_matrix
+    Z0_matrix = tl_data.Z0_matrix
+
+    # Test 1: Check shape
+    assert Z0_matrix.shape == (2, 3, 3), (
+        f"Z0_matrix shape should be (2, 3, 3), got {Z0_matrix.shape}"
+    )
+
+    # Test 2: Check dimensions
+    assert set(Z0_matrix.dims) == {"f", "mode_index_out", "mode_index_in"}, (
+        f"Z0_matrix dimensions should be (f, mode_index_out, mode_index_in), got {Z0_matrix.dims}"
+    )
+
+    # Test 3: Check coordinates
+    assert np.allclose(Z0_matrix.coords["f"].values, freqs), (
+        "Z0_matrix frequency coordinates don't match"
+    )
+    assert np.allclose(Z0_matrix.coords["mode_index_out"].values, mode_indices), (
+        "Z0_matrix mode_index_out coordinates don't match"
+    )
+    assert np.allclose(Z0_matrix.coords["mode_index_in"].values, mode_indices), (
+        "Z0_matrix mode_index_in coordinates don't match"
+    )
+
+    # Test 4: Check diagonal elements match original Z0
+    for f_idx, f in enumerate(freqs):
+        for m_idx, m in enumerate(mode_indices):
+            diagonal_value = Z0_matrix.sel(
+                f=f, mode_index_out=m, mode_index_in=m, method="nearest"
+            ).values
+            expected_value = Z0_values[f_idx, m_idx]
+            assert np.isclose(diagonal_value, expected_value), (
+                f"Diagonal element at f={f}, mode={m} should be {expected_value}, got {diagonal_value}"
+            )
+
+    # Test 5: Check off-diagonal elements are zero
+    for _f_idx, f in enumerate(freqs):
+        for i, m_out in enumerate(mode_indices):
+            for j, m_in in enumerate(mode_indices):
+                if i != j:  # Off-diagonal
+                    off_diag_value = Z0_matrix.sel(
+                        f=f, mode_index_out=m_out, mode_index_in=m_in, method="nearest"
+                    ).values
+                    assert np.isclose(off_diag_value, 0.0), (
+                        f"Off-diagonal element at f={f}, mode_out={m_out}, mode_in={m_in} "
+                        f"should be 0, got {off_diag_value}"
+                    )

--- a/tests/test_plugins/smatrix/test_component_modeler_cache.py
+++ b/tests/test_plugins/smatrix/test_component_modeler_cache.py
@@ -61,7 +61,8 @@ def _patch_terminal_smatrix(monkeypatch, modeler) -> None:
     monkeypatch.setattr(
         smatrix_utils,
         "compute_F",
-        lambda Z_numpy, s_param_def: 1.0 / (2.0 * np.sqrt(np.abs(Z_numpy) + 1e-4)),
+        lambda Z_numpy, s_param_def, compute_Finv=False: 1.0
+        / (2.0 * np.sqrt(np.abs(Z_numpy) + 1e-4)),
     )
     monkeypatch.setattr(
         terminal_analysis,

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -29,7 +29,7 @@ from tidy3d.plugins.smatrix.data.data_array import PortNameDataArray
 from tidy3d.plugins.smatrix.ports.base_lumped import AbstractLumpedPort
 from tidy3d.plugins.smatrix.utils import s_to_z, validate_square_matrix
 
-from ...utils import AssertLogLevel, run_emulated
+from ...utils import AssertLogLevel, AssertLogStr, run_emulated
 from .terminal_component_modeler_def import (
     make_basic_filter_terminals,
     make_coaxial_component_modeler,
@@ -56,10 +56,26 @@ def run_component_modeler(
         "port_array_inv",
         lambda matrix: np.eye(len(modeler.matrix_indices_monitor)),
     )
+
+    def _mock_compute_F(Z_numpy, s_param_def, compute_Finv=False):
+        num_freqs, num_ports, _ = Z_numpy.shape
+        Z_diag = np.diagonal(Z_numpy, axis1=1, axis2=2)
+        f_diag = 1.0 / (2.0 * np.sqrt(np.abs(Z_diag) + 1e-4))
+        F = np.zeros_like(Z_numpy)
+        for i in range(num_ports):
+            F[:, i, i] = f_diag[:, i]
+        if compute_Finv:
+            finv_diag = 2.0 * np.sqrt(np.abs(Z_diag) + 1e-4)
+            Finv = np.zeros_like(Z_numpy)
+            for i in range(num_ports):
+                Finv[:, i, i] = finv_diag[:, i]
+            return F, Finv
+        return F
+
     monkeypatch.setattr(
         td.plugins.smatrix.utils,
         "compute_F",
-        lambda Z_numpy, s_param_def: 1.0 / (2.0 * np.sqrt(np.abs(Z_numpy) + 1e-4)),
+        _mock_compute_F,
     )
     monkeypatch.setattr(
         td.plugins.smatrix.analysis.terminal,
@@ -457,14 +473,16 @@ def test_s_to_z_component_modeler():
     assert np.isclose(z_matrix_at_f[1, 0], Z21)
     assert np.isclose(z_matrix_at_f[1, 1], Z22)
 
-    # test version with different port reference impedances
-    values = np.full((len(freqs), len(port_names)), Z0)
-    coords = {
-        "f": np.array(freqs),
-        "port": port_names,
-    }
-    z_port_matrix = PortDataArray(data=values, coords=coords)
-    z_matrix = s_to_z(s_matrix, reference=z_port_matrix)
+    # test version with per-port reference impedances (diagonal matrix)
+    z_ref_values = np.array(
+        [Z0 * np.eye(len(port_names)) for _ in freqs],
+        dtype=complex,
+    )
+    z_ref = TerminalPortDataArray(
+        data=z_ref_values,
+        coords={"f": np.array(freqs), "port_out": port_names, "port_in": port_names},
+    )
+    z_matrix = s_to_z(s_matrix, reference=z_ref)
     z_matrix_at_f = z_matrix.sel(f=1e8)
     assert np.isclose(z_matrix_at_f[0, 0], Z11)
     assert np.isclose(z_matrix_at_f[0, 1], Z12)
@@ -510,7 +528,14 @@ def test_complex_reference_s_to_z_component_modeler():
     assert np.all(np.isclose(z_tidy3d.values, Z))
 
     # Test complex reference impedance calculations
-    z0_tidy3d = PortDataArray(data=z0, coords={"f": freqs, "port": ports})
+    # Convert per-port z0 (shape f, port) to diagonal TerminalPortDataArray (shape f, port, port)
+    num_freqs, num_ports = z0.shape
+    z0_diag = np.zeros((num_freqs, num_ports, num_ports), dtype=complex)
+    idx = np.arange(num_ports)
+    z0_diag[:, idx, idx] = z0
+    z0_tidy3d = TerminalPortDataArray(
+        data=z0_diag, coords={"f": freqs, "port_out": ports, "port_in": ports}
+    )
     smatrix.values = skrf_S_power.s
     z_tidy3d = s_to_z(smatrix, reference=z0_tidy3d, s_param_def="power")
     assert np.all(np.isclose(z_tidy3d.values, Z))
@@ -561,7 +586,22 @@ def test_data_s_to_z(monkeypatch):
     )
 
     z0 = 50.0
-    z_matrix = modeler_data.s_to_z(reference=z0)
+    # Build a diagonal reference impedance matrix (z0 * I) per frequency
+    z_ref_values = np.array(
+        [z0 * np.eye(len(port_names)) for _ in freqs],
+        dtype=complex,
+    )
+    z_ref = TerminalPortDataArray(
+        data=z_ref_values,
+        coords={"f": freqs, "port_out": port_names, "port_in": port_names},
+    )
+    monkeypatch.setattr(
+        TerminalComponentModelerData,
+        "port_reference_impedances",
+        property(lambda self: z_ref),
+    )
+
+    z_matrix = modeler_data.s_to_z()
 
     delta_s = (1 - s11) * (1 - s22) - s12 * s21
     z11 = z0 * ((1 + s11) * (1 - s22) + s12 * s21) / delta_s
@@ -1597,9 +1637,12 @@ def test_internal_construct_smatrix_with_port_vi(monkeypatch):
         return voltage, current
 
     # Mock port reference impedances to return frequency-dependent per-port Zref
+    # Build a diagonal 3D impedance matrix (f, port_out, port_in)
     def mock_port_impedances(modeler_data):
-        coords = {"f": np.array(freqs), "port": port_names}
-        return PortDataArray(Zref, coords=coords)
+        num_ports = len(port_names)
+        Zref_3d = Zref[:, :, None] * np.eye(num_ports)
+        coords = {"f": np.array(freqs), "port_out": port_names, "port_in": port_names}
+        return TerminalPortDataArray(Zref_3d, coords=coords)
 
     # Apply monkeypatches in all import locations
     monkeypatch.setattr(
@@ -2264,7 +2307,7 @@ def test_wave_port_mode_index_validation():
         direction="+",
         mode_index=0,
     )
-    assert port._mode_indices == (0,)
+    assert port._mode_indices() == (0,)
 
     # Invalid: index greater than number of modes
     with pytest.raises(ValidationError):
@@ -2286,7 +2329,7 @@ def test_wave_port_mode_index_validation():
         direction="+",
         mode_selection=[0, 2],
     )
-    assert port._mode_indices == (0, 2)
+    assert port._mode_indices() == (0, 2)
 
     # Valid: None (use all modes)
     port = WavePort(
@@ -2297,7 +2340,7 @@ def test_wave_port_mode_index_validation():
         direction="+",
         mode_selection=None,
     )
-    assert port._mode_indices == (0, 1, 2)
+    assert port._mode_indices() == (0, 1, 2)
 
     # Invalid: negative index
     with pytest.raises(ValidationError, match="non-negative"):
@@ -2333,6 +2376,45 @@ def test_wave_port_mode_index_validation():
         )
 
 
+def test_wave_port_multimode_absorption_warning():
+    """Test that WavePort warns when absorber is enabled with multiple modes."""
+    # Create mode_spec with 3 modes
+    mode_spec = td.MicrowaveModeSpec(num_modes=3)
+
+    # Test 1: Single mode with absorber=True - should NOT warn
+    with AssertLogStr("WARNING", excludes_str="multimode"):
+        port = WavePort(
+            center=(0, 0, -10),
+            size=(0, 2, 2),
+            name="port_single_mode",
+            mode_spec=td.MicrowaveModeSpec(num_modes=1),
+            direction="+",
+            absorber=True,
+        )
+
+    # Test 2: Multiple modes with absorber=True - SHOULD warn
+    with AssertLogStr("WARNING", contains_str="multimode"):
+        port = WavePort(
+            center=(0, 0, -10),
+            size=(0, 2, 2),
+            name="port_multimode",
+            mode_spec=mode_spec,
+            direction="+",
+            absorber=True,
+        )
+
+    # Test 3: Multiple modes with absorber=False - should NOT warn
+    with AssertLogStr("WARNING", excludes_str="multimode"):
+        port = WavePort(
+            center=(0, 0, -10),
+            size=(0, 2, 2),
+            name="port_no_absorber",
+            mode_spec=mode_spec,
+            direction="+",
+            absorber=False,
+        )
+
+
 def test_wave_port_mode_index_with_modeler():
     """Test that WavePort.mode_index works correctly with TerminalComponentModeler."""
     z_grid = td.UniformGrid(dl=1 * 1e3)
@@ -2354,7 +2436,7 @@ def test_wave_port_mode_index_with_modeler():
     )
 
     # Verify the port has only the selected modes
-    assert port._mode_indices == (0, 2)
+    assert port._mode_indices() == (0, 2)
 
     # Create a simple simulation to test with
     sim = td.Simulation(
@@ -2479,3 +2561,224 @@ def test_structure_priority_mode_override():
 
     # Check that base_sim uses the overridden priority mode
     assert modeler.base_sim.structure_priority_mode == "equal"
+
+
+# ---------------------------------------------------------------------------
+# Renormalization tests
+# ---------------------------------------------------------------------------
+
+
+def _make_renormalize_fixture(monkeypatch):
+    """Set up a 2-port modeler with monkeypatched V/I from an analytical transmission line.
+
+    Monkeypatches ``port_voltage_current_matrices`` and ``port_reference_impedances``
+    directly on the class so that the fixture survives ``updated_copy`` (which deep-copies
+    data and invalidates object-id-based mocks).
+
+    Returns ``(modeler_data, Zref, Z0, gamma, length, freqs, port_names)`` so that
+    callers can compute the expected S-matrix for any reference impedance.
+    """
+    modeler = make_component_modeler(planar_pec=False)
+    freqs = np.array([1e9, 5e9, 10e9])
+    modeler = modeler.updated_copy(freqs=freqs)
+
+    # Lossy microstrip parameters (engineering convention exp(jwt))
+    length = 0.02
+    gamma = np.array(
+        [
+            35.845260386378 + 52.964956959149j,
+            48.283102945750 + 208.91753284900j,
+            50.594134809653 + 397.12168963974j,
+        ]
+    )
+    Z0 = np.array(
+        [
+            12.843105732941 + 15.394208173652j,
+            28.567192048123 + 9.1023847562915j,
+            31.209457618234 + 3.8475102934671j,
+        ]
+    )
+    Z01 = np.array(
+        [
+            18.725191534567 + 12.672421364213j,
+            34.038884625562 + 7.8654410284980j,
+            35.725175635077 + 4.5490999181327j,
+        ]
+    )
+    Z02 = np.array(
+        [
+            24.156839210485 + 10.234195827361j,
+            41.892301567293 + 6.7812039451120j,
+            29.451276384019 + 5.1298475620183j,
+        ]
+    )
+    Zref = np.column_stack((Z01, Z02))
+    S_pseudo = calc_transmission_line_S_matrix_pseudo(Z0, Zref[:, 0], Zref[:, 1], gamma, length)
+    Zref3 = Zref[:, :, np.newaxis]
+
+    A = np.tile(np.eye(2), (len(freqs), 1, 1))
+    B = S_pseudo @ A
+    Vscale = np.abs(Zref3) / np.sqrt(np.real(Zref3))
+    Iscale = Vscale / Zref3
+    voltages = Vscale * (A + B)  # (f, port_out, port_in)
+    currents = Iscale * (A - B)  # (f, port_out, port_in)
+
+    port_names = [port.name for port in modeler.ports]
+
+    # Build actual SimulationDataMap (contents don't matter — V/I are mocked)
+    sim_data_list = []
+    port_name_list = []
+    for port_in in modeler.ports:
+        task_name = modeler.get_task_name(port_in)
+        sim_data_list.append(run_emulated(simulation=modeler.simulation))
+        port_name_list.append(task_name)
+
+    index_data = SimulationDataMap(keys=tuple(port_name_list), values=tuple(sim_data_list))
+    modeler_data = TerminalComponentModelerData(modeler=modeler, data=index_data)
+
+    # Pre-build the V/I matrices as TerminalPortDataArray
+    vi_coords = {"f": np.array(freqs), "port_out": port_names, "port_in": port_names}
+    voltage_matrix = TerminalPortDataArray(voltages, coords=vi_coords)
+    current_matrix = TerminalPortDataArray(currents, coords=vi_coords)
+
+    # Build the native Zref as TerminalPortDataArray
+    num_ports = len(port_names)
+    Zref_3d = Zref[:, :, None] * np.eye(num_ports)
+    z_ref_native = TerminalPortDataArray(
+        Zref_3d, coords={"f": np.array(freqs), "port_out": port_names, "port_in": port_names}
+    )
+
+    # Monkeypatch port_voltage_current_matrices as a regular property on the class.
+    # This survives updated_copy because the property is on the class, not the instance.
+    monkeypatch.setattr(
+        TerminalComponentModelerData,
+        "port_voltage_current_matrices",
+        property(lambda self: (voltage_matrix, current_matrix)),
+    )
+
+    # Monkeypatch the module-level port_reference_impedances function used when
+    # renormalized_reference_impedance is None or "Z0".
+    monkeypatch.setattr(
+        tidy3d.plugins.smatrix.analysis.terminal,
+        "port_reference_impedances",
+        lambda modeler_data_arg: z_ref_native,
+    )
+
+    return modeler_data, Zref, Z0, gamma, length, freqs, port_names
+
+
+def test_renormalize_identity(monkeypatch):
+    """Renormalizing to the same reference impedance gives the same S-matrix."""
+    modeler_data, Zref, *_ = _make_renormalize_fixture(monkeypatch)
+    freqs, port_names = _[3], _[4]
+
+    s_orig = modeler_data.smatrix().data.values
+    z_ref_orig = modeler_data.port_reference_impedances
+
+    s_renorm = modeler_data.renormalize(z_ref_orig).smatrix().data.values
+    assert np.allclose(s_orig, s_renorm, rtol=1e-12, atol=1e-14), (
+        f"Identity renormalization changed S-matrix.\n"
+        f"Max diff: {np.max(np.abs(s_orig - s_renorm)):.2e}"
+    )
+
+
+def test_renormalize_z_matrix_invariance(monkeypatch):
+    """Z-matrix should be the same regardless of reference impedance renormalization."""
+    modeler_data, Zref, Z0, gamma, length, freqs, port_names = _make_renormalize_fixture(
+        monkeypatch
+    )
+
+    z_orig = modeler_data.s_to_z().values
+    z_renorm = modeler_data.renormalize(50).s_to_z().values
+
+    assert np.allclose(z_orig, z_renorm, rtol=1e-10, atol=1e-12), (
+        f"Z-matrix changed after renormalization.\n"
+        f"Max diff: {np.max(np.abs(z_orig - z_renorm)):.2e}"
+    )
+
+
+def test_renormalize_scalar(monkeypatch):
+    """Renormalize with a scalar impedance produces different S-matrix."""
+    modeler_data, *_ = _make_renormalize_fixture(monkeypatch)
+
+    s_orig = modeler_data.smatrix().data.values
+    s_50 = modeler_data.renormalize(50).smatrix().data.values
+
+    # S-matrix should change since original Zref is not 50
+    assert not np.allclose(s_orig, s_50, atol=1e-6), "Renormalization to 50 did not change S-matrix"
+
+    # Verify it computed the expected S for Z_ref=50
+    Zref, Z0, gamma, length, freqs, port_names = _[0], _[1], _[2], _[3], _[4], _[5]
+    S_expected = calc_transmission_line_S_matrix_pseudo(Z0, 50, 50, gamma, length)
+    assert np.allclose(s_50, S_expected, rtol=1e-10, atol=1e-12), (
+        f"Renormalized S-matrix does not match analytical expectation.\n"
+        f"Max diff: {np.max(np.abs(s_50 - S_expected)):.2e}"
+    )
+
+
+def test_renormalize_port_data_array(monkeypatch):
+    """Renormalize with a per-port PortDataArray impedance."""
+    modeler_data, Zref, Z0, gamma, length, freqs, port_names = _make_renormalize_fixture(
+        monkeypatch
+    )
+
+    # Use 50 ohm for port 1, 75 ohm for port 2
+    per_port_z = PortDataArray(
+        np.array([[50, 75]] * len(freqs), dtype=complex),
+        coords={"f": freqs, "port": port_names},
+    )
+    s_renorm = modeler_data.renormalize(per_port_z).smatrix().data.values
+
+    S_expected = calc_transmission_line_S_matrix_pseudo(Z0, 50, 75, gamma, length)
+    assert np.allclose(s_renorm, S_expected, rtol=1e-10, atol=1e-12), (
+        f"Per-port renormalized S-matrix does not match analytical expectation.\n"
+        f"Max diff: {np.max(np.abs(s_renorm - S_expected)):.2e}"
+    )
+
+
+def test_renormalize_terminal_port_data_array(monkeypatch):
+    """Renormalize with a full TerminalPortDataArray impedance matrix."""
+    modeler_data, Zref, Z0, gamma, length, freqs, port_names = _make_renormalize_fixture(
+        monkeypatch
+    )
+
+    # Build a diagonal TerminalPortDataArray with 50 ohm
+    num_ports = len(port_names)
+    z_values = np.zeros((len(freqs), num_ports, num_ports), dtype=complex)
+    for i in range(num_ports):
+        z_values[:, i, i] = 50
+    z_ref_full = TerminalPortDataArray(
+        z_values, coords={"f": freqs, "port_out": port_names, "port_in": port_names}
+    )
+
+    s_renorm = modeler_data.renormalize(z_ref_full).smatrix().data.values
+    S_expected = calc_transmission_line_S_matrix_pseudo(Z0, 50, 50, gamma, length)
+    assert np.allclose(s_renorm, S_expected, rtol=1e-10, atol=1e-12)
+
+
+def test_renormalize_chaining_s_to_z(monkeypatch):
+    """renormalize(50).s_to_z() works and equals original s_to_z()."""
+    modeler_data, *_ = _make_renormalize_fixture(monkeypatch)
+
+    z_orig = modeler_data.s_to_z().values
+    z_50 = modeler_data.renormalize(50).s_to_z().values
+
+    assert np.allclose(z_orig, z_50, rtol=1e-10, atol=1e-12)
+
+
+def test_renormalize_invalid_type(monkeypatch):
+    """Passing an unsupported type raises ValidationError from Pydantic."""
+    modeler_data, *_ = _make_renormalize_fixture(monkeypatch)
+
+    with pytest.raises(ValidationError):
+        modeler_data.renormalize("invalid_string")
+
+
+def test_renormalize_none_is_default(monkeypatch):
+    """When renormalized_reference_impedance is None (default), behavior is unchanged."""
+    modeler_data, *_ = _make_renormalize_fixture(monkeypatch)
+
+    assert modeler_data.renormalized_reference_impedance is None
+    # Should be able to call smatrix normally
+    s = modeler_data.smatrix()
+    assert s.data.values.shape[1] == 2

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -14,6 +14,7 @@ import tidy3d.plugins.smatrix.utils
 from tidy3d import SimulationDataMap
 from tidy3d.components.boundary import BroadbandModeABCSpec
 from tidy3d.components.data.data_array import FreqDataArray
+from tidy3d.components.mode.mode_solver import ModeSolver
 from tidy3d.exceptions import SetupError, Tidy3dError, Tidy3dKeyError
 from tidy3d.plugins.smatrix import (
     CoaxialLumpedPort,
@@ -31,6 +32,8 @@ from tidy3d.plugins.smatrix.utils import s_to_z, validate_square_matrix
 
 from ...utils import AssertLogLevel, AssertLogStr, run_emulated
 from .terminal_component_modeler_def import (
+    Rinner,
+    Router,
     make_basic_filter_terminals,
     make_coaxial_component_modeler,
     make_component_modeler,
@@ -2782,3 +2785,138 @@ def test_renormalize_none_is_default(monkeypatch):
     # Should be able to call smatrix normally
     s = modeler_data.smatrix()
     assert s.data.values.shape[1] == 2
+
+
+def test_wave_port_mode_spec_resolution():
+    """Unit test WavePort._mode_spec for three resolution branches."""
+    # Shared geometry for WavePort construction
+    center = (0, 0, 0)
+    size = (2 * Router, 2 * Router, 0)
+
+    # Build a voltage spec that lies within the port bounds
+    mean_radius = (Router + Rinner) / 2
+    voltage_spec = td.AxisAlignedVoltageIntegralSpec(
+        center=(mean_radius, 0, 0),
+        size=(Router - Rinner, 0, 0),
+        extrapolate_to_endpoints=True,
+        snap_path_to_grid=True,
+        sign="+",
+    )
+    custom_impedance = td.CustomImpedanceSpec(voltage_spec=voltage_spec)
+
+    # Case 1: explicit integer num_modes — returns mode_spec as-is
+    spec_explicit = td.MicrowaveModeSpec(
+        num_modes=1,
+        impedance_specs=(custom_impedance,),
+    )
+    port_explicit = WavePort(
+        center=center, size=size, direction="+", name="explicit", mode_spec=spec_explicit
+    )
+    resolved = port_explicit._mode_spec
+    assert resolved is not None
+    assert resolved.num_modes == 1
+
+    # Case 2: num_modes="auto" with a tuple of impedance_specs — infer from length
+    spec_auto_tuple = td.MicrowaveModeSpec(
+        num_modes="auto",
+        impedance_specs=(custom_impedance, custom_impedance),
+    )
+    port_auto_tuple = WavePort(
+        center=center, size=size, direction="+", name="auto_tuple", mode_spec=spec_auto_tuple
+    )
+    resolved_tuple = port_auto_tuple._mode_spec
+    assert resolved_tuple is not None
+    assert resolved_tuple.num_modes == 2
+
+    # Case 3: num_modes="auto" with AutoImpedanceSpec — cannot resolve, returns None
+    spec_auto_default = td.MicrowaveModeSpec(num_modes="auto")
+    port_auto_default = WavePort(
+        center=center, size=size, direction="+", name="auto_default", mode_spec=spec_auto_default
+    )
+    assert port_auto_default._mode_spec is None
+
+
+def test_wave_port_auto_num_modes_modeler():
+    """Integration test: auto num_modes detection for WavePort via TerminalComponentModeler."""
+    # Build a single-strip stripline: one signal trace between two ground planes.
+    # PEC boundary on y ensures ground planes touching y-boundary are filtered out,
+    # leaving only the signal strip as a floating conductor.
+    mil = 25.4
+    w = 3.2 * mil  # signal strip width
+    t = 0.7 * mil  # conductor thickness
+    h = 10.7 * mil  # substrate thickness
+    L = 4000 * mil  # line length
+    len_inf = 1e6
+    f_max = 70e9
+
+    med_sub = td.Medium(permittivity=4.4)
+    med_metal = td.PEC
+
+    str_sub = td.Structure(geometry=td.Box(center=(0, 0, 0), size=(len_inf, h, L)), medium=med_sub)
+    str_signal = td.Structure(geometry=td.Box(center=(0, 0, 0), size=(w, t, L)), medium=med_metal)
+    str_gnd_top = td.Structure(
+        geometry=td.Box(center=(0, h / 2 + t / 2, 0), size=(len_inf, t, L)),
+        medium=med_metal,
+    )
+    str_gnd_bot = td.Structure(
+        geometry=td.Box(center=(0, -h / 2 - t / 2, 0), size=(len_inf, t, L)),
+        medium=med_metal,
+    )
+
+    lr_spec = td.LayerRefinementSpec.from_structures(
+        structures=[str_signal],
+        axis=1,
+        min_steps_along_axis=10,
+        refinement_inside_sim_only=False,
+        bounds_snapping="bounds",
+        corner_refinement=td.GridRefinement(dl=t / 10, num_cells=2),
+    )
+    lr_spec_top = lr_spec.updated_copy(center=(0, h / 2 + t / 2, 0), size=(len_inf, t, L))
+    lr_spec_bot = lr_spec.updated_copy(center=(0, -h / 2 - t / 2, 0), size=(len_inf, t, L))
+
+    grid_spec = td.GridSpec.auto(
+        wavelength=td.C_0 / f_max,
+        min_steps_per_wvl=30,
+        layer_refinement_specs=[lr_spec, lr_spec_top, lr_spec_bot],
+    )
+
+    sim = td.Simulation(
+        size=(50 * mil, h + 2 * t, 1.05 * L),
+        center=(0, 0, 0),
+        grid_spec=grid_spec,
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.pml(), y=td.Boundary.pec(), z=td.Boundary.pml()
+        ),
+        structures=[str_sub, str_signal, str_gnd_top, str_gnd_bot],
+        monitors=[],
+        run_time=2e-9,
+        shutoff=1e-7,
+    )
+
+    port = WavePort(
+        center=(0, 0, -L / 2),
+        size=(len_inf, len_inf, 0),
+        direction="+",
+        name="wave_auto",
+        mode_spec=td.MicrowaveModeSpec(num_modes="auto"),
+    )
+
+    freqs = np.array([1e9, 10e9])
+    modeler = TerminalComponentModeler(simulation=sim, ports=[port], freqs=freqs)
+
+    # Modeler should identify 1 wave port
+    assert len(modeler._wave_ports) == 1
+
+    # Should detect 1 floating isolated conductor (signal strip;
+    # ground planes filtered because they touch the PEC boundary on y)
+    conductors = modeler._floating_isolated_conductors_at_waveport["wave_auto"]
+    assert len(conductors) == 1
+
+    # Resolved mode spec should have num_modes == 1
+    resolved = modeler._resolved_mode_specs["wave_auto"]
+    assert isinstance(resolved, td.MicrowaveModeSpec)
+    assert resolved.num_modes == 1
+
+    # mode_solver_for_port should return a ModeSolver
+    ms = modeler.mode_solver_for_port("wave_auto")
+    assert isinstance(ms, ModeSolver)

--- a/tests/test_plugins/smatrix/test_terminal_plot_label_packing.py
+++ b/tests/test_plugins/smatrix/test_terminal_plot_label_packing.py
@@ -1,0 +1,46 @@
+"""Tests for automated label packing used in terminal port plotting."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from tidy3d.plugins.smatrix.component_modelers.terminal import _pack_label_centers_1d
+
+
+def _assert_non_overlapping_centers(
+    centers_px: np.ndarray, widths_px: np.ndarray, pad_px: float
+) -> None:
+    order = np.argsort(centers_px)
+    for left_idx, right_idx in zip(order[:-1], order[1:]):
+        left_right_edge = centers_px[left_idx] + widths_px[left_idx] / 2
+        right_left_edge = centers_px[right_idx] - widths_px[right_idx] / 2
+        assert right_left_edge >= left_right_edge + pad_px - 1e-9
+
+
+def test_pack_label_centers_1d_non_overlapping_and_in_bounds():
+    anchors = np.array([10.0, 11.0, 12.0])
+    widths = np.array([10.0, 10.0, 10.0])
+    x_min, x_max = 0.0, 40.0
+    pad = 2.0
+
+    centers = _pack_label_centers_1d(
+        anchor_centers_px=anchors, widths_px=widths, x_min_px=x_min, x_max_px=x_max, pad_px=pad
+    )
+
+    _assert_non_overlapping_centers(centers_px=centers, widths_px=widths, pad_px=pad)
+    assert np.all(centers - widths / 2 >= x_min - 1e-9)
+    assert np.all(centers + widths / 2 <= x_max + 1e-9)
+
+
+def test_pack_label_centers_1d_handles_right_overflow():
+    anchors = np.array([30.0, 31.0, 32.0])
+    widths = np.array([12.0, 12.0, 12.0])
+    x_min, x_max = 0.0, 40.0
+    pad = 2.0
+
+    centers = _pack_label_centers_1d(
+        anchor_centers_px=anchors, widths_px=widths, x_min_px=x_min, x_max_px=x_max, pad_px=pad
+    )
+
+    _assert_non_overlapping_centers(centers_px=centers, widths_px=widths, pad_px=pad)
+    assert np.all(centers + widths / 2 <= x_max + 1e-9)

--- a/tests/test_plugins/smatrix/test_terminal_plot_label_packing.py
+++ b/tests/test_plugins/smatrix/test_terminal_plot_label_packing.py
@@ -18,6 +18,7 @@ def _assert_non_overlapping_centers(
 
 
 def test_pack_label_centers_1d_non_overlapping_and_in_bounds():
+    """Packed labels stay non-overlapping and within the given bounds."""
     anchors = np.array([10.0, 11.0, 12.0])
     widths = np.array([10.0, 10.0, 10.0])
     x_min, x_max = 0.0, 40.0
@@ -33,6 +34,7 @@ def test_pack_label_centers_1d_non_overlapping_and_in_bounds():
 
 
 def test_pack_label_centers_1d_handles_right_overflow():
+    """Labels anchored near the right edge are shifted left to stay in bounds."""
     anchors = np.array([30.0, 31.0, 32.0])
     widths = np.array([12.0, 12.0, 12.0])
     x_min, x_max = 0.0, 40.0

--- a/tests/test_plugins/smatrix/test_terminal_wave_port.py
+++ b/tests/test_plugins/smatrix/test_terminal_wave_port.py
@@ -1,0 +1,477 @@
+"""Unit tests for TerminalWavePort."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+import tidy3d as td
+from tidy3d.components.data.data_array import (
+    CurrentFreqTerminalModeDataArray,
+    ImpedanceFreqTerminalTerminalDataArray,
+    ModeIndexDataArray,
+    ScalarModeFieldDataArray,
+    VoltageFreqTerminalModeDataArray,
+)
+from tidy3d.components.microwave.data.dataset import (
+    TerminalFieldDataset,
+    TransmissionLineTerminalDataset,
+)
+from tidy3d.components.microwave.data.monitor_data import MicrowaveModeSolverData
+from tidy3d.components.microwave.mode_spec import MicrowaveTerminalModeSpec
+from tidy3d.components.microwave.source import MicrowaveTerminalSource
+from tidy3d.components.mode.mode_solver import ModeSolver
+from tidy3d.plugins.smatrix import TerminalComponentModeler, TerminalWavePort
+
+
+def _make_voltage_spec(center=(0, 0, -10), size=(1, 0, 0)):
+    """Helper to create an AxisAlignedVoltageIntegralSpec."""
+    return td.AxisAlignedVoltageIntegralSpec(
+        center=center,
+        size=size,
+        extrapolate_to_endpoints=True,
+        snap_path_to_grid=True,
+        sign="+",
+    )
+
+
+def _make_custom_spec(voltage_spec=None):
+    """Helper to create a CustomImpedanceSpec with a voltage spec."""
+    if voltage_spec is None:
+        voltage_spec = _make_voltage_spec()
+    return td.CustomImpedanceSpec(voltage_spec=voltage_spec)
+
+
+def test_terminal_wave_port_custom_specs():
+    """Test TerminalWavePort with explicit CustomImpedanceSpec tuples."""
+    # Single terminal
+    spec0 = _make_custom_spec()
+    port_1mode = TerminalWavePort(
+        center=(0, 0, -10),
+        size=(2, 2, 0),
+        direction="+",
+        name="twp1",
+        terminal_specs=(spec0,),
+    )
+    mode_spec = port_1mode._mode_spec
+    assert isinstance(mode_spec, MicrowaveTerminalModeSpec)
+    assert mode_spec.num_modes == 1
+    assert port_1mode._mode_indices() == (0,)
+
+    # Two terminals
+    spec1 = _make_custom_spec(
+        voltage_spec=_make_voltage_spec(center=(0.5, 0, -10), size=(0.5, 0, 0))
+    )
+    port_2mode = TerminalWavePort(
+        center=(0, 0, -10),
+        size=(2, 2, 0),
+        direction="+",
+        name="twp2",
+        terminal_specs=(spec0, spec1),
+    )
+    mode_spec_2 = port_2mode._mode_spec
+    assert isinstance(mode_spec_2, MicrowaveTerminalModeSpec)
+    assert mode_spec_2.num_modes == 2
+    assert port_2mode._mode_indices() == (0, 1)
+
+
+def test_terminal_wave_port_differential_pairs():
+    """Test differential pair mapping and terminal classification."""
+    spec0 = _make_custom_spec()
+    spec1 = _make_custom_spec(
+        voltage_spec=_make_voltage_spec(center=(0.5, 0, -10), size=(0.5, 0, 0))
+    )
+    port = TerminalWavePort(
+        center=(0, 0, -10),
+        size=(2, 2, 0),
+        direction="+",
+        name="twp_diff",
+        terminal_specs=(spec0, spec1),
+        differential_pairs=(("T0", "T1"),),
+    )
+
+    # Check differential pair mapping
+    diff_map = port._differential_pair_mapping
+    assert "Diff0@comm" in diff_map
+    assert "Diff0@diff" in diff_map
+    assert diff_map["Diff0@comm"] == ("T0", "T1")
+    assert diff_map["Diff0@diff"] == ("T0", "T1")
+
+    # Both terminals are consumed by the differential pair
+    active = port._get_active_single_ended_terminals(["T0", "T1"])
+    assert active == []
+
+    # Terminals mapping should contain only differential pairs (no active single-ended)
+    terminals_mapping = port._get_terminals_mapping(["T0", "T1"])
+    assert "Diff0@comm" in terminals_mapping
+    assert "Diff0@diff" in terminals_mapping
+    # No single-ended keys since both are consumed
+    assert "T0" not in terminals_mapping
+    assert "T1" not in terminals_mapping
+
+
+def test_terminal_wave_port_validate_differential_pairs():
+    """Test that duplicate terminal labels in differential pairs raise ValidationError."""
+    spec0 = _make_custom_spec()
+    spec1 = _make_custom_spec(
+        voltage_spec=_make_voltage_spec(center=(0.5, 0, -10), size=(0.5, 0, 0))
+    )
+    spec2 = _make_custom_spec(
+        voltage_spec=_make_voltage_spec(center=(1.0, 0, -10), size=(0.5, 0, 0))
+    )
+    with pytest.raises(ValidationError):
+        TerminalWavePort(
+            center=(0, 0, -10),
+            size=(2, 2, 0),
+            direction="+",
+            name="twp_bad_diff",
+            terminal_specs=(spec0, spec1, spec2),
+            differential_pairs=(("T0", "T1"), ("T1", "T2")),
+        )
+
+
+def test_terminal_wave_port_validate_terminal_specs():
+    """Test validation of terminal_specs: empty tuple and inconsistent voltage specs."""
+    # Empty tuple should raise ValidationError
+    with pytest.raises(ValidationError):
+        TerminalWavePort(
+            center=(0, 0, -10),
+            size=(2, 2, 0),
+            direction="+",
+            name="twp_empty",
+            terminal_specs=(),
+        )
+
+    # Inconsistent voltage specs: one has voltage_spec, the other doesn't
+    spec_with_voltage = _make_custom_spec()
+    spec_without_voltage = td.CustomImpedanceSpec(
+        current_spec=td.AxisAlignedCurrentIntegralSpec(center=(0, 0, -10), size=(1, 1, 0), sign="+")
+    )
+    with pytest.raises(ValidationError):
+        TerminalWavePort(
+            center=(0, 0, -10),
+            size=(2, 2, 0),
+            direction="+",
+            name="twp_inconsistent",
+            terminal_specs=(spec_with_voltage, spec_without_voltage),
+        )
+
+
+def test_terminal_wave_port_to_source():
+    """Test that to_source returns a properly configured MicrowaveTerminalSource."""
+    spec = _make_custom_spec()
+    port = TerminalWavePort(
+        center=(0, 0, -10),
+        size=(2, 2, 0),
+        direction="+",
+        name="twp_src",
+        terminal_specs=(spec,),
+    )
+
+    source_time = td.GaussianPulse(freq0=10e9, fwidth=1e9)
+    source = port.to_source(source_time=source_time)
+
+    assert isinstance(source, MicrowaveTerminalSource)
+    assert list(source.center) == [0, 0, -10]
+    assert list(source.size) == [2, 2, 0]
+    assert source.direction == "+"
+    assert source.name == "twp_src"
+    # Default terminal_label should be the first terminal "T0"
+    assert source.terminal_label == "T0"
+
+
+def _make_differential_stripline_sim_and_port():
+    """Build a 2-signal-trace stripline simulation with a TerminalWavePort using AutoImpedanceSpec.
+
+    Adapted from terminal_component_modeler_def.py:make_differential_stripline_modeler.
+    """
+    mil = 25.4  # mil to micron conversion
+    w = 3.2 * mil  # signal strip width
+    t = 0.7 * mil  # conductor thickness
+    h = 10.7 * mil  # substrate thickness
+    se = 7 * mil  # gap between edge-coupled pair
+    L = 4000 * mil  # line length
+    len_inf = 1e6  # effective infinity
+
+    f_max = 70e9
+    eps = 4.4
+
+    med_sub = td.Medium(permittivity=eps)
+    med_metal = td.PEC
+
+    left_strip = td.Box(center=(-(se + w) / 2, 0, 0), size=(w, t, L))
+    right_strip = td.Box(center=((se + w) / 2, 0, 0), size=(w, t, L))
+
+    str_sub = td.Structure(geometry=td.Box(center=(0, 0, 0), size=(len_inf, h, L)), medium=med_sub)
+    str_signal = td.Structure(
+        geometry=td.GeometryGroup(geometries=[left_strip, right_strip]),
+        medium=med_metal,
+    )
+    str_gnd_top = td.Structure(
+        geometry=td.Box(center=(0, h / 2 + t / 2, 0), size=(len_inf, t, L)),
+        medium=med_metal,
+    )
+    str_gnd_bot = td.Structure(
+        geometry=td.Box(center=(0, -h / 2 - t / 2, 0), size=(len_inf, t, L)),
+        medium=med_metal,
+    )
+
+    # Layer refinement to snap grid to conductor boundaries (needed for auto-detection)
+    lr_spec = td.LayerRefinementSpec.from_structures(
+        structures=[str_signal],
+        axis=1,
+        min_steps_along_axis=10,
+        refinement_inside_sim_only=False,
+        bounds_snapping="bounds",
+        corner_refinement=td.GridRefinement(dl=t / 10, num_cells=2),
+    )
+    lr_spec_top = lr_spec.updated_copy(center=(0, h / 2 + t / 2, 0), size=(len_inf, t, L))
+    lr_spec_bot = lr_spec.updated_copy(center=(0, -h / 2 - t / 2, 0), size=(len_inf, t, L))
+
+    grid_spec = td.GridSpec.auto(
+        wavelength=td.C_0 / f_max,
+        min_steps_per_wvl=30,
+        layer_refinement_specs=[lr_spec, lr_spec_top, lr_spec_bot],
+    )
+    boundary_spec = td.BoundarySpec(
+        x=td.Boundary.pml(),
+        y=td.Boundary.pec(),
+        z=td.Boundary.pml(),
+    )
+
+    sim = td.Simulation(
+        size=(50 * mil, h + 2 * t, 1.05 * L),
+        center=(0, 0, 0),
+        grid_spec=grid_spec,
+        boundary_spec=boundary_spec,
+        structures=[str_sub, str_signal, str_gnd_top, str_gnd_bot],
+        monitors=[],
+        run_time=2e-9,
+        shutoff=1e-7,
+    )
+
+    # TerminalWavePort with AutoImpedanceSpec (default)
+    port = TerminalWavePort(
+        center=(0, 0, -L / 2),
+        size=(len_inf, len_inf, 0),
+        direction="+",
+        name="terminal",
+    )
+
+    return sim, port
+
+
+def test_terminal_wave_port_modeler_auto_detection():
+    """Test TerminalComponentModeler with AutoImpedanceSpec auto-detects conductors."""
+    sim, port = _make_differential_stripline_sim_and_port()
+    freqs = np.array([1e9, 10e9])
+
+    modeler = TerminalComponentModeler(
+        simulation=sim,
+        ports=[port],
+        freqs=freqs,
+    )
+
+    # Port should be listed in terminal wave ports
+    assert len(modeler._terminal_wave_ports) == 1
+    assert modeler._terminal_wave_ports[0].name == "terminal"
+
+    # Two signal traces detected as floating conductors (ground planes filtered out
+    # because they touch the PEC boundary on y)
+    conductors = modeler._floating_isolated_conductors_at_waveport["terminal"]
+    assert len(conductors) == 2
+
+    # Resolved mode spec should be a MicrowaveTerminalModeSpec with 2 modes
+    resolved = modeler._resolved_mode_specs["terminal"]
+    assert isinstance(resolved, MicrowaveTerminalModeSpec)
+    assert resolved.num_modes == 2
+
+    # mode_solver_for_port should return a ModeSolver without error
+    ms = modeler.mode_solver_for_port("terminal")
+    assert isinstance(ms, ModeSolver)
+
+    # network_dict should map terminal labels for TerminalWavePort
+    network = modeler.network_dict
+    assert len(network) == 2
+    for _key, (p, label) in network.items():
+        assert p.name == "terminal"
+        assert label in resolved._terminal_indices
+
+    # matrix_indices_monitor should list all terminal indices
+    indices = modeler.matrix_indices_monitor
+    assert len(indices) == 2
+
+    # task_name_from_index should work for each index
+    for idx in indices:
+        task_name = modeler.task_name_from_index(idx)
+        assert isinstance(task_name, str)
+
+
+def test_terminal_fields_from_mock_data():
+    """Test that MicrowaveModeSolverData.terminal_fields returns a TerminalFieldDataset."""
+    n_terminals = 2
+    n_modes = 2
+    terminal_labels = ["T0", "T1"]
+    mode_indices = list(range(n_modes))
+    freqs = [10e9]
+
+    # Spatial grid for the mode plane (z is the injection axis → z has 1 cell)
+    x = [-1.0, 1.0, 3.0]
+    y = [-2.0, 0.0]
+    z = [-1.0, 1.0]
+    grid = td.Grid(boundaries=td.Coords(x=x, y=y, z=z))
+
+    # Field data: shape (nx, ny, nz, nf, n_modes) = (2, 1, 1, 1, 2)
+    field_coords = {"x": x[:-1], "y": y[:-1], "z": z[:-1], "f": freqs, "mode_index": mode_indices}
+    field_shape = (len(x) - 1, len(y) - 1, len(z) - 1, len(freqs), n_modes)
+    field = ScalarModeFieldDataArray((1 + 1j) * np.random.random(field_shape), coords=field_coords)
+
+    # n_complex
+    index_coords = {"f": freqs, "mode_index": mode_indices}
+    n_complex = ModeIndexDataArray((1.5 + 0.01j) * np.ones((1, n_modes)), coords=index_coords)
+
+    # Terminal impedance matrix: Z0[f, terminal_label_out, terminal_label_in]
+    z0_coords = {
+        "f": freqs,
+        "terminal_label_out": terminal_labels,
+        "terminal_label_in": terminal_labels,
+    }
+    z0_data = np.zeros((1, n_terminals, n_terminals), dtype=complex)
+    for i in range(n_terminals):
+        z0_data[0, i, i] = 50.0
+    Z0 = ImpedanceFreqTerminalTerminalDataArray(z0_data, coords=z0_coords)
+
+    # Voltage and current transforms: identity matrices [f, terminal_label, mode_index]
+    transform_coords = {"f": freqs, "terminal_label": terminal_labels, "mode_index": mode_indices}
+    identity = np.eye(n_terminals).reshape(1, n_terminals, n_modes)
+    voltage_transform = VoltageFreqTerminalModeDataArray(
+        identity.astype(complex), coords=transform_coords
+    )
+    current_transform = CurrentFreqTerminalModeDataArray(
+        identity.astype(complex), coords=transform_coords
+    )
+
+    terminal_data = TransmissionLineTerminalDataset(
+        Z0=Z0,
+        voltage_transform=voltage_transform,
+        current_transform=current_transform,
+    )
+
+    # Create impedance specs for the MicrowaveTerminalModeSpec
+    impedance_specs = {}
+    for label in terminal_labels:
+        impedance_specs[label] = td.CustomImpedanceSpec(
+            voltage_spec=td.AxisAlignedVoltageIntegralSpec(
+                center=(0, 0, 0), size=(1, 0, 0), extrapolate_to_endpoints=True, sign="+"
+            )
+        )
+
+    mode_spec = MicrowaveTerminalModeSpec(
+        num_modes=n_modes,
+        impedance_specs=impedance_specs,
+    )
+
+    monitor = td.MicrowaveModeSolverMonitor(
+        center=(0, 0, 0),
+        size=(4, 2, 0),
+        freqs=freqs,
+        mode_spec=mode_spec,
+        name="mw_mode_solver",
+    )
+
+    mode_data = MicrowaveModeSolverData(
+        monitor=monitor,
+        Ex=field,
+        Ey=field,
+        Ez=field,
+        Hx=field,
+        Hy=field,
+        Hz=field,
+        n_complex=n_complex,
+        grid_expanded=grid,
+        transmission_line_terminal_data=terminal_data,
+    )
+
+    # Verify terminal_fields
+    tf = mode_data.terminal_fields
+    assert tf is not None
+    assert isinstance(tf, TerminalFieldDataset)
+    assert "terminal_label" in tf.Ex.dims
+    assert list(tf.Ex.coords["terminal_label"].values) == terminal_labels
+
+
+def test_terminal_wave_port_plot_port():
+    """Test plot_port for TerminalWavePort with differential pairs."""
+    import matplotlib.pyplot as plt
+
+    sim, _ = _make_differential_stripline_sim_and_port()
+    freqs = np.array([1e9, 10e9])
+
+    mil = 25.4
+    L = 4000 * mil
+    len_inf = 1e6
+    port = TerminalWavePort(
+        center=(0, 0, -L / 2),
+        size=(len_inf, len_inf, 0),
+        direction="+",
+        name="terminal",
+        differential_pairs=(("T0", "T1"),),
+    )
+
+    modeler = TerminalComponentModeler(
+        simulation=sim,
+        ports=[port],
+        freqs=freqs,
+    )
+
+    # plot_port by name (str path) — cascades through full plotting stack
+    ax = modeler.plot_port("terminal")
+    assert ax is not None
+    plt.close()
+
+    # plot_port by port object
+    ax = modeler.plot_port(port)
+    assert ax is not None
+    plt.close()
+
+    # plot_sim_grid
+    modeler.plot_sim_grid(z=port.center[2])
+    plt.close()
+
+
+def test_terminal_wave_port_plot_port_custom_voltage_specs():
+    """Test plot_port with explicit voltage specs and invalid port type error."""
+    import matplotlib.pyplot as plt
+
+    spec0 = _make_custom_spec()
+    spec1 = _make_custom_spec(voltage_spec=_make_voltage_spec(center=(0.5, 0, 0), size=(0.5, 0, 0)))
+    port = TerminalWavePort(
+        center=(0, 0, 0),
+        size=(2, 2, 0),
+        direction="+",
+        name="twp_volt",
+        terminal_specs=(spec0, spec1),
+    )
+    sim = td.Simulation(
+        size=(4, 4, 4),
+        center=(0, 0, 0),
+        grid_spec=td.GridSpec.auto(wavelength=td.C_0 / 10e9, min_steps_per_wvl=10),
+        boundary_spec=td.BoundarySpec.all_sides(boundary=td.PML()),
+        structures=[],
+        monitors=[],
+        run_time=1e-9,
+    )
+    modeler = TerminalComponentModeler(
+        simulation=sim,
+        ports=[port],
+        freqs=np.array([1e9, 10e9]),
+    )
+
+    ax = modeler.plot_port("twp_volt")
+    assert ax is not None
+    plt.close()
+
+    # Invalid port type raises ValueError
+    with pytest.raises(ValueError, match="Invalid port type"):
+        modeler.plot_port(42)

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -56,6 +56,9 @@ DIM_ATTRS = {
     "t": {"units": SECOND, "long_name": "time"},
     "direction": {"long_name": "propagation direction"},
     "mode_index": {"long_name": "mode index"},
+    "terminal_label": {"long_name": "terminal label"},
+    "terminal_label_out": {"long_name": "output terminal label"},
+    "terminal_label_in": {"long_name": "input terminal label"},
     "eme_port_index": {"long_name": "EME port index"},
     "eme_cell_index": {"long_name": "EME cell index"},
     "mode_index_in": {"long_name": "mode index in"},
@@ -286,7 +289,8 @@ class DataArray(xr.DataArray):
         sub_group = f_handle.create_group(group_path)
         sub_group[DATA_ARRAY_VALUE_NAME] = get_static(self.data)
         for key, val in self.coords.items():
-            if val.dtype == "<U1":
+            if str(val.dtype).startswith("<U") or str(val.dtype).startswith("U"):
+                # Convert Unicode strings to list for HDF5 storage
                 sub_group[key] = val.values.tolist()
             else:
                 sub_group[key] = val
@@ -614,6 +618,32 @@ class FreqVoltageDataArray(DataArray):
     )
 
 
+class ModeDataArray(DataArray):
+    """Mode index data array.
+    Example
+    -------
+    >>> mode_index = np.arange(4)
+    >>> coords = dict(mode_index=mode_index)
+    >>> data = ModeDataArray((1+1j) * np.random.random(4), coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("mode_index",)
+
+
+class TerminalDataArray(DataArray):
+    """Terminal index data array.
+    Example
+    -------
+    >>> terminal_label = ["t0", "t1", "t2", "t3", "t4"]
+    >>> coords = dict(terminal_label=terminal_label)
+    >>> data = TerminalDataArray((1+1j) * np.random.random(5), coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("terminal_label",)
+
+
 class FreqModeDataArray(DataArray):
     """Array over frequency and mode index.
 
@@ -627,6 +657,84 @@ class FreqModeDataArray(DataArray):
 
     __slots__ = ()
     _dims = ("f", "mode_index")
+
+
+class FreqTerminalDataArray(DataArray):
+    """Array over frequency and terminal index.
+
+    Example
+    -------
+    >>> f = [2e14, 3e14]
+    >>> terminal_label = ["t0", "t1", "t2", "t3", "t4"]
+    >>> coords = dict(f=f, terminal_label=terminal_label)
+    >>> fd = FreqTerminalDataArray((1+1j) * np.random.random((2, 5)), coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("f", "terminal_label")
+
+
+class FreqModeModeDataArray(DataArray):
+    """Array over frequency, mode index, and mode index.
+    Example
+    -------
+    >>> f = [2e14, 3e14]
+    >>> mode_index_out = np.arange(5)
+    >>> mode_index_in = np.arange(5)
+    >>> coords = dict(f=f, mode_index_out=mode_index_out, mode_index_in=mode_index_in)
+    >>> fd = FreqModeModeDataArray((1+1j) * np.random.random((2, 5, 5)), coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("f", "mode_index_out", "mode_index_in")
+
+
+class FreqTerminalModeDataArray(DataArray):
+    """Array over frequency, terminal index, and mode index.
+
+    Example
+    -------
+    >>> f = [2e14, 3e14]
+    >>> mode_index = np.arange(5)
+    >>> terminal_label = ["t0", "t1"]
+    >>> coords = dict(f=f, terminal_label=terminal_label, mode_index=mode_index)
+    >>> fd = FreqTerminalModeDataArray((1+1j) * np.random.random((2, 2, 5)), coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("f", "terminal_label", "mode_index")
+
+
+class FreqModeTerminalDataArray(DataArray):
+    """Array over frequency, mode index, and terminal index.
+
+    Example
+    -------
+    >>> f = [2e14, 3e14]
+    >>> mode_index = np.arange(5)
+    >>> terminal_label = ["t0", "t1"]
+    >>> coords = dict(f=f, mode_index=mode_index, terminal_label=terminal_label)
+    >>> fd = FreqModeTerminalDataArray((1+1j) * np.random.random((2, 5, 2)), coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("f", "mode_index", "terminal_label")
+
+
+class FreqTerminalTerminalDataArray(DataArray):
+    """Array over frequency, terminal index, and terminal index.
+
+    Example
+    -------
+    >>> f = [2e14, 3e14]
+    >>> terminal_label_out = ["t0", "t1"]
+    >>> terminal_label_in = ["t0", "t1"]
+    >>> coords = dict(f=f, terminal_label_out=terminal_label_out, terminal_label_in=terminal_label_in)
+    >>> fd = FreqTerminalTerminalDataArray((1+1j) * np.random.random((2, 2, 2)), coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("f", "terminal_label_out", "terminal_label_in")
 
 
 class TimeDataArray(DataArray):
@@ -927,6 +1035,24 @@ class ScalarModeFieldCylindricalDataArray(AbstractSpatialDataArray):
 
     __slots__ = ()
     _dims = ("rho", "theta", "axial", "f", "mode_index")
+
+
+class ScalarTerminalFieldDataArray(AbstractSpatialDataArray):
+    """Spatial distribution of a terminal field in frequency-domain as a function of terminal index.
+
+    Example
+    -------
+    >>> x = [1,2]
+    >>> y = [2,3,4]
+    >>> z = [3,4,5,6]
+    >>> f = [2e14, 3e14]
+    >>> terminal_label = ["t0", "t1", "t2"]
+    >>> coords = dict(x=x, y=y, z=z, f=f, terminal_label=terminal_label)
+    >>> fd = ScalarTerminalFieldDataArray((1+1j) * np.random.random((2,3,4,2,3)), coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("x", "y", "z", "f", "terminal_label")
 
 
 class FluxDataArray(DataArray):
@@ -1528,6 +1654,56 @@ class VoltageFreqModeDataArray(VoltageArray, FreqModeDataArray):
     __slots__ = ()
 
 
+class VoltageFreqTerminalDataArray(VoltageArray, FreqTerminalDataArray):
+    """Voltage data array in frequency-terminal domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> f = [2e9, 3e9]
+    >>> terminal_label = ["t0", "t1"]
+    >>> coords = dict(f=f, terminal_label=terminal_label)
+    >>> data = np.random.random((2, 2)) + 1j * np.random.random((2, 2))
+    >>> vftd = VoltageFreqTerminalDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
+class VoltageFreqTerminalModeDataArray(VoltageArray, FreqTerminalModeDataArray):
+    """Voltage transformation matrix data array from modes to terminals in frequency domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> f = [2e9, 3e9]
+    >>> terminal_label = ["t0", "t1"]
+    >>> mode_index = [0, 1]
+    >>> coords = dict(f=f, terminal_label=terminal_label, mode_index=mode_index)
+    >>> data = np.random.random((2, 2, 2)) + 1j * np.random.random((2, 2, 2))
+    >>> vtransform = VoltageFreqTerminalModeDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
+class VoltageFreqModeTerminalDataArray(VoltageArray, FreqModeTerminalDataArray):
+    """Inverse voltage transformation matrix data array from terminals to modes in frequency domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> f = [2e9, 3e9]
+    >>> mode_index = [0, 1]
+    >>> terminal_label = ["t0", "t1"]
+    >>> coords = dict(f=f, mode_index=mode_index, terminal_label=terminal_label)
+    >>> data = np.random.random((2, 2, 2)) + 1j * np.random.random((2, 2, 2))
+    >>> vtransform_inv = VoltageFreqModeTerminalDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
 # Current arrays
 class CurrentFreqDataArray(CurrentArray, FreqDataArray):
     """Current data array in frequency domain.
@@ -1575,7 +1751,63 @@ class CurrentFreqModeDataArray(CurrentArray, FreqModeDataArray):
     __slots__ = ()
 
 
+class CurrentFreqTerminalDataArray(CurrentArray, FreqTerminalDataArray):
+    """Current data array in frequency-terminal domain.
+    Example
+    -------
+    >>> import numpy as np
+    >>> f = [2e9, 3e9]
+    >>> terminal_label = ["t0", "t1", "t2", "t3", "t4"]
+    >>> coords = dict(f=f, terminal_label=terminal_label)
+    >>> data = np.random.random((2, 5)) + 1j * np.random.random((2, 5))
+    >>> cftd = CurrentFreqTerminalDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
+class CurrentFreqTerminalModeDataArray(CurrentArray, FreqTerminalModeDataArray):
+    """Current transformation matrix data array from modes to terminals in frequency domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> f = [2e9, 3e9]
+    >>> mode_index = [0, 1]
+    >>> terminal_label = ["t0", "t1"]
+    >>> coords = dict(f=f, terminal_label=terminal_label, mode_index=mode_index)
+    >>> data = np.random.random((2, 2, 2)) + 1j * np.random.random((2, 2, 2))
+    >>> itransform = CurrentFreqTerminalModeDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
 # Impedance arrays
+class ImpedanceModeDataArray(ImpedanceArray, ModeDataArray):
+    """Impedance data array in mode index domain.
+    Example
+    -------
+    >>> mode_index = np.arange(4)
+    >>> coords = dict(mode_index=mode_index)
+    >>> data = ImpedanceModeDataArray((1+1j) * np.random.random(4), coords=coords)
+    """
+
+    __slots__ = ()
+
+
+class ImpedanceTerminalDataArray(ImpedanceArray, TerminalDataArray):
+    """Impedance data array in terminal index domain.
+    Example
+    -------
+    >>> terminal_label = ["t0", "t1", "t2", "t3", "t4"]
+    >>> coords = dict(terminal_label=terminal_label)
+    >>> data = ImpedanceTerminalDataArray((1+1j) * np.random.random(5), coords=coords)
+    """
+
+    __slots__ = ()
+
+
 class ImpedanceFreqDataArray(ImpedanceArray, FreqDataArray):
     """Impedance data array in frequency domain.
 
@@ -1622,6 +1854,40 @@ class ImpedanceFreqModeDataArray(ImpedanceArray, FreqModeDataArray):
     __slots__ = ()
 
 
+class ImpedanceFreqModeModeDataArray(ImpedanceArray, FreqModeModeDataArray):
+    """Impedance matrix data array between modes in frequency domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> f = [2e9, 3e9]
+    >>> mode_index_out = np.arange(2)
+    >>> mode_index_in = np.arange(2)
+    >>> coords = dict(f=f, mode_index_out=mode_index_out, mode_index_in=mode_index_in)
+    >>> data = ImpedanceFreqModeModeDataArray(50.0 + 10.0 * np.random.random((2, 2, 2)), coords=coords)
+    >>> zfmmd = data
+    """
+
+    __slots__ = ()
+
+
+class ImpedanceFreqTerminalTerminalDataArray(ImpedanceArray, FreqTerminalTerminalDataArray):
+    """Impedance matrix data array between terminals in frequency domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> f = [2e9, 3e9]
+    >>> terminal_label_out = ["t0", "t1"]
+    >>> terminal_label_in = ["t0", "t1"]
+    >>> coords = dict(f=f, terminal_label_out=terminal_label_out, terminal_label_in=terminal_label_in)
+    >>> data = ImpedanceFreqTerminalTerminalDataArray(50.0 + 10.0 * np.random.random((2, 2, 2)), coords=coords)
+    >>> zfttd = data
+    """
+
+    __slots__ = ()
+
+
 def _make_base_result_data_array(result: DataArray) -> IntegralResultType:
     """Helper for creating the proper base result type."""
     cls = FreqDataArray
@@ -1629,6 +1895,8 @@ def _make_base_result_data_array(result: DataArray) -> IntegralResultType:
         cls = TimeDataArray
     if "f" in result.coords and "mode_index" in result.coords:
         cls = FreqModeDataArray
+    if "f" in result.coords and "terminal_label" in result.coords and "mode_index" in result.coords:
+        cls = FreqTerminalModeDataArray
     return cls._assign_data_attrs(cls(data=result.data, coords=result.coords))
 
 
@@ -1639,6 +1907,8 @@ def _make_voltage_data_array(result: DataArray) -> VoltageIntegralResultType:
         cls = VoltageTimeDataArray
     if "f" in result.coords and "mode_index" in result.coords:
         cls = VoltageFreqModeDataArray
+    if "f" in result.coords and "terminal_label" in result.coords and "mode_index" in result.coords:
+        cls = VoltageFreqTerminalModeDataArray
     return cls._assign_data_attrs(cls(data=result.data, coords=result.coords))
 
 
@@ -1649,6 +1919,8 @@ def _make_current_data_array(result: DataArray) -> CurrentIntegralResultType:
         cls = CurrentTimeDataArray
     if "f" in result.coords and "mode_index" in result.coords:
         cls = CurrentFreqModeDataArray
+    if "f" in result.coords and "terminal_label" in result.coords and "mode_index" in result.coords:
+        cls = CurrentFreqTerminalModeDataArray
     return cls._assign_data_attrs(cls(data=result.data, coords=result.coords))
 
 
@@ -1659,6 +1931,12 @@ def _make_impedance_data_array(result: DataArray) -> ImpedanceResultType:
         cls = ImpedanceTimeDataArray
     if "f" in result.coords and "mode_index" in result.coords:
         cls = ImpedanceFreqModeDataArray
+    if (
+        "f" in result.coords
+        and "terminal_label_out" in result.coords
+        and "terminal_label_in" in result.coords
+    ):
+        cls = ImpedanceFreqTerminalTerminalDataArray
     return cls._assign_data_attrs(cls(data=result.data, coords=result.coords))
 
 
@@ -1667,6 +1945,7 @@ DATA_ARRAY_TYPES = [
     ScalarFieldDataArray,
     ScalarFieldTimeDataArray,
     ScalarModeFieldDataArray,
+    ScalarTerminalFieldDataArray,
     FluxDataArray,
     FluxTimeDataArray,
     ModeAmpsDataArray,
@@ -1677,11 +1956,17 @@ DATA_ARRAY_TYPES = [
     FieldProjectionCartesianDataArray,
     FieldProjectionKSpaceDataArray,
     DiffractionDataArray,
+    ModeDataArray,
+    TerminalDataArray,
     FreqModeDataArray,
     FreqDataArray,
     TimeDataArray,
     FreqModeDataArray,
     FreqVoltageDataArray,
+    FreqTerminalDataArray,
+    FreqTerminalModeDataArray,
+    FreqModeTerminalDataArray,
+    FreqTerminalTerminalDataArray,
     TriangleMeshDataArray,
     HeatDataArray,
     EMEScalarFieldDataArray,
@@ -1705,12 +1990,22 @@ DATA_ARRAY_TYPES = [
     VoltageFreqDataArray,
     VoltageTimeDataArray,
     VoltageFreqModeDataArray,
+    VoltageFreqTerminalDataArray,
+    VoltageFreqTerminalModeDataArray,
+    VoltageFreqModeTerminalDataArray,
     CurrentFreqDataArray,
     CurrentTimeDataArray,
     CurrentFreqModeDataArray,
+    CurrentFreqTerminalDataArray,
+    CurrentFreqTerminalModeDataArray,
+    ImpedanceModeDataArray,
+    ImpedanceTerminalDataArray,
     ImpedanceFreqDataArray,
     ImpedanceTimeDataArray,
     ImpedanceFreqModeDataArray,
+    FreqModeModeDataArray,
+    ImpedanceFreqModeModeDataArray,
+    ImpedanceFreqTerminalTerminalDataArray,
 ]
 DATA_ARRAY_MAP = {data_array.__name__: data_array for data_array in DATA_ARRAY_TYPES}
 
@@ -1722,13 +2017,24 @@ IndexedDataArrayTypes = Union[
     PointDataArray,
 ]
 
-IntegralResultType = Union[FreqDataArray, FreqModeDataArray, TimeDataArray]
+IntegralResultType = Union[
+    FreqDataArray, FreqModeDataArray, FreqTerminalModeDataArray, TimeDataArray
+]
 VoltageIntegralResultType = Union[
-    VoltageFreqDataArray, VoltageFreqModeDataArray, VoltageTimeDataArray
+    VoltageFreqDataArray,
+    VoltageFreqModeDataArray,
+    VoltageTimeDataArray,
+    VoltageFreqTerminalModeDataArray,
 ]
 CurrentIntegralResultType = Union[
-    CurrentFreqDataArray, CurrentFreqModeDataArray, CurrentTimeDataArray
+    CurrentFreqDataArray,
+    CurrentFreqModeDataArray,
+    CurrentTimeDataArray,
+    CurrentFreqTerminalModeDataArray,
 ]
 ImpedanceResultType = Union[
-    ImpedanceFreqDataArray, ImpedanceFreqModeDataArray, ImpedanceTimeDataArray
+    ImpedanceFreqDataArray,
+    ImpedanceFreqModeDataArray,
+    ImpedanceTimeDataArray,
+    ImpedanceFreqTerminalTerminalDataArray,
 ]

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -725,7 +725,7 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
     def mode_area(self) -> FreqModeDataArray:
         r"""Effective mode area corresponding to a 2D monitor.
 
-        .. math:
+        .. math::
 
            \frac{\left(\int |E|^2 \, {\rm d}S\right)^2}{\int |E|^4 \, {\rm d}S}
         """
@@ -830,7 +830,10 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
         return self.fill_fraction(bounding_box)
 
     def dot(
-        self, field_data: Union[FieldData, ModeData, ModeSolverData], conjugate: bool = True
+        self,
+        field_data: Union[FieldData, ModeData, ModeSolverData],
+        conjugate: bool = True,
+        use_symmetric_form: bool = True,
     ) -> ModeAmpsDataArray:
         r"""Dot product (modal overlap) with another :class:`.FieldData` object. Both datasets have
         to be frequency-domain data associated with a 2D monitor. Along the tangential directions,
@@ -843,9 +846,17 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
 
         The dot product is defined as:
 
-        .. math:
+        .. math::
 
            \frac{1}{4} \int \left( E_0 \times H_1^* + H_0^* \times E_1 \) \, {\rm d}S
+
+        when ``use_symmetric_form=True``, or as:
+
+        .. math::
+
+           \frac{1}{2} \int E_0 \times H_1^* \, {\rm d}S
+
+        when ``use_symmetric_form=False``.
 
         Parameters
         ----------
@@ -854,6 +865,9 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
         conjugate : bool, optional
             If ``True`` (default), the dot product is defined as above. If ``False``, the definition
             is similar, but without the complex conjugation of the $H$ fields.
+        use_symmetric_form : bool, optional
+            If ``True`` (default), uses the symmetric form: 1/4 ∫ (E_0 × H_1* + H_0* × E_1) dS.
+            If ``False``, uses the asymmetric form: 1/2 ∫ (E_0 × H_1*) dS.
 
         Note
         ----
@@ -864,15 +878,27 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
             and the sum of carried power fractions may be different from the total flux.
             In the non-conjugated definition, modes are orthogonal, but the interpretation of the
             dot product power carried by a given mode is no longer valid.
+
+        Note
+        ----
+            The symmetric form (``use_symmetric_form=True``) is the correct definition for the
+            mode orthogonality relation and ensures proper normalization of modal fields. The
+            asymmetric form (``use_symmetric_form=False``) is useful in other scenarios such as
+            transmission line analysis.
         """
 
         # Tangential fields for current and other field data
         fields_self = self._colocated_tangential_fields
-
-        if conjugate:
-            fields_self = {key: field.conj() for key, field in fields_self.items()}
-
         fields_other = field_data._interpolated_tangential_fields(self._plane_grid_boundaries)
+
+        # Apply conjugation based on the form and conjugate flag
+        # For symmetric form: conjugate fields_self to get (E₀* × H₁) - (H₀* × E₁)
+        # For asymmetric form: conjugate fields_other to get E₀ × H₁*
+        if conjugate:
+            if use_symmetric_form:
+                fields_self = {key: field.conj() for key, field in fields_self.items()}
+            else:
+                fields_other = {key: field.conj() for key, field in fields_other.items()}
         dim1, dim2 = self._tangential_dims
         d_area = self._diff_area
 
@@ -885,11 +911,16 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
             # Arrays are same shape, so we can use numpy
             e_self_x_h_other = fields_self["E" + dim1].values * fields_other["H" + dim2].values
             e_self_x_h_other -= fields_self["E" + dim2].values * fields_other["H" + dim1].values
-            h_self_x_e_other = fields_self["H" + dim1].values * fields_other["E" + dim2].values
-            h_self_x_e_other -= fields_self["H" + dim2].values * fields_other["E" + dim1].values
-            integrand = xr.DataArray(
-                e_self_x_h_other - h_self_x_e_other, coords=fields_self["E" + dim1].coords
-            )
+
+            if use_symmetric_form:
+                h_self_x_e_other = fields_self["H" + dim1].values * fields_other["E" + dim2].values
+                h_self_x_e_other -= fields_self["H" + dim2].values * fields_other["E" + dim1].values
+                integrand = xr.DataArray(
+                    e_self_x_h_other - h_self_x_e_other, coords=fields_self["E" + dim1].coords
+                )
+            else:
+                integrand = xr.DataArray(e_self_x_h_other, coords=fields_self["E" + dim1].coords)
+
             integrand *= d_area
         else:
             # Broadcasting is needed, which may be complicated depending on the dimensions order.
@@ -901,12 +932,17 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
             # Cross products of fields
             e_self_x_h_other = fields_self["E" + dim1] * fields_other["H" + dim2]
             e_self_x_h_other -= fields_self["E" + dim2] * fields_other["H" + dim1]
-            h_self_x_e_other = fields_self["H" + dim1] * fields_other["E" + dim2]
-            h_self_x_e_other -= fields_self["H" + dim2] * fields_other["E" + dim1]
-            integrand = (e_self_x_h_other - h_self_x_e_other) * d_area
+
+            if use_symmetric_form:
+                h_self_x_e_other = fields_self["H" + dim1] * fields_other["E" + dim2]
+                h_self_x_e_other -= fields_self["H" + dim2] * fields_other["E" + dim1]
+                integrand = (e_self_x_h_other - h_self_x_e_other) * d_area
+            else:
+                integrand = e_self_x_h_other * d_area
 
         # Integrate over plane
-        return ModeAmpsDataArray(0.25 * integrand.sum(dim=d_area.dims))
+        coefficient = 0.25 if use_symmetric_form else 0.5
+        return ModeAmpsDataArray(coefficient * integrand.sum(dim=d_area.dims))
 
     def _tangential_fields_match_coords(self, coords: ArrayFloat2D) -> bool:
         """Check if the tangential fields already match given coords in the tangential plane."""
@@ -954,7 +990,10 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
         return fields
 
     def outer_dot(
-        self, field_data: Union[FieldData, ModeData], conjugate: bool = True
+        self,
+        field_data: Union[FieldData, ModeData],
+        conjugate: bool = True,
+        use_symmetric_form: bool = True,
     ) -> MixedModeDataArray:
         r"""Dot product (modal overlap) with another :class:`.FieldData` object.
 
@@ -966,9 +1005,17 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
 
         The dot product is defined as:
 
-        .. math:
+        .. math::
 
            \frac{1}{4} \int \left( E_0 \times H_1^* + H_0^* \times E_1 \) \, {\rm d}S
+
+        when ``use_symmetric_form=True``, or as:
+
+        .. math::
+
+           \frac{1}{2} \int E_0 \times H_1^* \, {\rm d}S
+
+        when ``use_symmetric_form=False``.
 
         Parameters
         ----------
@@ -977,6 +1024,9 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
         conjugate : bool = True
             If ``True`` (default), the dot product is defined as above. If ``False``, the definition
             is similar, but without the complex conjugation of the $H$ fields.
+        use_symmetric_form : bool, optional
+            If ``True`` (default), uses the symmetric form: 1/4 ∫ (E_0 × H_1* + H_0* × E_1) dS.
+            If ``False``, uses the asymmetric form: 1/2 ∫ (E_0 × H_1*) dS.
 
         Returns
         -------
@@ -995,12 +1045,18 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
 
         # Tangential fields for current
         fields_self = self._colocated_tangential_fields
-        if conjugate:
-            fields_self = {component: field.conj() for component, field in fields_self.items()}
 
         # Tangential fields for other data
-
         fields_other = field_data._interpolated_tangential_fields(self._plane_grid_boundaries)
+
+        # Apply conjugation based on the form and conjugate flag
+        # For symmetric form: conjugate fields_self to get (E₀* × H₁) - (H₀* × E₁)
+        # For asymmetric form: conjugate fields_other to get E₀ × H₁*
+        if conjugate:
+            if use_symmetric_form:
+                fields_self = {key: field.conj() for key, field in fields_self.items()}
+            else:
+                fields_other = {key: field.conj() for key, field in fields_other.items()}
 
         # Tangential field component names
         dim1, dim2 = tan_dims
@@ -1058,9 +1114,12 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
 
             # Cross products of fields
             e_self_x_h_other = e_self_1 * h_other_2 - e_self_2 * h_other_1
-            h_self_x_e_other = h_self_1 * e_other_2 - h_self_2 * e_other_1
 
-            summand = 0.25 * (e_self_x_h_other - h_self_x_e_other) * d_area
+            if use_symmetric_form:
+                h_self_x_e_other = h_self_1 * e_other_2 - h_self_2 * e_other_1
+                summand = 0.25 * (e_self_x_h_other - h_self_x_e_other) * d_area
+            else:
+                summand = 0.5 * e_self_x_h_other * d_area
             return summand
 
         result = self._outer_fn_summation(

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -161,7 +161,12 @@ def merging_geometries_on_plane(
                 if not unionized.is_empty:
                     merged_parts.append(unionized)
             if zero_area:
-                unionized = linemerge(shapely.union_all(zero_area)).normalize()
+                merged = shapely.union_all(zero_area)
+                unionized = (
+                    linemerge(merged).normalize()
+                    if merged.geom_type == "MultiLineString"
+                    else merged.normalize()
+                )
                 if not unionized.is_empty:
                     merged_parts.append(unionized)
             if len(merged_parts) == 1:

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -16,6 +16,7 @@ from shapely.geometry import (
 from shapely.geometry.base import (
     BaseMultipartGeometry,
 )
+from shapely.ops import linemerge
 
 from tidy3d.components.autograd.utils import get_static
 from tidy3d.components.base import Tidy3dBaseModel
@@ -147,12 +148,27 @@ def merging_geometries_on_plane(
         shapes_by_prop = defaultdict(list)
         for prop, shape, _ in shapes:
             shapes_by_prop[prop].append(shape)
-        # union shapes of same property
+        # union shapes of same property, handling zero-area geometries (LineStrings, Points)
+        # separately since .buffer(0) collapses them to empty
+        _zero_area_types = ("LineString", "MultiLineString", "Point", "MultiPoint")
         results = []
-        for prop, shapes in shapes_by_prop.items():
-            unionized = shapely.union_all(shapes).buffer(0).normalize()
-            if not unionized.is_empty:
-                results.append((prop, unionized))
+        for prop, prop_shapes in shapes_by_prop.items():
+            polys = [s for s in prop_shapes if s.geom_type not in _zero_area_types]
+            zero_area = [s for s in prop_shapes if s.geom_type in _zero_area_types]
+            merged_parts = []
+            if polys:
+                unionized = shapely.union_all(polys).buffer(0).normalize()
+                if not unionized.is_empty:
+                    merged_parts.append(unionized)
+            if zero_area:
+                unionized = linemerge(shapely.union_all(zero_area)).normalize()
+                if not unionized.is_empty:
+                    merged_parts.append(unionized)
+            if len(merged_parts) == 1:
+                results.append((prop, merged_parts[0]))
+            elif len(merged_parts) > 1:
+                combined = shapely.GeometryCollection(merged_parts).normalize()
+                results.append((prop, combined))
         return results
 
     background_shapes = []

--- a/tidy3d/components/grid/corner_finder.py
+++ b/tidy3d/components/grid/corner_finder.py
@@ -111,7 +111,7 @@ class CornerFinderSpec(Tidy3dBaseModel):
         size : tuple[float, float, float] = [inf, inf, inf]
             Size of the 2D plane (size along ``axis`` is ignored)
         interior_disjoint_geometries: bool = False
-            If ``True``, geometries on the plane must not be overlapping.
+            If ``True``, geometries of different properties on the plane must be interior disjoint.
         keep_metal_only: bool = False
             If ``True``, drop all other structures that are not made of metal.
         Returns

--- a/tidy3d/components/microwave/data/dataset.py
+++ b/tidy3d/components/microwave/data/dataset.py
@@ -2,17 +2,48 @@
 
 from __future__ import annotations
 
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+import xarray as xr
 from pydantic import Field
 
+from tidy3d.components.base import cached_property
 from tidy3d.components.data.data_array import (
     CurrentFreqModeDataArray,
+    CurrentFreqTerminalModeDataArray,
     ImpedanceFreqModeDataArray,
+    ImpedanceFreqModeModeDataArray,
+    ImpedanceFreqTerminalTerminalDataArray,
+    ScalarTerminalFieldDataArray,
     VoltageFreqModeDataArray,
+    VoltageFreqTerminalModeDataArray,
 )
-from tidy3d.components.data.dataset import ModeFreqDataset
+from tidy3d.components.data.dataset import (
+    ElectromagneticFieldDataset,
+    FreqDataset,
+    ModeFreqDataset,
+)
+
+if TYPE_CHECKING:
+    from typing import Union
+
+    from tidy3d.components.data.data_array import VoltageFreqModeTerminalDataArray
 
 
-class TransmissionLineDataset(ModeFreqDataset):
+class AbstractTransmissionLineDataset(ModeFreqDataset):
+    """Base class for transmission line datasets."""
+
+    @property
+    @abstractmethod
+    def Z0_matrix(
+        self,
+    ) -> Union[ImpedanceFreqModeModeDataArray, ImpedanceFreqTerminalTerminalDataArray]:
+        """The characteristic impedance matrix."""
+
+
+class TransmissionLineDataset(AbstractTransmissionLineDataset):
     """Holds mode data that is specific to transmission lines in microwave and RF applications,
     like characteristic impedance.
 
@@ -40,4 +71,132 @@ class TransmissionLineDataset(ModeFreqDataset):
         description="Quantity calculated for transmission lines, which associates "
         "a current-like quantity with each mode profile that scales linearly with the "
         "complex-valued mode amplitude.",
+    )
+
+    @cached_property
+    def Z0_matrix(self) -> ImpedanceFreqModeModeDataArray:
+        """The characteristic impedance matrix (diagonal matrix here)."""
+        # Convert to full matrix with dimensions (f, mode_index_out, mode_index_in)
+        mode_indices = self.Z0.coords["mode_index"].values
+        num_modes = len(mode_indices)
+
+        # Create identity matrix as xarray DataArray
+        eye = xr.DataArray(
+            np.eye(num_modes),
+            coords={"mode_index_out": mode_indices, "mode_index_in": mode_indices},
+        )
+
+        # Rename dimension and multiply - xarray broadcasts correctly
+        # Z0[f, mode_index_out] * eye[mode_index_out, mode_index_in] -> Z0_diag[f, mode_index_out, mode_index_in]
+        Z0_diag = self.Z0.rename({"mode_index": "mode_index_out"}) * eye
+
+        return ImpedanceFreqModeModeDataArray(Z0_diag)
+
+
+class TransmissionLineTerminalDataset(AbstractTransmissionLineDataset):
+    """Holds terminal data that is specific to transmission lines in microwave and RF applications,
+    like characteristic impedance, and voltage and current mode to terminal transformation matrices.
+
+    Notes
+    -----
+        The data in this class is only calculated when a :class:`MicrowaveTerminalModeSpec`
+        is provided to the :class:`ModeMonitor`, :class:`ModeSolverMonitor`, :class:`ModeSolver`,
+        or :class:`ModeSimulation`.
+    """
+
+    Z0: ImpedanceFreqTerminalTerminalDataArray = Field(
+        ...,
+        title="Terminal Characteristic Impedance Matrix",
+        description="The terminal characteristic impedance matrix of the transmission line.",
+    )
+
+    voltage_transform: VoltageFreqTerminalModeDataArray = Field(
+        ...,
+        title="Voltage Transformation Matrix",
+        description="The voltage transformation matrix from modes to terminals.",
+    )
+
+    current_transform: CurrentFreqTerminalModeDataArray = Field(
+        ...,
+        title="Current Transformation Matrix",
+        description="The current transformation matrix from modes to terminals.",
+    )
+
+    @cached_property
+    def Z0_matrix(self) -> ImpedanceFreqTerminalTerminalDataArray:
+        """The characteristic impedance matrix (diagonal matrix here)."""
+        return self.Z0
+
+    @cached_property
+    def voltage_transform_inv(self) -> VoltageFreqModeTerminalDataArray:
+        """Inverse of the voltage transformation matrix.
+
+        Returns
+        -------
+        VoltageFreqModeTerminalDataArray
+            Inverse of the voltage transform matrix that maps terminals to modes.
+        """
+        return xr.apply_ufunc(
+            np.linalg.inv,
+            self.voltage_transform,
+            input_core_dims=[["terminal_label", "mode_index"]],
+            output_core_dims=[["mode_index", "terminal_label"]],
+            vectorize=True,
+        )
+
+
+class TerminalFieldDataset(ElectromagneticFieldDataset, FreqDataset):
+    """Dataset storing scalar components of E and H fields as a function of freq. and terminal_label.
+
+    This dataset is similar to ModeSolverDataset but uses terminal_label instead of mode_index.
+    Inherits from FreqDataset to support frequency interpolation via _interp_in_freq_update_dict.
+
+    Example
+    -------
+    >>> x = [-1,1]
+    >>> y = [0]
+    >>> z = [-3,-1,1,3]
+    >>> f = [2e14, 3e14]
+    >>> terminal_label = ["t0", "t1", "t2"]
+    >>> field_coords = dict(x=x, y=y, z=z, f=f, terminal_label=terminal_label)
+    >>> field = ScalarTerminalFieldDataArray((1+1j)*np.random.random((2,1,4,2,3)), coords=field_coords)
+    >>> data = TerminalFieldDataset(
+    ...     Ex=field,
+    ...     Ey=field,
+    ...     Ez=field,
+    ...     Hx=field,
+    ...     Hy=field,
+    ...     Hz=field,
+    ... )
+    """
+
+    Ex: Optional[ScalarTerminalFieldDataArray] = Field(
+        None,
+        title="Ex",
+        description="Spatial distribution of the x-component of the electric field for each terminal.",
+    )
+    Ey: Optional[ScalarTerminalFieldDataArray] = Field(
+        None,
+        title="Ey",
+        description="Spatial distribution of the y-component of the electric field for each terminal.",
+    )
+    Ez: Optional[ScalarTerminalFieldDataArray] = Field(
+        None,
+        title="Ez",
+        description="Spatial distribution of the z-component of the electric field for each terminal.",
+    )
+    Hx: Optional[ScalarTerminalFieldDataArray] = Field(
+        None,
+        title="Hx",
+        description="Spatial distribution of the x-component of the magnetic field for each terminal.",
+    )
+    Hy: Optional[ScalarTerminalFieldDataArray] = Field(
+        None,
+        title="Hy",
+        description="Spatial distribution of the y-component of the magnetic field for each terminal.",
+    )
+    Hz: Optional[ScalarTerminalFieldDataArray] = Field(
+        None,
+        title="Hz",
+        description="Spatial distribution of the z-component of the magnetic field for each terminal.",
     )

--- a/tidy3d/components/microwave/data/monitor_data.py
+++ b/tidy3d/components/microwave/data/monitor_data.py
@@ -7,12 +7,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np
+import xarray as xr
 from pydantic import Field
 
+from tidy3d.components.base import cached_property
 from tidy3d.components.data.data_array import (
     FreqDataArray,
     FreqModeDataArray,
     ImpedanceFreqModeDataArray,
+    ScalarTerminalFieldDataArray,
 )
 from tidy3d.components.data.monitor_data import DirectivityData, ModeData, ModeSolverData
 from tidy3d.components.microwave.base import MicrowaveBaseModel
@@ -21,7 +24,11 @@ from tidy3d.components.microwave.data.data_array import (
     PhaseVelocityArray,
     PropagationConstantArray,
 )
-from tidy3d.components.microwave.data.dataset import TransmissionLineDataset
+from tidy3d.components.microwave.data.dataset import (
+    TerminalFieldDataset,
+    TransmissionLineDataset,
+    TransmissionLineTerminalDataset,
+)
 from tidy3d.components.microwave.monitor import MicrowaveModeMonitor, MicrowaveModeSolverMonitor
 from tidy3d.constants import C_0
 from tidy3d.log import log
@@ -29,7 +36,6 @@ from tidy3d.log import log
 if TYPE_CHECKING:
     from typing import Literal
 
-    import xarray as xr
     from numpy.typing import NDArray
     from typing_extensions import Self
 
@@ -253,6 +259,40 @@ class MicrowaveModeDataBase(MicrowaveBaseModel):
         "been used to set up the monitor or mode solver.",
     )
 
+    transmission_line_terminal_data: Optional[TransmissionLineTerminalDataset] = Field(
+        None,
+        title="Transmission Line Terminal Data",
+        description="Additional data relevant to transmission line terminals in RF and microwave applications, "
+        "like characteristic impedance, voltage transformation matrix, and current transformation matrix. "
+        "This field is populated when a :class:`MicrowaveTerminalModeSpec` has "
+        "been used to set up the monitor or mode solver.",
+    )
+
+    @cached_property
+    def terminal_fields(self) -> Optional[TerminalFieldDataset]:
+        """Field data for each terminal.
+
+        Returns
+        -------
+        Optional[TerminalFieldDataset]
+            Dataset containing Ex, Ey, Ez, Hx, Hy, Hz field components indexed by terminal_label,
+            or None if transmission_line_terminal_data is not set.
+        """
+        if self.transmission_line_terminal_data is None:
+            return None
+
+        # Transform each field component: field_terminal = voltage_transform^-1 @ field_mode
+        # Use the cached inverse of the voltage transform matrix
+        voltage_transform_inv = self.transmission_line_terminal_data.voltage_transform_inv
+        field_dict = {}
+        for field_name, mode_field in self.field_components.items():
+            if mode_field is not None:
+                # Use xarray.dot for the matrix multiplication over mode_index
+                terminal_field = xr.dot(voltage_transform_inv, mode_field, dims="mode_index")
+                field_dict[field_name] = ScalarTerminalFieldDataArray(terminal_field)
+
+        return TerminalFieldDataset(**field_dict)
+
     @property
     def modes_info(self) -> xr.Dataset:
         """Dataset collecting various properties of the stored modes."""
@@ -446,6 +486,22 @@ class MicrowaveModeDataBase(MicrowaveBaseModel):
                 "current_coeffs": self.transmission_line_data.current_coeffs.isel(f=center_inds),
             }
             super_data = super_data.updated_copy(**update_dict, path="transmission_line_data")
+
+        # Add transmission line terminal data handling if present
+        if self.transmission_line_terminal_data is not None:
+            _, center_inds, _ = self._group_index_freq_slices()
+            update_dict = {
+                "Z0": self.transmission_line_terminal_data.Z0.isel(f=center_inds),
+                "voltage_transform": self.transmission_line_terminal_data.voltage_transform.isel(
+                    f=center_inds
+                ),
+                "current_transform": self.transmission_line_terminal_data.current_transform.isel(
+                    f=center_inds
+                ),
+            }
+            super_data = super_data.updated_copy(
+                **update_dict, path="transmission_line_terminal_data"
+            )
         return super_data
 
     def _apply_mode_reorder(self, sort_inds_2d: NDArray) -> Self:
@@ -466,6 +522,15 @@ class MicrowaveModeDataBase(MicrowaveBaseModel):
             )
             main_data_reordered = main_data_reordered.updated_copy(
                 transmission_line_data=transmission_line_data_reordered
+            )
+
+        # Add transmission line terminal data handling if present
+        if self.transmission_line_terminal_data is not None:
+            transmission_line_terminal_data_reordered = (
+                self.transmission_line_terminal_data._apply_mode_reorder(sort_inds_2d)
+            )
+            main_data_reordered = main_data_reordered.updated_copy(
+                transmission_line_terminal_data=transmission_line_terminal_data_reordered
             )
         return main_data_reordered
 
@@ -685,5 +750,13 @@ class MicrowaveModeSolverData(MicrowaveModeDataBase, ModeSolverData):
             transmission_line_data_interp = self.transmission_line_data.updated_copy(**update_dict)
             main_data_interp = main_data_interp.updated_copy(
                 transmission_line_data=transmission_line_data_interp
+            )
+        if self.transmission_line_terminal_data is not None:
+            update_dict = self.transmission_line_terminal_data._interp_in_freq_update_dict(
+                freqs, method, assume_sorted
+            )
+            terminal_data_interp = self.transmission_line_terminal_data.updated_copy(**update_dict)
+            main_data_interp = main_data_interp.updated_copy(
+                transmission_line_terminal_data=terminal_data_interp
             )
         return main_data_interp

--- a/tidy3d/components/microwave/impedance_calculator.py
+++ b/tidy3d/components/microwave/impedance_calculator.py
@@ -82,6 +82,31 @@ class ImpedanceCalculator(MicrowaveBaseModel):
         description="Definition of contour integral for computing current.",
     )
 
+    def compute_voltage_current(
+        self, em_field: IntegrableMonitorDataType
+    ) -> tuple[VoltageIntegralResultType, CurrentIntegralResultType]:
+        """Compute voltage and current for the supplied ``em_field`` using ``voltage_integral`` and
+        ``current_integral``. None is returned for the integral that is not defined.
+
+        Parameters
+        ----------
+        em_field : :class:`.IntegrableMonitorDataType`
+            The electromagnetic field data that will be used for computing the voltage and current.
+
+        Returns
+        -------
+        tuple[VoltageIntegralResultType, CurrentIntegralResultType]
+            Tuple of (voltage, current). None is returned for the integral that is not defined.
+        """
+        AxisAlignedPathIntegral._check_monitor_data_supported(em_field=em_field)
+        voltage = None
+        current = None
+        if self.voltage_integral is not None:
+            voltage = self.voltage_integral.compute_voltage(em_field)
+        if self.current_integral is not None:
+            current = self.current_integral.compute_current(em_field)
+        return (voltage, current)
+
     def compute_impedance(
         self,
         em_field: IntegrableMonitorDataType,
@@ -111,15 +136,7 @@ class ImpedanceCalculator(MicrowaveBaseModel):
             tuple of (impedance, voltage, current).
         """
 
-        AxisAlignedPathIntegral._check_monitor_data_supported(em_field=em_field)
-
-        voltage = None
-        current = None
-        # If both voltage and current integrals have been defined then impedance is computed directly
-        if self.voltage_integral is not None:
-            voltage = self.voltage_integral.compute_voltage(em_field)
-        if self.current_integral is not None:
-            current = self.current_integral.compute_current(em_field)
+        voltage, current = self.compute_voltage_current(em_field)
 
         # If only one of the integrals has been provided, then the computation falls back to using
         # total power (flux) with Ohm's law to compute the missing quantity. The input field should

--- a/tidy3d/components/microwave/mode_spec.py
+++ b/tidy3d/components/microwave/mode_spec.py
@@ -2,32 +2,32 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
-import numpy as np
-from pydantic import Field, model_validator
+from pydantic import Field, PositiveInt, model_validator
 
 from tidy3d.components.base import cached_property
-from tidy3d.components.geometry.bound_ops import bounds_contains
 from tidy3d.components.microwave.base import MicrowaveBaseModel
 from tidy3d.components.microwave.path_integrals.mode_plane_analyzer import ModePlaneAnalyzer
 from tidy3d.components.microwave.path_integrals.specs.impedance import (
     AutoImpedanceSpec,
+    CustomImpedanceSpec,
     ImpedanceSpecType,
 )
 from tidy3d.components.mode_spec import AbstractModeSpec
-from tidy3d.constants import fp_eps
 from tidy3d.exceptions import SetupError
 
 if TYPE_CHECKING:
     from tidy3d.compat import Self
     from tidy3d.components.geometry.base import Box
     from tidy3d.components.grid.grid import Grid
+    from tidy3d.components.microwave.types import ImpedanceDef
     from tidy3d.components.structure import Structure
     from tidy3d.components.types import Coordinate, Size, Symmetry
 
 TEM_POLARIZATION_THRESHOLD = 0.995
 QTEM_POLARIZATION_THRESHOLD = 0.95
+MONITOR_COLOCATE = False
 
 
 class MicrowaveModeSpec(AbstractModeSpec, MicrowaveBaseModel):
@@ -61,7 +61,21 @@ class MicrowaveModeSpec(AbstractModeSpec, MicrowaveBaseModel):
     ...     num_modes=1,
     ...     impedance_specs=custom_impedance
     ... )
+    >>> # Using num_modes='auto' with a tuple of specs
+    >>> mode_spec_auto_tuple = td.MicrowaveModeSpec(
+    ...     num_modes="auto",
+    ...     impedance_specs=(custom_impedance, custom_impedance)
+    ... )
     """
+
+    num_modes: Union[PositiveInt, Literal["auto"]] = Field(
+        1,
+        title="Number of modes",
+        description="Number of modes returned by mode solver. "
+        "Use 'auto' to infer from impedance_specs length (if tuple) or detected "
+        "from the number of isolated conductors "
+        "assuming quasi-TEM modes (if AutoImpedanceSpec).",
+    )
 
     impedance_specs: Union[
         ImpedanceSpecType,
@@ -114,23 +128,36 @@ class MicrowaveModeSpec(AbstractModeSpec, MicrowaveBaseModel):
 
     @model_validator(mode="after")
     def check_impedance_specs_consistent_with_num_modes(self) -> Self:
-        """Check that the number of impedance specifications is equal to the number of modes.
-        A single impedance spec is also permitted."""
+        """Check impedance specs consistency with num_modes.
+
+        Validates that:
+        1. num_modes='auto' with tuple
+        2. num_modes='auto' with single spec: must be AutoImpedanceSpec
+        3. num_modes=int with tuple: length must match
+        4. num_modes=int with single spec: allowed (applied to all modes)
+        """
         val = self.impedance_specs
         num_modes = self.num_modes
-        if isinstance(val, (tuple, list)):
-            num_impedance_specs = len(val)
-        else:
+
+        if num_modes == "auto":
+            if not isinstance(val, (tuple, list)):
+                if not isinstance(val, AutoImpedanceSpec):
+                    raise SetupError(
+                        "num_modes='auto' with a single non-AutoImpedanceSpec cannot determine "
+                        "the number of modes. Provide a tuple of specs, "
+                        "or use AutoImpedanceSpec for automatic conductor detection."
+                    )
             return self
 
-        # Otherwise, check that the count matches
-        if num_impedance_specs != num_modes:
-            raise SetupError(
-                f"Given {num_impedance_specs} impedance specifications in the 'MicrowaveModeSpec', "
-                f"but the number of modes requested is {num_modes}. Please ensure that the "
-                "number of impedance specifications is equal to the number of modes, or provide "
-                "a single specification to apply to all modes."
-            )
+        # For explicit num_modes, check tuple length matches
+        if isinstance(val, (tuple, list)):
+            if len(val) != num_modes:
+                raise SetupError(
+                    f"Given {len(val)} impedance specifications in the 'MicrowaveModeSpec', "
+                    f"but the number of modes requested is {num_modes}. Please ensure that the "
+                    "number of impedance specifications is equal to the number of modes, or provide "
+                    "a single specification to apply to all modes."
+                )
 
         return self
 
@@ -139,41 +166,18 @@ class MicrowaveModeSpec(AbstractModeSpec, MicrowaveBaseModel):
         defined outside a candidate box.
         """
         for impedance_ind, impedance_spec in enumerate(self._impedance_specs_as_tuple):
-            if isinstance(impedance_spec, AutoImpedanceSpec) or impedance_spec is None:
+            if impedance_spec is None:
                 continue
 
-            # Check both voltage and current specs using the same logic
-            specs_to_check = [
-                (impedance_spec.voltage_spec, "voltage"),
-                (impedance_spec.current_spec, "current"),
-            ]
-
-            for spec, spec_type in specs_to_check:
-                if spec is None:
-                    continue
-
-                box_bounds = box.bounds
-                # If the box is a plane (one dimension is zero), we need to ignore
-                # the bounds check along the normal axis
-                if box.size.count(0.0) == 1:
-                    normal_axis = box._normal_axis
-                    # Convert tuple to list so we can modify it
-                    box_bounds = [list(box_bounds[0]), list(box_bounds[1])]
-                    # Set the bounds along normal axis to match the spec bounds
-                    box_bounds[0][normal_axis] = spec.bounds[0][normal_axis]
-                    box_bounds[1][normal_axis] = spec.bounds[1][normal_axis]
-                    # Convert back to tuple for bounds_contains
-                    box_bounds = (tuple(box_bounds[0]), tuple(box_bounds[1]))
-
-                if not bounds_contains(
-                    box_bounds, spec.bounds, fp_eps, np.finfo(np.float32).smallest_normal
-                ):
-                    raise SetupError(
-                        "A 'MicrowaveModeSpec' must be setup with all path specifications defined within "
-                        f"the bounds of the mode solving plane. The 'CustomImpedanceSpec' at index "
-                        f"'{impedance_ind}' was provided with a {spec_type} path specification with bounds "
-                        f"'{spec.bounds}', but the mode plane bounds are '{box.bounds}'."
-                    )
+            # Use the impedance spec's own validation method and add context if it fails
+            try:
+                impedance_spec._check_path_integrals_within_box(box)
+            except SetupError as e:
+                raise SetupError(
+                    f"A 'MicrowaveModeSpec' must be setup with all path specifications defined within "
+                    f"the bounds of the mode solving plane. The impedance specification at index "
+                    f"'{impedance_ind}' failed validation: {e}"
+                ) from e
 
     def _validate_auto_impedance_setup(
         self,
@@ -185,8 +189,32 @@ class MicrowaveModeSpec(AbstractModeSpec, MicrowaveBaseModel):
         symmetry: tuple[Symmetry, Symmetry, Symmetry],
         simulation_geometry: Box,
         label: str = "",
+        interior_disjoint_geometries: bool = True,
     ) -> None:
-        """Validate that auto impedance specification can be set up for the given mode plane."""
+        """Validate that auto impedance specification can be set up for the given mode plane.
+
+        Parameters
+        ----------
+        center : Coordinate
+            Center of the mode plane.
+        size : Size
+            Size of the mode plane.
+        colocate : bool
+            Whether field data is colocated.
+        volumetric_structures : list[Structure]
+            List of volumetric structures in the simulation.
+        grid : Grid
+            Simulation grid for snapping paths.
+        symmetry : tuple[Symmetry, Symmetry, Symmetry]
+            Symmetry conditions for the simulation in (x, y, z) directions.
+        simulation_geometry : Box
+            Simulation domain box used for boundary conditions.
+        label : str = ""
+            Optional label for error messages.
+        interior_disjoint_geometries : bool = True
+            If ``True``, conductors on the plane will not be overridden by other materials,
+            allowing a faster merging path that skips overlap removal.
+        """
         if not self._using_auto_current_spec:
             return
         mode_plane_analyzer = ModePlaneAnalyzer(
@@ -200,6 +228,117 @@ class MicrowaveModeSpec(AbstractModeSpec, MicrowaveBaseModel):
                 grid,
                 symmetry,
                 simulation_geometry,
+                interior_disjoint_geometries=interior_disjoint_geometries,
             )
         except SetupError as e:
             raise SetupError(f"Failed to setup auto impedance specification{label}. {e!s}") from e
+
+
+class MicrowaveTerminalModeSpec(MicrowaveModeSpec):
+    """The :class:`.MicrowaveTerminalModeSpec` class specifies how quantities related to transmission line
+    terminals are computed. All specs must be specified explicitly here: num_modes must be an integer; and impedance_specs
+    must not contain AutoImpedanceSpec, and must be labeled by terminal names. Terminal mapping needs to be
+    provided in the presence of differential pairs.
+
+    Note
+    -----
+    This class is for internal usage only.
+
+    Example
+    -------
+    >>> import tidy3d as td
+    >>> # Using custom impedance specification for multiple terminals
+    >>> current_spec = td.AxisAlignedCurrentIntegralSpec(
+    ...     center=(0, 0, 0), size=(2, 1, 0), sign="+"
+    ... )
+    >>> custom_impedance = td.CustomImpedanceSpec(
+    ...     current_spec=current_spec
+    ... )
+    >>> terminal_mode_spec_custom = td.MicrowaveTerminalModeSpec(
+    ...     num_modes=1,
+    ...     labeled_impedance_specs={"T0": custom_impedance},
+    ... )
+    """
+
+    num_modes: PositiveInt = Field(
+        ...,
+        title="Number of modes",
+        description="Number of modes (terminals) returned by mode solver.",
+    )
+
+    impedance_specs: dict[str, CustomImpedanceSpec] = Field(
+        ...,
+        title="Impedance Specification For Each Singled-ended Terminal",
+        description="Field controls how the voltage, current, and impedance are calculated for each "
+        "singled-ended terminal. "
+        "The size of the dictionary should match the number of modes field. ",
+    )
+
+    terminals_mapping: Optional[dict[str, Union[str, tuple[str, str]]]] = Field(
+        None,
+        title="Terminals Mapping",
+        description="Mapping from terminal (including differential pairs) labels to single-ended terminal labels.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_terminal_mode_spec(self) -> Self:
+        """Validate impedance definitions consistency, num_modes match, and terminals mapping."""
+        # Validate consistent impedance definitions
+        val = self.impedance_specs
+        if len(val) > 0:
+            specs = list(val.values())
+            first_definition = specs[0].impedance_definition
+            for impedance_spec in specs[1:]:
+                if impedance_spec.impedance_definition != first_definition:
+                    raise SetupError("Inconsistent impedance definitions across terminals.")
+
+        # Check impedance specs consistent with num_modes
+        if len(val) != self.num_modes:
+            raise SetupError(
+                f"Given {len(val)} impedance specifications in the 'MicrowaveTerminalModeSpec', "
+                f"but the number of modes requested is {self.num_modes}. Please ensure that the "
+                "number of impedance specifications is equal to the number of modes."
+            )
+
+        # Check terminals mapping consistency with impedance specs
+        terminals_mapping = self.terminals_mapping
+        if terminals_mapping is not None:
+            if len(terminals_mapping) != len(val):
+                raise SetupError(
+                    f"Given {len(terminals_mapping)} terminals mapping in the 'MicrowaveTerminalModeSpec', "
+                    f"but the number of impedance specifications is {len(val)}. Please ensure that the "
+                    "number of terminals mapping is equal to the number of impedance specifications."
+                )
+
+            for terminal_label in terminals_mapping.values():
+                # Handle both single terminal (str) and differential pair (tuple[str, str])
+                labels_to_check = (
+                    (terminal_label,) if isinstance(terminal_label, str) else terminal_label
+                )
+                for label in labels_to_check:
+                    if label not in val.keys():
+                        raise SetupError(
+                            f"Terminal label '{label}' is not present in the impedance specifications."
+                        )
+
+        return self
+
+    @cached_property
+    def impedance_definition(self) -> ImpedanceDef:
+        """Impedance definition (consistent across all terminals)."""
+        return next(iter(self.impedance_specs.values())).impedance_definition
+
+    @cached_property
+    def _terminal_indices(self) -> list[str]:
+        """List of terminal indices."""
+        if self.terminals_mapping is None:
+            return list(self.impedance_specs.keys())
+        return list(self.terminals_mapping.keys())
+
+    @cached_property
+    def _impedance_specs_as_tuple(self) -> tuple[Optional[ImpedanceSpecType], ...]:
+        """Gets the impedance_specs field converted to a tuple."""
+        return tuple(self.impedance_specs.values())
+
+
+MicrowaveModeSpecType = Union[MicrowaveModeSpec, MicrowaveTerminalModeSpec]

--- a/tidy3d/components/microwave/monitor.py
+++ b/tidy3d/components/microwave/monitor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pydantic import Field
 
 from tidy3d.components.microwave.base import MicrowaveBaseModel
-from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
+from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec, MicrowaveModeSpecType
 from tidy3d.components.monitor import ModeMonitor, ModeSolverMonitor
 
 
@@ -22,7 +22,7 @@ class MicrowaveModeMonitorBase(MicrowaveBaseModel):
     precedence over the base :class:`.ModeSpec` field from :class:`.AbstractModeMonitor`.
     """
 
-    mode_spec: MicrowaveModeSpec = Field(
+    mode_spec: MicrowaveModeSpecType = Field(
         default_factory=MicrowaveModeSpec._default_without_license_warning,
         title="Mode Specification",
         description="Parameters to feed to mode solver which determine modes measured by monitor.",

--- a/tidy3d/components/microwave/path_integrals/factory.py
+++ b/tidy3d/components/microwave/path_integrals/factory.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
         CurrentIntegralType,
         VoltageIntegralType,
     )
-    from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
+    from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec, MicrowaveTerminalModeSpec
     from tidy3d.components.microwave.path_integrals.specs.impedance import CustomImpedanceSpec
     from tidy3d.components.microwave.path_integrals.types import (
         CurrentPathSpecType,
@@ -153,3 +153,55 @@ def make_path_integrals(
                 "Please create a github issue so that the problem can be investigated."
             ) from e
     return (tuple(v_integrals), tuple(i_integrals))
+
+
+def make_path_integrals_for_terminal(
+    microwave_terminal_mode_spec: MicrowaveTerminalModeSpec,
+) -> dict[str, tuple[Optional[VoltageIntegralType], Optional[CurrentIntegralType]]]:
+    """
+    Given a microwave terminal mode specification, create the voltage and
+    current path integrals for each terminal.
+
+    Parameters
+    ----------
+    microwave_terminal_mode_spec : MicrowaveTerminalModeSpec
+        Microwave terminal mode specification containing impedance specs as a dict
+        mapping terminal labels to CustomImpedanceSpec instances.
+
+    Returns
+    -------
+    dict[str, tuple[Optional[VoltageIntegralType], Optional[CurrentIntegralType]]]
+        Dictionary mapping terminal labels to tuples of (voltage_integral, current_integral).
+
+    Raises
+    ------
+    SetupError
+        If path integrals cannot be constructed from the impedance specifications.
+    """
+
+    integrals_dict = {}
+
+    # impedance_specs is a dict mapping terminal labels to CustomImpedanceSpec
+    impedance_specs = microwave_terminal_mode_spec.impedance_specs
+
+    for terminal_label, impedance_spec in impedance_specs.items():
+        # Get voltage and current specs from CustomImpedanceSpec
+        v_spec = impedance_spec.voltage_spec
+        i_spec = impedance_spec.current_spec
+
+        try:
+            v_integral = None
+            i_integral = None
+            if v_spec is not None:
+                v_integral = make_voltage_integral(v_spec)
+            if i_spec is not None:
+                i_integral = make_current_integral(i_spec)
+            integrals_dict[terminal_label] = (v_integral, i_integral)
+        except Exception as e:
+            raise SetupError(
+                f"Failed to construct path integrals for terminal '{terminal_label}' "
+                "from the impedance specification. "
+                "Please create a github issue so that the problem can be investigated."
+            ) from e
+
+    return integrals_dict

--- a/tidy3d/components/microwave/path_integrals/mode_plane_analyzer.py
+++ b/tidy3d/components/microwave/path_integrals/mode_plane_analyzer.py
@@ -20,6 +20,7 @@ from tidy3d.components.geometry.utils import (
     merging_geometries_on_plane,
     snap_box_to_grid,
 )
+from tidy3d.components.grid.corner_finder import N_SHAPELY_QUAD_SEGS, SHAPELY_CLEANUP
 from tidy3d.components.medium import LossyMetalMedium
 from tidy3d.components.validators import assert_plane
 from tidy3d.exceptions import SetupError
@@ -89,12 +90,40 @@ class ModePlaneAnalyzer(Box):
 
         return (tuple(min_b_2d_list), max_b)
 
+    @staticmethod
+    def _is_conductor(med: Medium) -> bool:
+        return med.is_pec or isinstance(med, LossyMetalMedium)
+
+    @staticmethod
+    def apply_interior_disjoint_geometries(structure_priority_mode: str) -> bool:
+        """Whether conductors on the mode plane will not be overridden by other materials.
+
+        When ``structure_priority_mode`` is ``"conductor"``, conductor structures
+        have the highest priority, so geometries of different properties are
+        guaranteed to be interior disjoint on the plane. This allows a faster
+        merging path that skips overlap removal.
+
+        Parameters
+        ----------
+        structure_priority_mode : str
+            The structure priority mode setting (e.g. ``"conductor"`` or ``"equal"``).
+
+        Returns
+        -------
+        bool
+            ``True`` when ``structure_priority_mode`` is ``"conductor"``.
+        """
+        return structure_priority_mode == "conductor"
+
     def _get_isolated_conductors_as_shapely(
         self,
         plane: Box,
         structures: list[Structure],
+        interior_disjoint_geometries: bool = True,
     ) -> list[Shapely]:
-        """Find and merge all conductor structures that intersect the given plane.
+        """Find and merge all conductor structures that intersect the given plane. The geometries
+        are ordered by their center coordinates from left to right, and bottom to top if their horizontal
+        axis is identical.
 
         Parameters
         ----------
@@ -102,6 +131,9 @@ class ModePlaneAnalyzer(Box):
             The plane to check for conductor intersections
         structures : list[Structure]
             List of all simulation structures to analyze
+        interior_disjoint_geometries: bool = True
+            If ``True``, conductors on the plane will not be overridden by other materials,
+            allowing a faster merging path that skips overlap removal.
 
         Returns
         -------
@@ -110,17 +142,20 @@ class ModePlaneAnalyzer(Box):
             that intersect with the given plane
         """
 
-        def is_conductor(med: Medium) -> bool:
-            return med.is_pec or isinstance(med, LossyMetalMedium)
-
         geometry_list = [structure.geometry for structure in structures]
-        # For metal, we don't distinguish between LossyMetal and PEC,
-        # so they'll be merged to PEC. Other materials are considered as dielectric.
-        prop_list = [is_conductor(structure.medium) for structure in structures]
+        prop_list = [self._is_conductor(structure.medium) for structure in structures]
         # merge geometries
-        geos = merging_geometries_on_plane(geometry_list, plane, prop_list)
+        geos = merging_geometries_on_plane(
+            geometry_list,
+            plane,
+            prop_list,
+            interior_disjoint_geometries=interior_disjoint_geometries,
+            cleanup=SHAPELY_CLEANUP,
+            quad_segs=N_SHAPELY_QUAD_SEGS,
+        )
         conductor_geos = [item[1] for item in geos if item[0]]
         shapely_list = flatten_shapely_geometries(conductor_geos, keep_types=(Polygon, LineString))
+        shapely_list = sorted(shapely_list, key=lambda x: (x.centroid.x, x.centroid.y))
         return shapely_list
 
     def _filter_conductors_touching_sim_bounds(
@@ -178,9 +213,10 @@ class ModePlaneAnalyzer(Box):
         grid: Grid,
         symmetry: tuple[Symmetry, Symmetry, Symmetry],
         sim_box: Box,
+        interior_disjoint_geometries: bool = True,
     ) -> tuple[list[Box], list[Shapely]]:
         """Returns bounding boxes that encompass each isolated conductor
-        in the mode plane.
+        in the mode plane, as well as the list of conductor shapely geometries.
 
         This method identifies isolated conductor geometries in the given plane.
         The paths are snapped to the simulation grid
@@ -196,6 +232,9 @@ class ModePlaneAnalyzer(Box):
             Symmetry conditions for the simulation in (x, y, z) directions.
         sim_box : Box
             Simulation domain box used for boundary conditions.
+        interior_disjoint_geometries : bool = True
+            If ``True``, conductors on the plane will not be overridden by other materials,
+            allowing a faster merging path that skips overlap removal.
 
         Returns
         -------
@@ -216,7 +255,9 @@ class ModePlaneAnalyzer(Box):
 
         intersection_plane = Box.from_bounds(min_b_3d, max_b_3d)
         isolated_conductor_shapely = self._get_isolated_conductors_as_shapely(
-            intersection_plane, structures
+            intersection_plane,
+            structures,
+            interior_disjoint_geometries=interior_disjoint_geometries,
         )
 
         filtered_conductor_shapely = self._filter_conductors_touching_sim_bounds(
@@ -265,7 +306,7 @@ class ModePlaneAnalyzer(Box):
                     "Failed to automatically generate path specification because a generated path "
                     "specification extends outside the mode solving plane bounds. This issue can be fixed "
                     "by enlarging the mode solving plane and ensuring that there is a buffer of at "
-                    "least 2 grid cells between the mode solving plane bounds and the nearest conductors."
+                    "least 2 grid cells between the mode solving plane bounds and the nearest conductors. "
                     "Alternatively, enforce a smaller grid around the conductors in the mode plane, "
                     "which may resolve the issue."
                 )

--- a/tidy3d/components/microwave/path_integrals/specs/current.py
+++ b/tidy3d/components/microwave/path_integrals/specs/current.py
@@ -160,6 +160,7 @@ class AxisAlignedCurrentIntegralSpec(AbstractAxesRH, Box):
         y: Optional[float] = None,
         z: Optional[float] = None,
         ax: Ax = None,
+        plot_arrow: bool = True,
         **path_kwargs: Any,
     ) -> Ax:
         """Plot path integral at single (x,y,z) coordinate.
@@ -174,6 +175,8 @@ class AxisAlignedCurrentIntegralSpec(AbstractAxesRH, Box):
             Position of plane in z direction, only one of x,y,z can be specified to define plane.
         ax : matplotlib.axes._subplots.Axes = None
             Matplotlib axes to plot on, if not specified, one is created.
+        plot_arrow : bool = True
+            Whether to plot the arrow indicating current direction. Default is ``True``.
         **path_kwargs
             Optional keyword arguments passed to the matplotlib plotting of the line.
             For details on accepted values, refer to
@@ -196,39 +199,40 @@ class AxisAlignedCurrentIntegralSpec(AbstractAxesRH, Box):
             (xs, ys) = path._vertices_2D(axis)
             ax.plot(xs, ys, **plot_kwargs)
 
-        (ax1, ax2) = self.remaining_axes
-
         # Add arrow to bottom path, unless right path is longer
-        arrow_path = path_integrals[0]
-        if self.size[ax2] > self.size[ax1]:
-            arrow_path = path_integrals[1]
+        if plot_arrow:
+            (ax1, ax2) = self.remaining_axes
 
-        (xs, ys) = arrow_path._vertices_2D(axis)
-        X = (xs[0] + xs[1]) / 2
-        Y = (ys[0] + ys[1]) / 2
-        center = np.array([X, Y])
-        dx = xs[1] - xs[0]
-        dy = ys[1] - ys[0]
-        direction = np.array([dx, dy])
-        segment_length = np.linalg.norm(direction)
-        unit_dir = direction / segment_length
+            arrow_path = path_integrals[0]
+            if self.size[ax2] > self.size[ax1]:
+                arrow_path = path_integrals[1]
 
-        # Change direction of arrow depending on sign of current definition
-        if self.sign == "-":
-            unit_dir *= -1.0
-        # Change direction of arrow when the "y" axis is dropped,
-        # since the plotted coordinate system will be left-handed (x, z)
-        if self.main_axis == 1:
-            unit_dir *= -1.0
+            (xs, ys) = arrow_path._vertices_2D(axis)
+            X = (xs[0] + xs[1]) / 2
+            Y = (ys[0] + ys[1]) / 2
+            center = np.array([X, Y])
+            dx = xs[1] - xs[0]
+            dy = ys[1] - ys[0]
+            direction = np.array([dx, dy])
+            segment_length = np.linalg.norm(direction)
+            unit_dir = direction / segment_length
 
-        start = center - unit_dir * segment_length
-        end = center
-        ax.annotate(
-            "",
-            xytext=(start[0], start[1]),
-            xy=(end[0], end[1]),
-            arrowprops=ARROW_CURRENT,
-        )
+            # Change direction of arrow depending on sign of current definition
+            if self.sign == "-":
+                unit_dir *= -1.0
+            # Change direction of arrow when the "y" axis is dropped,
+            # since the plotted coordinate system will be left-handed (x, z)
+            if self.main_axis == 1:
+                unit_dir *= -1.0
+
+            start = center - unit_dir * segment_length
+            end = center
+            ax.annotate(
+                "",
+                xytext=(start[0], start[1]),
+                xy=(end[0], end[1]),
+                arrowprops=ARROW_CURRENT,
+            )
         return ax
 
 
@@ -255,6 +259,7 @@ class Custom2DCurrentIntegralSpec(Custom2DPathIntegralSpec):
         y: Optional[float] = None,
         z: Optional[float] = None,
         ax: Ax = None,
+        plot_arrow: bool = True,
         **path_kwargs: Any,
     ) -> Ax:
         """Plot path integral at single (x,y,z) coordinate.
@@ -269,6 +274,8 @@ class Custom2DCurrentIntegralSpec(Custom2DPathIntegralSpec):
             Position of plane in z direction, only one of x,y,z can be specified to define plane.
         ax : matplotlib.axes._subplots.Axes = None
             Matplotlib axes to plot on, if not specified, one is created.
+        plot_arrow : bool = True
+            Whether to plot the arrow indicating current direction. Default is ``True``.
         **path_kwargs
             Optional keyword arguments passed to the matplotlib plotting of the line.
             For details on accepted values, refer to
@@ -290,12 +297,13 @@ class Custom2DCurrentIntegralSpec(Custom2DPathIntegralSpec):
         ax.plot(xs, ys, **plot_kwargs)
 
         # Add arrow at start of contour
-        ax.annotate(
-            "",
-            xytext=(xs[0], ys[0]),
-            xy=(xs[1], ys[1]),
-            arrowprops=ARROW_CURRENT,
-        )
+        if plot_arrow:
+            ax.annotate(
+                "",
+                xytext=(xs[0], ys[0]),
+                xy=(xs[1], ys[1]),
+                arrowprops=ARROW_CURRENT,
+            )
         return ax
 
 
@@ -344,6 +352,7 @@ class CompositeCurrentIntegralSpec(MicrowaveBaseModel):
         y: Optional[float] = None,
         z: Optional[float] = None,
         ax: Ax = None,
+        plot_arrow: bool = True,
         **path_kwargs: Any,
     ) -> Ax:
         """Plot path integral at single (x,y,z) coordinate.
@@ -358,6 +367,8 @@ class CompositeCurrentIntegralSpec(MicrowaveBaseModel):
             Position of plane in z direction, only one of x,y,z can be specified to define plane.
         ax : matplotlib.axes._subplots.Axes = None
             Matplotlib axes to plot on, if not specified, one is created.
+        plot_arrow : bool = True
+            Whether to plot the arrow indicating current direction. Default is ``True``.
         **path_kwargs
             Optional keyword arguments passed to the matplotlib plotting of the line.
             For details on accepted values, refer to
@@ -369,7 +380,7 @@ class CompositeCurrentIntegralSpec(MicrowaveBaseModel):
             The supplied or created matplotlib axes.
         """
         for path_spec in self.path_specs:
-            ax = path_spec.plot(x=x, y=y, z=z, ax=ax, **path_kwargs)
+            ax = path_spec.plot(x=x, y=y, z=z, ax=ax, plot_arrow=plot_arrow, **path_kwargs)
         return ax
 
     @field_validator("path_specs")

--- a/tidy3d/components/microwave/path_integrals/specs/impedance.py
+++ b/tidy3d/components/microwave/path_integrals/specs/impedance.py
@@ -2,22 +2,40 @@
 
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import TYPE_CHECKING, Optional, Union
 
+import numpy as np
 from pydantic import Field, model_validator
 
+from tidy3d.components.geometry.bound_ops import bounds_contains
 from tidy3d.components.microwave.base import MicrowaveBaseModel
+from tidy3d.components.microwave.path_integrals.specs.current import AxisAlignedCurrentIntegralSpec
 from tidy3d.components.microwave.path_integrals.types import (
     CurrentPathSpecType,
     VoltagePathSpecType,
 )
+from tidy3d.constants import fp_eps
 from tidy3d.exceptions import SetupError
 
 if TYPE_CHECKING:
     from tidy3d.compat import Self
+    from tidy3d.components.geometry.base import Box
+    from tidy3d.components.microwave.types import ImpedanceDef
+    from tidy3d.components.types.base import Direction
 
 
-class AutoImpedanceSpec(MicrowaveBaseModel):
+class AbstractImpedanceSpec(MicrowaveBaseModel):
+    """Abstract base class for impedance specifications."""
+
+    @abstractmethod
+    def _check_path_integrals_within_box(self, box: Box) -> None:
+        """Raise SetupError if a path specification is
+        defined outside a candidate box.
+        """
+
+
+class AutoImpedanceSpec(AbstractImpedanceSpec):
     """Specification for fully automatic transmission line impedance computation.
 
     Notes
@@ -27,8 +45,13 @@ class AutoImpedanceSpec(MicrowaveBaseModel):
         specifications are required.
     """
 
+    def _check_path_integrals_within_box(self, box: Box) -> None:
+        """Raise SetupError if a path specification is
+        defined outside a candidate box.
+        """
 
-class CustomImpedanceSpec(MicrowaveBaseModel):
+
+class CustomImpedanceSpec(AbstractImpedanceSpec):
     """Specification for custom transmission line voltages and currents in mode solvers.
 
     Notes
@@ -82,6 +105,72 @@ class CustomImpedanceSpec(MicrowaveBaseModel):
                 "Not a valid 'CustomImpedanceSpec', the 'voltage_spec' and 'current_spec' cannot both be 'None'."
             )
         return self
+
+    @property
+    def impedance_definition(self) -> ImpedanceDef:
+        """Determine the impedance definition based on provided path specifications.
+
+        Returns
+        -------
+        ImpedanceDef
+            The impedance definition type:
+            - VI: Both voltage and current specs provided.
+            - PI: Only current spec provided.
+            - PV: Only voltage spec provided.
+        """
+        if self.voltage_spec is not None and self.current_spec is not None:
+            return "VI"
+        elif self.current_spec is not None:
+            return "PI"
+        else:
+            return "PV"
+
+    def _check_path_integrals_within_box(self, box: Box) -> None:
+        """Raise 'SetupError' if a path specification is defined outside a candidate box."""
+        for spec, spec_type in [
+            (self.voltage_spec, "voltage"),
+            (self.current_spec, "current"),
+        ]:
+            if spec is None:
+                continue
+
+            box_bounds = box.bounds
+            # If the box is a plane (one dimension is zero), we need to ignore
+            # the bounds check along the normal axis
+            if box.size.count(0.0) == 1:
+                normal_axis = box._normal_axis
+                # Convert tuple to list so we can modify it
+                box_bounds = [list(box_bounds[0]), list(box_bounds[1])]
+                # Set the bounds along normal axis to match the spec bounds
+                box_bounds[0][normal_axis] = spec.bounds[0][normal_axis]
+                box_bounds[1][normal_axis] = spec.bounds[1][normal_axis]
+                # Convert back to tuple for bounds_contains
+                box_bounds = (tuple(box_bounds[0]), tuple(box_bounds[1]))
+
+            if not bounds_contains(
+                box_bounds, spec.bounds, fp_eps, np.finfo(np.float32).smallest_normal
+            ):
+                raise SetupError(
+                    "A 'CustomImpedanceSpec' must be setup with all path specifications defined within "
+                    f"the bounds of the mode solving plane. The 'CustomImpedanceSpec' was provided with a {spec_type} path specification with bounds "
+                    f"'{spec.bounds}', but the mode plane bounds are '{box.bounds}'."
+                )
+
+    @classmethod
+    def from_bounding_box(
+        cls, bounding_box: Box, current_sign: Direction = "+"
+    ) -> CustomImpedanceSpec:
+        """Create a custom impedance specification from a bounding box."""
+        return cls(
+            current_spec=AxisAlignedCurrentIntegralSpec(
+                center=bounding_box.center,
+                size=bounding_box.size,
+                sign=current_sign,
+                extrapolate_to_endpoints=False,
+                snap_contour_to_grid=True,
+            ),
+            voltage_spec=None,
+        )
 
 
 ImpedanceSpecType = Union[AutoImpedanceSpec, CustomImpedanceSpec]

--- a/tidy3d/components/microwave/path_integrals/specs/voltage.py
+++ b/tidy3d/components/microwave/path_integrals/specs/voltage.py
@@ -102,6 +102,7 @@ class AxisAlignedVoltageIntegralSpec(AxisAlignedPathIntegralSpec):
         y: Optional[float] = None,
         z: Optional[float] = None,
         ax: Ax = None,
+        plot_markers: bool = True,
         **path_kwargs: Any,
     ) -> Ax:
         """Plot path integral at single (x,y,z) coordinate.
@@ -116,6 +117,8 @@ class AxisAlignedVoltageIntegralSpec(AxisAlignedPathIntegralSpec):
             Position of plane in z direction, only one of x,y,z can be specified to define plane.
         ax : matplotlib.axes._subplots.Axes = None
             Matplotlib axes to plot on, if not specified, one is created.
+        plot_markers : bool = True
+            Whether to plot endpoint markers (+ and -). Default is ``True``.
         **path_kwargs
             Optional keyword arguments passed to the matplotlib plotting of the line.
             For details on accepted values, refer to
@@ -134,17 +137,22 @@ class AxisAlignedVoltageIntegralSpec(AxisAlignedPathIntegralSpec):
         # Plot the path
         plot_params = plot_params_voltage_path.include_kwargs(**path_kwargs)
         plot_kwargs = plot_params.to_kwargs()
-        ax.plot(xs, ys, markevery=[0, -1], **plot_kwargs)
+        if plot_markers:
+            ax.plot(xs, ys, markevery=[0, -1], **plot_kwargs)
+        else:
+            # Plot without markers
+            ax.plot(xs, ys, **{**plot_kwargs, "marker": ""})
 
         # Plot special end points
-        end_kwargs = plot_params_voltage_plus.include_kwargs(**path_kwargs).to_kwargs()
-        start_kwargs = plot_params_voltage_minus.include_kwargs(**path_kwargs).to_kwargs()
+        if plot_markers:
+            end_kwargs = plot_params_voltage_plus.include_kwargs(**path_kwargs).to_kwargs()
+            start_kwargs = plot_params_voltage_minus.include_kwargs(**path_kwargs).to_kwargs()
 
-        if self.sign == "-":
-            start_kwargs, end_kwargs = end_kwargs, start_kwargs
+            if self.sign == "-":
+                start_kwargs, end_kwargs = end_kwargs, start_kwargs
 
-        ax.plot(xs[0], ys[0], **start_kwargs)
-        ax.plot(xs[1], ys[1], **end_kwargs)
+            ax.plot(xs[0], ys[0], **start_kwargs)
+            ax.plot(xs[1], ys[1], **end_kwargs)
         return ax
 
 
@@ -167,6 +175,7 @@ class Custom2DVoltageIntegralSpec(Custom2DPathIntegralSpec):
         y: Optional[float] = None,
         z: Optional[float] = None,
         ax: Ax = None,
+        plot_markers: bool = True,
         **path_kwargs: Any,
     ) -> Ax:
         """Plot path integral at single (x,y,z) coordinate.
@@ -181,6 +190,8 @@ class Custom2DVoltageIntegralSpec(Custom2DPathIntegralSpec):
             Position of plane in z direction, only one of x,y,z can be specified to define plane.
         ax : matplotlib.axes._subplots.Axes = None
             Matplotlib axes to plot on, if not specified, one is created.
+        plot_markers : bool = True
+            Whether to plot endpoint markers (+ and -). Default is ``True``.
         **path_kwargs
             Optional keyword arguments passed to the matplotlib plotting of the line.
             For details on accepted values, refer to
@@ -199,12 +210,17 @@ class Custom2DVoltageIntegralSpec(Custom2DPathIntegralSpec):
         plot_kwargs = plot_params.to_kwargs()
         xs = self.vertices[:, 0]
         ys = self.vertices[:, 1]
-        ax.plot(xs, ys, markevery=[0, -1], **plot_kwargs)
+        if plot_markers:
+            ax.plot(xs, ys, markevery=[0, -1], **plot_kwargs)
+        else:
+            # Plot without markers
+            ax.plot(xs, ys, **{**plot_kwargs, "marker": ""})
 
         # Plot special end points
-        end_kwargs = plot_params_voltage_plus.include_kwargs(**path_kwargs).to_kwargs()
-        start_kwargs = plot_params_voltage_minus.include_kwargs(**path_kwargs).to_kwargs()
-        ax.plot(xs[0], ys[0], **start_kwargs)
-        ax.plot(xs[-1], ys[-1], **end_kwargs)
+        if plot_markers:
+            end_kwargs = plot_params_voltage_plus.include_kwargs(**path_kwargs).to_kwargs()
+            start_kwargs = plot_params_voltage_minus.include_kwargs(**path_kwargs).to_kwargs()
+            ax.plot(xs[0], ys[0], **start_kwargs)
+            ax.plot(xs[-1], ys[-1], **end_kwargs)
 
         return ax

--- a/tidy3d/components/microwave/source.py
+++ b/tidy3d/components/microwave/source.py
@@ -1,0 +1,77 @@
+"""Microwave sources for RF and transmission line simulations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import Field, model_validator
+
+from tidy3d.components.microwave.mode_spec import MicrowaveTerminalModeSpec
+from tidy3d.components.source.field import AbstractModeSource
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
+
+
+class MicrowaveTerminalSource(AbstractModeSource):
+    """Injects current source to excite a specific terminal mode.
+
+    Example
+    -------
+    >>> from tidy3d import GaussianPulse, AxisAlignedCurrentIntegralSpec, CustomImpedanceSpec
+    >>> pulse = GaussianPulse(freq0=10e9, fwidth=1e9)
+    >>>
+    >>> # Define impedance spec for terminal
+    >>> current_spec = AxisAlignedCurrentIntegralSpec(
+    ...     center=(0, 0, 0), size=(2, 1, 0), sign="+"
+    ... )
+    >>> impedance_spec = CustomImpedanceSpec(current_spec=current_spec)
+    >>>
+    >>> # Create terminal mode spec
+    >>> terminal_spec = MicrowaveTerminalModeSpec(
+    ...     num_modes=1,
+    ...     impedance_specs={"port1": impedance_spec}
+    ... )
+    >>>
+    >>> # Create terminal source
+    >>> terminal_source = MicrowaveTerminalSource(
+    ...     size=(10, 10, 0),
+    ...     source_time=pulse,
+    ...     mode_spec=terminal_spec,
+    ...     terminal_label="port1",
+    ...     direction='+'
+    ... )
+
+    See Also
+    --------
+    :class:`.MicrowaveTerminalModeSpec`:
+        Specification for terminal modes with explicit impedance definitions.
+    :class:`.ModeSource`:
+        Standard mode source for photonic waveguide modes.
+    """
+
+    mode_spec: MicrowaveTerminalModeSpec = Field(
+        ...,
+        title="Terminal Mode Specification",
+        description="Specification for terminal modes with explicit impedance definitions. "
+        "Defines how voltage, current, and impedance are computed for each terminal.",
+    )
+
+    terminal_label: str = Field(
+        ...,
+        title="Terminal Label",
+        description="String identifier for the terminal to excite. Must match the label of "
+        "a terminal (single-ended or differential pair).",
+    )
+
+    @model_validator(mode="after")
+    def _validate_terminal_label(self) -> Self:
+        """Validate that terminal_label exists in mode_spec terminal indices."""
+        terminal_indices = self.mode_spec._terminal_indices
+        if self.terminal_label not in terminal_indices:
+            raise ValueError(
+                f"terminal_label '{self.terminal_label}' not found in mode_spec. "
+                f"Available terminals: {terminal_indices}"
+            )
+
+        return self

--- a/tidy3d/components/microwave/types.py
+++ b/tidy3d/components/microwave/types.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from typing import Literal
+
+ImpedanceDef = Literal[
+    "VI",
+    "PI",
+    "PV",
+]

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -18,9 +18,12 @@ from tidy3d.components.base import (
 )
 from tidy3d.components.boundary import PML, Absorber, Boundary, BoundarySpec, PECBoundary, StablePML
 from tidy3d.components.data.data_array import (
+    CurrentFreqTerminalModeDataArray,
+    ImpedanceFreqTerminalTerminalDataArray,
     ModeIndexDataArray,
     ScalarModeFieldCylindricalDataArray,
     ScalarModeFieldDataArray,
+    VoltageFreqTerminalModeDataArray,
     _make_current_data_array,
     _make_impedance_data_array,
     _make_voltage_data_array,
@@ -35,12 +38,19 @@ from tidy3d.components.medium import (
     IsotropicUniformMediumType,
     LossyMetalMedium,
 )
-from tidy3d.components.microwave.data.dataset import TransmissionLineDataset
+from tidy3d.components.microwave.data.dataset import (
+    TransmissionLineDataset,
+    TransmissionLineTerminalDataset,
+)
 from tidy3d.components.microwave.data.monitor_data import MicrowaveModeSolverData
 from tidy3d.components.microwave.impedance_calculator import ImpedanceCalculator
-from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
+from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec, MicrowaveTerminalModeSpec
 from tidy3d.components.microwave.monitor import MicrowaveModeMonitor, MicrowaveModeSolverMonitor
-from tidy3d.components.microwave.path_integrals.factory import make_path_integrals
+from tidy3d.components.microwave.path_integrals.factory import (
+    make_path_integrals,
+    make_path_integrals_for_terminal,
+)
+from tidy3d.components.microwave.path_integrals.mode_plane_analyzer import ModePlaneAnalyzer
 from tidy3d.components.monitor import ModeMonitor, ModeSolverMonitor
 from tidy3d.components.scene import Scene
 from tidy3d.components.simulation import Simulation
@@ -65,7 +75,9 @@ if TYPE_CHECKING:
     from pydantic import NonNegativeFloat, NonNegativeInt, PositiveInt
 
     from tidy3d.compat import Self
-    from tidy3d.components.data.data_array import FreqModeDataArray
+    from tidy3d.components.data.data_array import (
+        FreqModeDataArray,
+    )
     from tidy3d.components.grid.grid import Coords, Grid
     from tidy3d.components.microwave.impedance_calculator import (
         CurrentIntegralType,
@@ -86,7 +98,11 @@ if TYPE_CHECKING:
         Symmetry,
     )
     from tidy3d.components.types.monitor_data import ModeSolverDataType
-from tidy3d.packaging import supports_local_subpixel, tidy3d_extras
+from tidy3d.packaging import (
+    check_tidy3d_extras_licensed_feature,
+    supports_local_subpixel,
+    tidy3d_extras,
+)
 
 # Importing the local solver may not work if e.g. scipy is not installed
 IMPORT_ERROR_MSG = """Could not import local solver, 'ModeSolver' objects can still be constructed
@@ -208,6 +224,13 @@ class ModeSolver(Tidy3dBaseModel):
         "methods like ``flux``, ``dot`` require all tangential field components, while others "
         "like ``mode_area`` require all E-field components.",
     )
+
+    @model_validator(mode="after")
+    def _validate_mode_spec(self) -> Self:
+        """Validate that num_modes is an integer."""
+        if not isinstance(self.mode_spec.num_modes, int):
+            raise ValidationError("num_modes must be an integer.")
+        return self
 
     @field_validator("simulation")
     @classmethod
@@ -489,9 +512,16 @@ class ModeSolver(Tidy3dBaseModel):
 
     @property
     def _has_microwave_mode_spec(self) -> bool:
-        """Check if the mode solver is using a :class:`~tidy3d.rf.MicrowaveModeSpec`.,
-        and will thus be creating :class:`.MicrowaveModeSolverData`."""
-        return isinstance(self.mode_spec, MicrowaveModeSpec)
+        """Check if the mode solver is using a :class:`.MicrowaveModeSpec` but not :class:`.MicrowaveTerminalModeSpec`."""
+        return (
+            isinstance(self.mode_spec, MicrowaveModeSpec)
+            and not self._has_microwave_terminal_mode_spec
+        )
+
+    @property
+    def _has_microwave_terminal_mode_spec(self) -> bool:
+        """Check if the mode solver is using a :class:`.MicrowaveTerminalModeSpec`."""
+        return isinstance(self.mode_spec, MicrowaveTerminalModeSpec)
 
     @supports_local_subpixel
     def solve(self) -> ModeSolverData:
@@ -567,10 +597,10 @@ class ModeSolver(Tidy3dBaseModel):
 
         # Compute data on the Yee grid
         mode_solver_data = self._data_on_yee_grid()
-        if self._has_microwave_mode_spec:
-            mode_solver_data = MicrowaveModeSolverData(
-                **mode_solver_data.model_dump(exclude={"type"})
-            )
+        if self._has_microwave_mode_spec or self._has_microwave_terminal_mode_spec:
+            data = mode_solver_data.model_dump(exclude={"type", "monitor"})
+            data["monitor"] = mode_solver_data.monitor
+            mode_solver_data = MicrowaveModeSolverData(**data)
 
         # Colocate to grid boundaries if requested
         if self.colocate:
@@ -609,9 +639,11 @@ class ModeSolver(Tidy3dBaseModel):
             if not self.mode_spec.interp_spec.reduce_data:
                 mode_solver_data = mode_solver_data.interpolated_copy
 
-        # Calculate and add the characteristic impedance
+        # Calculate and add the transmission line data
         if self._has_microwave_mode_spec:
             mode_solver_data = self._add_microwave_data(mode_solver_data)
+        if self._has_microwave_terminal_mode_spec:
+            mode_solver_data = self._add_microwave_terminal_data(mode_solver_data)
         return mode_solver_data
 
     @cached_property
@@ -1448,10 +1480,31 @@ class ModeSolver(Tidy3dBaseModel):
             )
         return make_path_integrals(self.mode_spec)
 
-    def _add_microwave_data(
+    def _make_path_integrals_for_terminal(
+        self,
+    ) -> dict[str, tuple[Optional[VoltageIntegralType], Optional[CurrentIntegralType]]]:
+        """Wrapper for making path integrals for each terminal from the MicrowaveTerminalModeSpec."""
+        if not self._has_microwave_terminal_mode_spec:
+            raise ValueError(
+                "Cannot make path integrals for when 'mode_spec' is not a 'MicrowaveTerminalModeSpec'."
+            )
+        return make_path_integrals_for_terminal(self.mode_spec)
+
+    def _generate_transmission_line_data(
         self, mode_solver_data: MicrowaveModeSolverData
-    ) -> MicrowaveModeSolverData:
-        """Calculate and add microwave data to ``mode_solver_data`` which uses the path specifications."""
+    ) -> TransmissionLineDataset:
+        """Generate transmission line data from mode solver data using path integrals.
+
+        Parameters
+        ----------
+        mode_solver_data : MicrowaveModeSolverData
+            Mode solver data to compute transmission line quantities from.
+
+        Returns
+        -------
+        TransmissionLineDataset
+            Dataset containing characteristic impedance, voltage coefficients, and current coefficients.
+        """
         voltage_integrals, current_integrals = self._make_path_integrals()
         # Need to operate on the full symmetry expanded fields
         mode_solver_data_expanded = mode_solver_data.symmetry_expanded_copy
@@ -1483,10 +1536,277 @@ class ModeSolver(Tidy3dBaseModel):
         all_mode_V = _make_voltage_data_array(all_mode_V)
         all_mode_I = xr.concat(I_list, dim="mode_index")
         all_mode_I = _make_current_data_array(all_mode_I)
-        mw_data = TransmissionLineDataset(
+        return TransmissionLineDataset(
             Z0=all_mode_Z0, voltage_coeffs=all_mode_V, current_coeffs=all_mode_I
         )
+
+    @staticmethod
+    def _assemble_transform_matrices(
+        input_list: Optional[dict[str, list]],
+        terminal_labels: list[str],
+    ) -> xr.DataArray:
+        """Assemble voltage/current transform matrices from per-terminal, per-mode data.
+
+        Parameters
+        ----------
+        input_list : Optional[dict[str, list]]
+            Dictionary mapping terminal labels to lists of voltage/current data per mode.
+        terminal_labels : list[str]
+            Ordered list of terminal labels.
+
+        Returns
+        -------
+        xr.DataArray
+            Transform matrix with dimensions (f, terminal_label, mode_index).
+        """
+        # Stack voltage/current data for each terminal across modes, then stack terminals
+        # Result: (f, terminal_label, mode_index)
+        stacked_list = []
+        for terminal_label in terminal_labels:
+            # Concat across modes for this terminal: list of FreqDataArray -> (f, mode_index)
+            mode_data = xr.concat(input_list[terminal_label], dim="mode_index")
+            stacked_list.append(mode_data)
+
+        # Stack all terminals: (f, mode_index) per terminal -> (f, terminal_label, mode_index)
+        result = xr.concat(stacked_list, dim="terminal_label")
+        result = result.assign_coords(terminal_label=terminal_labels)
+
+        # Assign explicit mode_index coordinates
+        num_modes = len(input_list[terminal_labels[0]])
+        result = result.assign_coords(mode_index=np.arange(num_modes))
+
+        # Ensure dimension order is (f, terminal_label, mode_index)
+        result = result.transpose("f", "terminal_label", "mode_index")
+
+        return result
+
+    @staticmethod
+    def _construct_differential_pair_transform(
+        terminals_mapping: Optional[dict[str, Union[str, tuple[str, str]]]],
+        terminal_labels: list[str],
+        voltage_transform: bool = True,
+    ) -> np.ndarray:
+        """Construct differential pair transformation matrix Q.
+
+        This matrix transforms single-ended terminal voltages to output terminal voltages,
+        which may include differential pairs. For differential pairs:
+        - Common mode: V_comm = 0.5 * (V_1 + V_2), I_comm = I_1 + I_2
+        - Differential mode: V_diff = V_1 - V_2, I_diff = 0.5 * (I_1 - I_2)
+
+        Parameters
+        ----------
+        terminals_mapping : Optional[dict[str, Union[str, tuple[str, str]]]]
+            Mapping from output terminals (including differential pairs) to input single-ended terminals.
+            Keys ending with "@comm" or "@diff" indicate differential pair modes.
+        terminal_labels : list[str]
+            Ordered list of input single-ended terminal labels.
+        voltage_transform : bool, optional
+            Whether it's applied to voltage transform (True), or current transform (False).
+
+        Returns
+        -------
+        np.ndarray
+            Transformation matrix Q with shape (num_output_terminals, num_input_terminals).
+        """
+        # if terminals_mapping is None, return an identity matrix
+        if terminals_mapping is None:
+            return np.eye(len(terminal_labels))
+
+        # Create mapping from terminal labels to indices for fast lookup
+        label_to_idx = {label: idx for idx, label in enumerate(terminal_labels)}
+
+        # Initialize Q matrix
+        num_output = len(terminals_mapping)
+        num_input = len(terminal_labels)
+        Q = np.zeros((num_output, num_input))
+
+        # Fill Q matrix based on terminals_mapping
+        for output_idx, (output_label, input_mapping) in enumerate(terminals_mapping.items()):
+            if isinstance(input_mapping, str):
+                # Single-ended terminal: direct mapping
+                input_idx = label_to_idx[input_mapping]
+                Q[output_idx, input_idx] = 1.0
+            else:
+                # Differential pair: tuple (label1, label2)
+                label1, label2 = input_mapping
+                idx1 = label_to_idx[label1]
+                idx2 = label_to_idx[label2]
+
+                if output_label.endswith("@comm"):
+                    factor = 0.5 if voltage_transform else 1.0
+                    Q[output_idx, idx1] = factor
+                    Q[output_idx, idx2] = factor
+                elif output_label.endswith("@diff"):
+                    factor = 1 if voltage_transform else 0.5
+                    Q[output_idx, idx1] = factor
+                    Q[output_idx, idx2] = -factor
+                else:
+                    # Should not happen based on the design, but handle gracefully
+                    raise ValueError(
+                        f"Differential pair terminal '{output_label}' must end with '@comm' or '@diff'"
+                    )
+
+        return Q
+
+    def _generate_transmission_line_terminal_data(
+        self, mode_solver_data: MicrowaveModeSolverData
+    ) -> TransmissionLineTerminalDataset:
+        """Generate transmission line terminal data from mode field integrals.
+
+        Computes voltage and current path integrals over the mode fields for each
+        terminal, then applies a terminal transformation to obtain the impedance
+        matrix and mode-to-terminal transformation matrices.
+
+        Parameters
+        ----------
+        mode_solver_data : MicrowaveModeSolverData
+            Mode solver data to extract frequency and mode dimensions from.
+
+        Returns
+        -------
+        TransmissionLineTerminalDataset
+            Dataset containing Z0 matrix (terminal_label_out × terminal_label_in),
+            voltage transformation matrix (terminal_label × mode_index),
+            and current transformation matrix (terminal_label × mode_index).
+        """
+        integrals_dict = self._make_path_integrals_for_terminal()
+        impedance_definition = self.mode_spec.impedance_definition
+        # Need to operate on the full symmetry expanded fields
+        mode_solver_data_expanded = mode_solver_data.symmetry_expanded_copy
+
+        # Initialize dictionaries to collect voltage/current for each terminal across all modes
+        # Structure: {terminal_label: [voltage_mode0, voltage_mode1, ...]}
+        V_list = {terminal_label: [] for terminal_label in integrals_dict.keys()}
+        I_list = {terminal_label: [] for terminal_label in integrals_dict.keys()}
+
+        # Loop over mode indices
+        for mode_index in range(self.mode_spec.num_modes):
+            single_mode_data = mode_solver_data_expanded._isel(mode_index=[mode_index])
+            for terminal_label, (v_integral, i_integral) in integrals_dict.items():
+                impedance_calc = ImpedanceCalculator(
+                    voltage_integral=v_integral, current_integral=i_integral
+                )
+                voltage, current = impedance_calc.compute_voltage_current(
+                    single_mode_data,
+                )
+                # Append to list for this terminal
+                V_list[terminal_label].append(voltage)
+                I_list[terminal_label].append(current)
+
+        # Validate that terminal transforms feature is available
+        check_tidy3d_extras_licensed_feature("terminal_transformation_matrix")
+
+        # Get input terminal labels (before differential pair transformation)
+        terminal_labels = list(integrals_dict.keys())
+
+        # Determine which arrays are needed based on impedance definition
+        # VI: needs v_list, i_list
+        # PI: needs i_list, power_matrix
+        # PV: needs v_list, power_matrix
+        need_v = impedance_definition in ("VI", "PV")
+        need_i = impedance_definition in ("VI", "PI")
+        need_p = impedance_definition in ("PI", "PV")
+
+        # Assemble V and I arrays as numpy arrays: (num_freqs, num_terminals, num_modes)
+        v_array = (
+            self._assemble_transform_matrices(V_list, terminal_labels).values if need_v else None
+        )
+        i_array = (
+            self._assemble_transform_matrices(I_list, terminal_labels).values if need_i else None
+        )
+
+        # Compute power matrix if needed: (num_freqs, num_modes, num_modes)
+        power_matrix = None
+        if need_p:
+            power_matrix = (
+                2
+                * mode_solver_data_expanded.outer_dot(
+                    mode_solver_data_expanded, conjugate=True, use_symmetric_form=False
+                )
+            ).values
+
+        # Build Q matrices for differential pair transformation
+        Q_voltage = self._construct_differential_pair_transform(
+            self.mode_spec.terminals_mapping, terminal_labels, voltage_transform=True
+        )
+        Q_current = self._construct_differential_pair_transform(
+            self.mode_spec.terminals_mapping, terminal_labels, voltage_transform=False
+        )
+
+        # Call tidy3d_extras to compute transforms and Z0
+        voltage_transform_arr, current_transform_arr, z0_arr = tidy3d_extras[
+            "mod"
+        ].extension._compute_terminal_transforms(
+            v_array,
+            i_array,
+            power_matrix,
+            Q_voltage,
+            Q_current,
+        )
+
+        # Get output terminal labels (after differential pair transformation)
+        out_terminal_labels = list(self.mode_spec._terminal_indices)
+
+        # Get coordinates from mode solver data
+        freqs = mode_solver_data.n_eff.coords["f"].values
+        mode_indices = mode_solver_data.n_eff.coords["mode_index"].values
+
+        # Wrap voltage_transform: (num_freqs, num_terminals, num_modes)
+        voltage_transform = VoltageFreqTerminalModeDataArray(
+            xr.DataArray(
+                voltage_transform_arr,
+                coords={
+                    "f": freqs,
+                    "terminal_label": out_terminal_labels,
+                    "mode_index": mode_indices,
+                },
+                dims=["f", "terminal_label", "mode_index"],
+            )
+        )
+
+        # Wrap current_transform: (num_freqs, num_terminals, num_modes)
+        current_transform = CurrentFreqTerminalModeDataArray(
+            xr.DataArray(
+                current_transform_arr,
+                coords={
+                    "f": freqs,
+                    "terminal_label": out_terminal_labels,
+                    "mode_index": mode_indices,
+                },
+                dims=["f", "terminal_label", "mode_index"],
+            )
+        )
+
+        # Wrap Z0: (num_freqs, num_terminals, num_terminals)
+        Z0 = ImpedanceFreqTerminalTerminalDataArray(
+            xr.DataArray(
+                z0_arr,
+                coords={
+                    "f": freqs,
+                    "terminal_label_out": out_terminal_labels,
+                    "terminal_label_in": out_terminal_labels,
+                },
+                dims=["f", "terminal_label_out", "terminal_label_in"],
+            )
+        )
+
+        return TransmissionLineTerminalDataset(
+            Z0=Z0, voltage_transform=voltage_transform, current_transform=current_transform
+        )
+
+    def _add_microwave_data(
+        self, mode_solver_data: MicrowaveModeSolverData
+    ) -> MicrowaveModeSolverData:
+        """Calculate and add microwave data to ``mode_solver_data`` which uses the path specifications."""
+        mw_data = self._generate_transmission_line_data(mode_solver_data)
         return mode_solver_data.updated_copy(transmission_line_data=mw_data)
+
+    def _add_microwave_terminal_data(
+        self, mode_solver_data: MicrowaveModeSolverData
+    ) -> MicrowaveModeSolverData:
+        """Calculate and add microwave terminal data to ``mode_solver_data`` which uses the path specifications."""
+        mw_data = self._generate_transmission_line_terminal_data(mode_solver_data)
+        return mode_solver_data.updated_copy(transmission_line_terminal_data=mw_data)
 
     @cached_property
     def data(self) -> ModeSolverDataType:
@@ -2126,7 +2446,7 @@ class ModeSolver(Tidy3dBaseModel):
             )
 
         mode_solver_monitor_type = ModeMonitor
-        if self._has_microwave_mode_spec:
+        if self._has_microwave_mode_spec or self._has_microwave_terminal_mode_spec:
             mode_solver_monitor_type = MicrowaveModeMonitor
 
         return mode_solver_monitor_type(
@@ -2177,7 +2497,7 @@ class ModeSolver(Tidy3dBaseModel):
             colocate = self.colocate
 
         mode_solver_monitor_type = ModeSolverMonitor
-        if self._has_microwave_mode_spec:
+        if self._has_microwave_mode_spec or self._has_microwave_terminal_mode_spec:
             mode_solver_monitor_type = MicrowaveModeSolverMonitor
 
         return mode_solver_monitor_type(
@@ -2773,6 +3093,9 @@ class ModeSolver(Tidy3dBaseModel):
             symmetry=self.simulation.symmetry,
             simulation_geometry=self.simulation.simulation_geometry,
             label=" for mode solver",
+            interior_disjoint_geometries=ModePlaneAnalyzer.apply_interior_disjoint_geometries(
+                self.simulation.structure_priority_mode
+            ),
         )
 
     def validate_pre_upload(self) -> None:

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -506,7 +506,7 @@ class AbstractModeMonitor(AbstractOverlapMonitor):
         cls: type[ModeMonitor], val: ModeSpec, info: FieldValidationInfo
     ) -> ModeSpec:
         """Warn if number of modes is too large."""
-        if val.num_modes > WARN_NUM_MODES:
+        if isinstance(val.num_modes, int) and val.num_modes > WARN_NUM_MODES:
             log.warning(
                 f"A large number ({val.num_modes}) of modes requested in monitor "
                 f"'{info.field_name}'. This can lead to solver slow-down and increased cost. "

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -20,6 +20,7 @@ from pydantic import (
 )
 
 from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
+from tidy3d.components.microwave.path_integrals.mode_plane_analyzer import ModePlaneAnalyzer
 from tidy3d.components.types.base import discriminated_union
 from tidy3d.constants import C_0, SECOND, fp_eps, inf
 from tidy3d.exceptions import (
@@ -4919,6 +4920,9 @@ class Simulation(AbstractYeeGridSimulation):
                 symmetry=self.symmetry,
                 simulation_geometry=self.simulation_geometry,
                 label=f" for monitor '{monitor.name}'",
+                interior_disjoint_geometries=ModePlaneAnalyzer.apply_interior_disjoint_geometries(
+                    self.structure_priority_mode
+                ),
             )
 
     @cached_property

--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -347,7 +347,59 @@ class AngledFieldSource(DirectionalSource, ABC):
         return pol_vector
 
 
-class ModeSource(DirectionalSource, PlanarSource, BroadbandSource):
+class AbstractModeSource(DirectionalSource, PlanarSource, BroadbandSource):
+    """Abstract base class for mode-based sources.
+
+    Provides common functionality for sources that inject electromagnetic modes,
+    including angle-dependent propagation direction and optional PEC frames.
+    """
+
+    mode_spec: ModeSpecType = Field(
+        default_factory=ModeSpec,
+        title="Mode Specification",
+        description="Parameters to feed to mode solver which determine modes measured by monitor.",
+        discriminator=TYPE_TAG_STR,
+    )
+
+    frame: Optional[PECFrame] = Field(
+        None,
+        title="Source Frame",
+        description="Add a thin frame around the source during the FDTD run to improve "
+        "the injection quality. The frame is positioned along the primal grid lines "
+        "so that it aligns with the boundaries of the mode solver used to obtain the source profile.",
+    )
+
+    @cached_property
+    def angle_theta(self) -> float:
+        """Polar angle of propagation."""
+        return self.mode_spec.angle_theta
+
+    @cached_property
+    def angle_phi(self) -> float:
+        """Azimuth angle of propagation."""
+        return self.mode_spec.angle_phi
+
+    @cached_property
+    def _dir_vector(self) -> tuple[float, float, float]:
+        """Source direction normal vector in cartesian coordinates."""
+        radius = 1.0 if self.direction == "+" else -1.0
+        dx = radius * np.cos(self.angle_phi) * np.sin(self.angle_theta)
+        dy = radius * np.sin(self.angle_phi) * np.sin(self.angle_theta)
+        dz = radius * np.cos(self.angle_theta)
+        return self.unpop_axis(dz, (dx, dy), axis=self._injection_axis)
+
+    @cached_property
+    def _bend_axis(self) -> Axis:
+        """Bend axis for curved sources."""
+        if self.mode_spec.bend_radius is None:
+            return None
+        in_plane = [0, 0]
+        in_plane[self.mode_spec.bend_axis] = 1
+        direction = self.unpop_axis(0, in_plane, axis=self.injection_axis)
+        return direction.index(1)
+
+
+class ModeSource(AbstractModeSource):
     """Injects current source to excite modal profile on finite extent plane.
 
     Notes
@@ -398,13 +450,6 @@ class ModeSource(DirectionalSource, PlanarSource, BroadbandSource):
         * `Prelude to Integrated Photonics Simulation: Mode Injection <https://www.flexcompute.com/fdtd101/Lecture-4-Prelude-to-Integrated-Photonics-Simulation-Mode-Injection/>`_
     """
 
-    mode_spec: ModeSpecType = Field(
-        default_factory=ModeSpec,
-        title="Mode Specification",
-        description="Parameters to feed to mode solver which determine modes measured by monitor.",
-        discriminator=TYPE_TAG_STR,
-    )
-
     mode_index: NonNegativeInt = Field(
         0,
         title="Mode Index",
@@ -413,42 +458,6 @@ class ModeSource(DirectionalSource, PlanarSource, BroadbandSource):
         "If larger than ``mode_spec.num_modes``, "
         "``num_modes`` in the solver will be set to ``mode_index + 1``.",
     )
-
-    frame: Optional[PECFrame] = Field(
-        None,
-        title="Source Frame",
-        description="Add a thin frame around the source during the FDTD run to improve "
-        "the injection quality. The frame is positioned along the primal grid lines "
-        "so that it aligns with the boundaries of the mode solver used to obtain the source profile.",
-    )
-
-    @cached_property
-    def angle_theta(self) -> float:
-        """Polar angle of propagation."""
-        return self.mode_spec.angle_theta
-
-    @cached_property
-    def angle_phi(self) -> float:
-        """Azimuth angle of propagation."""
-        return self.mode_spec.angle_phi
-
-    @cached_property
-    def _dir_vector(self) -> tuple[float, float, float]:
-        """Source direction normal vector in cartesian coordinates."""
-        radius = 1.0 if self.direction == "+" else -1.0
-        dx = radius * np.cos(self.angle_phi) * np.sin(self.angle_theta)
-        dy = radius * np.sin(self.angle_phi) * np.sin(self.angle_theta)
-        dz = radius * np.cos(self.angle_theta)
-        return self.unpop_axis(dz, (dx, dy), axis=self._injection_axis)
-
-    @cached_property
-    def _bend_axis(self) -> Optional[Axis]:
-        if self.mode_spec.bend_radius is None:
-            return None
-        in_plane = [0, 0]
-        in_plane[self.mode_spec.bend_axis] = 1
-        direction = self.unpop_axis(0, in_plane, axis=self.injection_axis)
-        return direction.index(1)
 
 
 """ Angled Field Sources one can use. """

--- a/tidy3d/components/source/utils.py
+++ b/tidy3d/components/source/utils.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Union
 
+from tidy3d.components.microwave.source import MicrowaveTerminalSource
+
 from .current import CustomCurrentSource, PointDipole, UniformCurrentSource
 from .field import (
     TFSF,
@@ -25,4 +27,5 @@ SourceType = Union[
     CustomFieldSource,
     CustomCurrentSource,
     TFSF,
+    MicrowaveTerminalSource,
 ]

--- a/tidy3d/components/types/mode_spec.py
+++ b/tidy3d/components/types/mode_spec.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Union
 
-from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
+from tidy3d.components.microwave.mode_spec import MicrowaveModeSpecType
 from tidy3d.components.mode_spec import ModeSpec
 
 # Type aliases
-ModeSpecType = Union[ModeSpec, MicrowaveModeSpec]
+ModeSpecType = Union[ModeSpec, MicrowaveModeSpecType]

--- a/tidy3d/plugins/smatrix/__init__.py
+++ b/tidy3d/plugins/smatrix/__init__.py
@@ -28,7 +28,7 @@ from tidy3d.plugins.smatrix.data.types import ComponentModelerDataType
 from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
 from tidy3d.plugins.smatrix.ports.modal import AstigmaticGaussianPort, GaussianPort, Port
 from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
-from tidy3d.plugins.smatrix.ports.wave import WavePort
+from tidy3d.plugins.smatrix.ports.wave import TerminalWavePort, WavePort
 
 # Instantiate on plugin import till we unite with toplevel
 warnings.filterwarnings(
@@ -60,5 +60,6 @@ __all__ = [
     "TerminalComponentModeler",
     "TerminalComponentModelerData",
     "TerminalPortDataArray",
+    "TerminalWavePort",
     "WavePort",
 ]

--- a/tidy3d/plugins/smatrix/analysis/terminal.py
+++ b/tidy3d/plugins/smatrix/analysis/terminal.py
@@ -18,8 +18,9 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from tidy3d.plugins.smatrix.data.data_array import PortDataArray
-from tidy3d.plugins.smatrix.ports.wave import WavePort
+from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
+from tidy3d.plugins.smatrix.ports.base_lumped import AbstractLumpedPort
+from tidy3d.plugins.smatrix.ports.wave import TerminalWavePort, WavePort
 from tidy3d.plugins.smatrix.utils import (
     ab_to_s,
     check_port_impedance_sign,
@@ -115,55 +116,111 @@ def terminal_construct_smatrix(
     return s_matrix_expanded
 
 
-def port_reference_impedances(modeler_data: TerminalComponentModelerData) -> PortDataArray:
-    """Calculates the reference impedance for each port across all frequencies.
+def port_reference_impedances(modeler_data: TerminalComponentModelerData) -> TerminalPortDataArray:
+    """Calculates the reference impedance matrix for each port across all frequencies.
 
     This function determines the characteristic impedance for every port defined
-    in the modeler. It handles two types of ports differently: for a
-    :class:`.WavePort`, the impedance is frequency-dependent and computed from
-    modal properties, while for other types like :class:`.LumpedPort`, the
-    impedance is a user-defined constant value.
+    in the modeler. It returns a matrix with dimensions (f, port_out, port_in)
+    to support coupled impedances from :class:`.TerminalWavePort`. For
+    :class:`.WavePort` and :class:`.LumpedPort`, the impedance matrix is diagonal.
 
     Parameters
     ----------
     modeler_data : TerminalComponentModelerData
         Data object containing the modeler definition and the raw
-        simulation data needed for :class:`.WavePort` impedance calculations.
+        simulation data needed for impedance calculations.
 
     Returns
     -------
-    PortDataArray
-        A ``PortDataArray`` containing the complex impedance for each port at each
-        frequency.
+    TerminalPortDataArray
+        A ``TerminalPortDataArray`` containing the complex impedance matrix
+        with dimensions (f, port_out, port_in) for each frequency.
     """
-    values = np.zeros(
-        (len(modeler_data.modeler.freqs), len(modeler_data.modeler.matrix_indices_monitor)),
-        dtype=complex,
-    )
+    network_indices = list(modeler_data.modeler.matrix_indices_monitor)
+    num_ports = len(network_indices)
+    num_freqs = len(modeler_data.modeler.freqs)
+
+    # Initialize 3D array: (freq, port_out, port_in)
+    values = np.zeros((num_freqs, num_ports, num_ports), dtype=complex)
 
     coords = {
         "f": np.array(modeler_data.modeler.freqs),
-        "port": list(modeler_data.modeler.matrix_indices_monitor),
+        "port_out": network_indices,
+        "port_in": network_indices,
     }
-    port_impedances = PortDataArray(values, coords=coords)
+    port_impedances = TerminalPortDataArray(values, coords=coords)
+
     # Each simulation will store the results from the ModeMonitors,
     # so here we just choose the first one.
     first_sim_index = modeler_data.modeler.matrix_indices_run_sim[0]
-    port, mode_index = modeler_data.modeler.network_dict[first_sim_index]
-    sim_data = modeler_data.data[
-        modeler_data.modeler.get_task_name(port=port, mode_index=mode_index)
-    ]
-    for network_index in modeler_data.modeler.matrix_indices_monitor:
-        port, mode_index = modeler_data.modeler.network_dict[network_index]
-        indexer = {"port": network_index}
-        if isinstance(port, WavePort):
-            # WavePorts have a port impedance calculated from its associated modal field distribution
-            # and is frequency dependent.
-            data = port.get_port_impedance(sim_data, mode_index).data
-            port_impedances = port_impedances._with_updated_data(data=data, coords=indexer)
-        else:
-            # LumpedPorts have a constant reference impedance
-            data = np.full(len(modeler_data.modeler.freqs), port.impedance)
+    port, selection_index = modeler_data.modeler.network_dict[first_sim_index]
+    if isinstance(port, TerminalWavePort):
+        task_name = modeler_data.modeler.get_task_name(port=port, terminal_label=selection_index)
+    elif isinstance(port, WavePort):
+        task_name = modeler_data.modeler.get_task_name(port=port, mode_index=selection_index)
+    else:
+        task_name = modeler_data.modeler.get_task_name(port=port)
+    sim_data = modeler_data.data[task_name]
+
+    # Track which ports have been processed to avoid redundant computation.
+    # Each network index represents a single mode/terminal, but get_reference_impedance_matrix
+    # returns the full matrix for all modes/terminals of that port. Process each port once
+    # and extract all matrix elements to populate the impedance array.
+    processed_ports = set()
+
+    for network_index in network_indices:
+        port, _ = modeler_data.modeler.network_dict[network_index]
+
+        if isinstance(port, (WavePort, TerminalWavePort)):
+            # get_reference_impedance_matrix returns the full impedance matrix.
+            # Only process each port once to handle full matrix
+            if port.name not in processed_ports:
+                processed_ports.add(port.name)
+                ref_Z0_matrix = port.get_reference_impedance_matrix(sim_data)
+
+                # Extract dimension names (e.g., mode_index_out/in or terminal_label_out/in)
+                is_mode_based = "mode_index_out" in ref_Z0_matrix.dims
+                # Determine kwarg name for network_index based on dimension type
+                idx_kwarg = "mode_index" if is_mode_based else "terminal_label"
+                idx_out_name = f"{idx_kwarg}_out"
+                idx_in_name = f"{idx_kwarg}_in"
+
+                # Identify valid output and input indices and their corresponding network indices
+                valid_out = [
+                    (idx, modeler_data.modeler.network_index(port, **{idx_kwarg: idx}))
+                    for idx in ref_Z0_matrix.coords[idx_out_name].values
+                    if modeler_data.modeler.network_index(port, **{idx_kwarg: idx})
+                    in network_indices
+                ]
+
+                valid_in = [
+                    (idx, modeler_data.modeler.network_index(port, **{idx_kwarg: idx}))
+                    for idx in ref_Z0_matrix.coords[idx_in_name].values
+                    if modeler_data.modeler.network_index(port, **{idx_kwarg: idx})
+                    in network_indices
+                ]
+
+                if valid_out and valid_in:
+                    local_out, net_out = zip(*valid_out)
+                    local_in, net_in = zip(*valid_in)
+
+                    # Extract submatrix and transpose to ensure (freq, out, in) order
+                    dims_other = [
+                        d for d in ref_Z0_matrix.dims if d not in (idx_out_name, idx_in_name)
+                    ]
+                    sub_matrix = ref_Z0_matrix.sel(
+                        {idx_out_name: list(local_out), idx_in_name: list(local_in)}
+                    ).transpose(*dims_other, idx_out_name, idx_in_name)
+
+                    # Assign to port_impedances using vectorized indexing
+                    port_impedances.loc[{"port_out": list(net_out), "port_in": list(net_in)}] = (
+                        sub_matrix.values
+                    )
+
+        elif isinstance(port, AbstractLumpedPort):
+            # LumpedPorts have a constant diagonal reference impedance
+            data = np.full(num_freqs, port.impedance)
+            indexer = {"port_out": network_index, "port_in": network_index}
             port_impedances = port_impedances._with_updated_data(data=data, coords=indexer)
 
     port_impedances = modeler_data.modeler._set_port_data_array_attributes(port_impedances)
@@ -178,8 +235,8 @@ def _compute_port_voltages_currents(
 
     This function calculates the voltage and current at each monitor port from the
     electromagnetic field data in a single simulation result. The voltages and currents
-    are computed according to the specific port type (e.g., lumped, wave) and are used
-    as inputs for subsequent wave amplitude calculations.
+    are computed according to the specific port type (e.g., lumped, wave, terminal wave)
+    and are used as inputs for subsequent wave amplitude calculations.
 
     Parameters
     ----------
@@ -207,25 +264,35 @@ def _compute_port_voltages_currents(
     V_matrix = PortDataArray(values, coords=coords)
     I_matrix = V_matrix.copy(deep=True)
 
-    waveport_cache_results = (None, None, None)
+    wave_port_cache_results = (None, None, None)
+
     for network_index in network_indices:
-        port, mode_index = modeler.network_dict[network_index]
-        if isinstance(port, WavePort):
-            if waveport_cache_results[0] is not port:
-                V_modes, I_modes = compute_port_VI(port, sim_data)
-                waveport_cache_results = (port, V_modes, I_modes)
-            V_out = waveport_cache_results[1].sel(mode_index=mode_index)
-            I_out = waveport_cache_results[2].sel(mode_index=mode_index)
+        port, selection_index = modeler.network_dict[network_index]
+
+        if isinstance(port, (WavePort, TerminalWavePort)):
+            # Both WavePort and TerminalWavePort use similar logic with different index names
+            if wave_port_cache_results[0] is not port:
+                V_data, I_data = compute_port_VI(port, sim_data)
+                wave_port_cache_results = (port, V_data, I_data)
+
+            # Use mode_index for WavePort, terminal_label for TerminalWavePort
+            index_dim = "mode_index" if isinstance(port, WavePort) else "terminal_label"
+            V_out = wave_port_cache_results[1].sel({index_dim: selection_index})
+            I_out = wave_port_cache_results[2].sel({index_dim: selection_index})
+
         else:
+            # LumpedPort: direct voltage/current computation
             V_out, I_out = compute_port_VI(port, sim_data)
+
         indexer = {"port": network_index}
         V_matrix = V_matrix._with_updated_data(data=V_out.data, coords=indexer)
         I_matrix = I_matrix._with_updated_data(data=I_out.data, coords=indexer)
+
     return (V_matrix, I_matrix)
 
 
 def _compute_wave_amplitudes_from_VI(
-    port_reference_impedances: PortDataArray,
+    port_reference_impedances: TerminalPortDataArray,
     port_voltages: PortDataArray,
     port_currents: PortDataArray,
     s_param_def: SParamDef = "pseudo",
@@ -237,10 +304,18 @@ def _compute_wave_amplitudes_from_VI(
     specified wave definition. The conversion handles impedance sign consistency and
     applies the appropriate normalization based on the chosen S-parameter definition.
 
+    For coupled systems (off-diagonal Z terms), the wave amplitudes are computed using
+    matrix multiplication to account for inter-port coupling.
+
+    The wave amplitudes are computed using:
+    - Pseudo waves: Equations 53-54 from Marks and Williams [1]
+    - Power waves: Equation 4.67 from Pozar [2]
+
     Parameters
     ----------
-    port_reference_impedances : :class:`.PortDataArray`
-        Reference impedance values for each port with dimensions (f, port).
+    port_reference_impedances : :class:`.TerminalPortDataArray`
+        Reference impedance matrix with dimensions (f, port_out, port_in).
+        Can include off-diagonal coupling terms for TerminalWavePort.
     port_voltages : :class:`.PortDataArray`
         Voltage values at each port with dimensions (f, port).
     port_currents : :class:`.PortDataArray`
@@ -262,31 +337,50 @@ def _compute_wave_amplitudes_from_VI(
     I_numpy = port_currents.values
     Z_numpy = port_reference_impedances.values
 
-    # Check to make sure sign is consistent for all impedance values
-    check_port_impedance_sign(Z_numpy)
+    # Extract diagonal for F computation and sign handling
+    Z_diag = np.diagonal(Z_numpy, axis1=1, axis2=2)
 
-    # Check for negative real part of port impedance and flip the V and Z signs accordingly
-    negative_real_Z = np.real(Z_numpy) < 0
-    V_numpy = np.where(negative_real_Z, -V_numpy, V_numpy)
-    Z_numpy = np.where(negative_real_Z, -Z_numpy, Z_numpy)
+    # Check to make sure sign is consistent for all impedance values (checks diagonal)
+    check_port_impedance_sign(Z_diag)
 
+    # Check for negative real part of port impedance on diagonal and flip signs accordingly
+    negative_real_Z_diag = np.real(Z_diag) < 0
+    V_numpy = np.where(negative_real_Z_diag, -V_numpy, V_numpy)
+
+    # Also apply sign changes in Z for negative diagonal
+    sign_vec = np.where(negative_real_Z_diag, -1, 1)
+    # Apply sign to Z: Z --> sign @ Z (flip rows for negative diagonal)
+    if np.any(sign_vec == -1):
+        # sign_vec has shape (f, port), Z_numpy has shape (f, port_out, port_in)
+        # Apply: Z_new[f,i,j] = sign[f,i] * Z[f,i,j]
+        Z_numpy = sign_vec[:, :, np.newaxis] * Z_numpy
+
+    # Compute F
     F_numpy = compute_F(Z_numpy, s_param_def)
 
-    b_Zref = Z_numpy
+    # Matrix multiplication: Z @ I for full coupling support
+    # Z_numpy has shape (f, port_out, port_in), I_numpy has shape (f, port)
+    # Result ZI has shape (f, port_out)
+    ZI = np.einsum("fij,fj->fi", Z_numpy, I_numpy)
+
+    # For power waves, use conjugate of Z for reflected wave
     if s_param_def == "power":
-        b_Zref = np.conj(Z_numpy)
+        b_Zref_I = np.einsum("fij,fj->fi", np.conj(Z_numpy), I_numpy)
+    else:
+        b_Zref_I = ZI
 
     # Equations 53 and 54 from [1]
     # Equation 4.67 - Pozar - Microwave Engineering 4ed
-    a.values = F_numpy * (V_numpy + Z_numpy * I_numpy)
-    b.values = F_numpy * (V_numpy - b_Zref * I_numpy)
+    # Generalized for matrix Z: a = F @ (V + Z @ I), b = F @ (V - Z* @ I)
+    a.values = np.einsum("fij,fj->fi", F_numpy, V_numpy + ZI)
+    b.values = np.einsum("fij,fj->fi", F_numpy, V_numpy - b_Zref_I)
 
     return a, b
 
 
 def compute_wave_amplitudes_at_each_port(
     modeler: TerminalComponentModeler,
-    port_reference_impedances: PortDataArray,
+    port_reference_impedances: TerminalPortDataArray,
     sim_data: SimulationData,
     s_param_def: SParamDef = "pseudo",
 ) -> tuple[PortDataArray, PortDataArray]:
@@ -298,8 +392,8 @@ def compute_wave_amplitudes_at_each_port(
     ----------
     modeler : :class:`.TerminalComponentModeler`
         The component modeler defining the ports and simulation settings.
-    port_reference_impedances : :class:`.PortDataArray`
-        Reference impedance at each port.
+    port_reference_impedances : :class:`.TerminalPortDataArray`
+        Reference impedance matrix with dimensions (f, port_out, port_in).
     sim_data : :class:`.SimulationData`
         Results from a single simulation run.
     s_param_def : SParamDef
@@ -321,7 +415,7 @@ def compute_wave_amplitudes_at_each_port(
 
 def compute_power_wave_amplitudes_at_each_port(
     modeler: TerminalComponentModeler,
-    port_reference_impedances: PortDataArray,
+    port_reference_impedances: TerminalPortDataArray,
     sim_data: SimulationData,
 ) -> tuple[PortDataArray, PortDataArray]:
     """Compute the incident and reflected power wave amplitudes at each port.
@@ -334,8 +428,8 @@ def compute_power_wave_amplitudes_at_each_port(
     ----------
     modeler : :class:`.TerminalComponentModeler`
         The component modeler defining the ports and simulation settings.
-    port_reference_impedances : :class:`.PortDataArray`
-        Reference impedance at each port.
+    port_reference_impedances : :class:`.TerminalPortDataArray`
+        Reference impedance matrix with dimensions (f, port_out, port_in).
     sim_data : :class:`.SimulationData`
         Results from a single simulation run.
 

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -24,7 +24,7 @@ from tidy3d.exceptions import SetupError, Tidy3dKeyError
 from tidy3d.log import log
 from tidy3d.plugins.smatrix.ports.modal import Port
 from tidy3d.plugins.smatrix.ports.types import LumpedPortType, TerminalPortType
-from tidy3d.plugins.smatrix.ports.wave import WavePort
+from tidy3d.plugins.smatrix.ports.wave import TerminalWavePort, WavePort
 from tidy3d.plugins.smatrix.types import Element, MatrixIndex, NetworkElement, NetworkIndex
 
 if TYPE_CHECKING:
@@ -151,6 +151,25 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
             )
         return element_mappings
 
+    _freqs_not_empty = validate_freqs_not_empty()
+    _freqs_lower_bound = validate_freqs_min()
+    _freqs_unique = validate_freqs_unique()
+
+    @model_validator(mode="after")
+    def _freqs_in_custom_source_time(self) -> Self:
+        """Make sure freqs is in the range of the custom source time."""
+        val = self.custom_source_time
+        if val is None:
+            return self
+        freq_range = val._frequency_range_sigma_cached
+        freqs = self.freqs
+
+        if freq_range[0] > min(freqs) or max(freqs) > freq_range[1]:
+            log.warning(
+                "Custom source time does not cover all 'freqs'.",
+            )
+        return self
+
     @model_validator(mode="after")
     def _validate_run_only(self) -> Self:
         """Validate that run_only entries are unique and exist in matrix_indices_monitor."""
@@ -180,27 +199,10 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
 
         return self
 
-    _freqs_not_empty = validate_freqs_not_empty()
-    _freqs_lower_bound = validate_freqs_min()
-    _freqs_unique = validate_freqs_unique()
-
-    @model_validator(mode="after")
-    def _freqs_in_custom_source_time(self) -> Self:
-        """Make sure freqs is in the range of the custom source time."""
-        val = self.custom_source_time
-        if val is None:
-            return self
-        freq_range = val._frequency_range_sigma_cached
-        freqs = self.freqs
-
-        if freq_range[0] > min(freqs) or max(freqs) > freq_range[1]:
-            log.warning(
-                "Custom source time does not cover all 'freqs'.",
-            )
-        return self
-
     @staticmethod
-    def get_task_name(port: PortType, mode_index: Optional[int] = None) -> str:
+    def get_task_name(
+        port: PortType, mode_index: Optional[int] = None, terminal_label: Optional[str] = None
+    ) -> str:
         """Generates a standardized task name from a port object.
 
         This method creates a unique string identifier for a simulation task based on
@@ -214,7 +216,10 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
             If provided, this index is appended
             to the port name (e.g., 'port_1@1'). Defaults to `None`, in which case the first
             mode is chosen by default.
-
+        terminal_label : Optional[str], optional
+            If provided, this label is appended
+            to the port name (e.g., 'port_1@terminal_1'). Defaults to `None`, in which case an error is raised
+            if the port is a :class:`.TerminalWavePort`.
         Returns
         -------
         str
@@ -237,7 +242,12 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
             # WavePorts default to first mode index
             if mode_index is not None:
                 return f"{port.name}@{mode_index}"
-            return f"{port.name}@{port._mode_indices[0]}"
+            return f"{port.name}@{port._mode_indices()[0]}"
+        elif isinstance(port, TerminalWavePort):
+            # TerminalWavePorts has no default
+            if terminal_label is None:
+                raise ValueError("'terminal_label' must be specified for a terminal port.")
+            return f"{port.name}@{terminal_label}"
         else:
             # Modal ports default to 0
             if mode_index is not None:
@@ -251,9 +261,8 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
             raise Tidy3dKeyError(f'Port "{port_name}" not found.')
         return ports[0]
 
-    @staticmethod
     @abstractmethod
-    def _construct_matrix_indices_monitor(ports: tuple) -> tuple[IndexType, ...]:
+    def _construct_matrix_indices_monitor(self, ports: tuple) -> tuple[IndexType, ...]:
         """Construct matrix indices for monitoring from ports.
 
         This helper method is used by both the matrix_indices_monitor property

--- a/tidy3d/plugins/smatrix/component_modelers/modal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/modal.py
@@ -105,9 +105,8 @@ class ModalComponentModeler(AbstractComponentModeler):
             sim_dict[task_name] = sim_copy
         return SimulationMap(keys=tuple(sim_dict.keys()), values=tuple(sim_dict.values()))
 
-    @staticmethod
     def _construct_matrix_indices_monitor(
-        ports: tuple[ModalPortType, ...],
+        self, ports: tuple[ModalPortType, ...]
     ) -> tuple[MatrixIndex, ...]:
         """Construct matrix indices for monitoring from modal ports.
 

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -20,6 +20,7 @@ from tidy3d.components.geometry.utils import _shift_object
 from tidy3d.components.geometry.utils_2d import snap_coordinate_to_grid
 from tidy3d.components.index import SimulationMap
 from tidy3d.components.microwave.base import MicrowaveBaseModel
+from tidy3d.components.microwave.path_integrals.mode_plane_analyzer import ModePlaneAnalyzer
 from tidy3d.components.monitor import DirectivityMonitor, ModeMonitor
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.components.types import Complex, Coordinate
@@ -32,16 +33,32 @@ from tidy3d.plugins.smatrix.component_modelers.base import (
     FWIDTH_FRAC,
     AbstractComponentModeler,
 )
+from tidy3d.plugins.smatrix.component_modelers.viz import (
+    TERMINAL_BOX_COLOR,
+    plot_params_diff_pair_arrow,
+    plot_params_diff_pair_box,
+    plot_params_diff_pair_label,
+    plot_params_padding_shade,
+    plot_params_terminal_arrow,
+    plot_params_terminal_label,
+)
 from tidy3d.plugins.smatrix.ports.base_lumped import AbstractLumpedPort
-from tidy3d.plugins.smatrix.ports.types import TerminalPortType
-from tidy3d.plugins.smatrix.ports.wave import WavePort
+from tidy3d.plugins.smatrix.ports.types import TerminalPortType, WavePortType
+from tidy3d.plugins.smatrix.ports.wave import (
+    DEFAULT_DIFFERENTIAL_PAIR_LABEL_PREFIX,
+    AbstractWavePort,
+    TerminalWavePort,
+    WavePort,
+)
 from tidy3d.plugins.smatrix.types import NetworkElement, NetworkIndex, SParamDef
 
 if TYPE_CHECKING:
     from tidy3d.compat import Self
+    from tidy3d.components.microwave.mode_spec import MicrowaveModeSpecType
+    from tidy3d.components.mode.mode_solver import ModeSolver
     from tidy3d.components.simulation import Simulation
-    from tidy3d.components.types import Ax
-    from tidy3d.plugins.smatrix.data.data_array import PortDataArray
+    from tidy3d.components.types import Ax, Shapely
+    from tidy3d.plugins.smatrix.data.data_array import TerminalPortDataArray
     from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
     from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
 
@@ -49,6 +66,99 @@ AUTO_RADIATION_MONITOR_NAME = "radiation"
 AUTO_RADIATION_MONITOR_BUFFER = 2
 AUTO_RADIATION_MONITOR_NUM_POINTS_THETA = 100
 AUTO_RADIATION_MONITOR_NUM_POINTS_PHI = 200
+TERMINAL_BOX_PADDING_FRACTION = 0.1
+
+
+def _pack_label_centers_1d(
+    anchor_centers_px: np.ndarray,
+    widths_px: np.ndarray,
+    x_min_px: float,
+    x_max_px: float,
+    pad_px: float,
+) -> np.ndarray:
+    """Pack 1D label centers along x to avoid overlap, while staying within bounds.
+
+    This helper operates purely in display coordinates (pixels) and is intended for
+    deterministic, automated label placement.
+
+    Parameters
+    ----------
+    anchor_centers_px : np.ndarray
+        Desired label centers along x (pixels).
+    widths_px : np.ndarray
+        Label widths in pixels.
+    x_min_px : float
+        Minimum allowed x for label *left* edge (pixels).
+    x_max_px : float
+        Maximum allowed x for label *right* edge (pixels).
+    pad_px : float
+        Minimum gap between adjacent labels (pixels).
+
+    Returns
+    -------
+    np.ndarray
+        Packed label centers (pixels), same shape as ``anchor_centers_px``.
+    """
+    if anchor_centers_px.size == 0:
+        return anchor_centers_px
+
+    centers = np.asarray(anchor_centers_px, dtype=float).copy()
+    widths = np.asarray(widths_px, dtype=float)
+    order = np.argsort(centers)
+
+    # Forward greedy packing.
+    prev_right = None
+    for idx in order:
+        half = widths[idx] / 2
+        left = centers[idx] - half
+        if prev_right is None:
+            if left < x_min_px:
+                centers[idx] += x_min_px - left
+        else:
+            min_left = prev_right + pad_px
+            if left < min_left:
+                centers[idx] += min_left - left
+        prev_right = centers[idx] + half
+
+    # If we overflow the right bound, shift left and run a backward pass.
+    last = order[-1]
+    overflow = (centers[last] + widths[last] / 2) - x_max_px
+    if overflow > 0:
+        centers[order] -= overflow
+
+        next_left = None
+        for idx in order[::-1]:
+            half = widths[idx] / 2
+            right = centers[idx] + half
+            if next_left is None:
+                if right > x_max_px:
+                    centers[idx] -= right - x_max_px
+            else:
+                max_right = next_left - pad_px
+                if right > max_right:
+                    centers[idx] -= right - max_right
+            next_left = centers[idx] - half
+
+        # Ensure the first label doesn't underflow the left bound; if it does,
+        # shift right and do one final forward stabilization pass.
+        first = order[0]
+        underflow = x_min_px - (centers[first] - widths[first] / 2)
+        if underflow > 0:
+            centers[order] += underflow
+            prev_right = None
+            for idx in order:
+                half = widths[idx] / 2
+                left = centers[idx] - half
+                if prev_right is None:
+                    if left < x_min_px:
+                        centers[idx] += x_min_px - left
+                else:
+                    min_left = prev_right + pad_px
+                    if left < min_left:
+                        centers[idx] += min_left - left
+                prev_right = centers[idx] + half
+
+    return centers
 
 
 class DirectivityMonitorSpec(MicrowaveBaseModel):
@@ -249,11 +359,14 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
     def _sim_with_sources(self) -> Simulation:
         """Instance of :class:`.Simulation` with all sources and absorbers added for each port, for plotting."""
 
-        sources = [port.to_source(self._source_time) for port in self.ports]
-        absorbers = [
-            port.to_absorber()
+        sources = [
+            port.to_source(self._source_time, mode_spec=self._resolved_mode_specs.get(port.name))
             for port in self.ports
-            if isinstance(port, WavePort) and port.absorber
+        ]
+        absorbers = [
+            port.to_absorber(mode_spec=self._resolved_mode_specs.get(port.name))
+            for port in self.ports
+            if isinstance(port, AbstractWavePort) and port.absorber
         ]
         return self.simulation.updated_copy(
             sources=sources, internal_absorbers=absorbers, validate=False
@@ -296,6 +409,41 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
 
     @equal_aspect
     @add_ax_if_none
+    def plot_sim_grid(
+        self,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+        ax: Ax = None,
+        **kwargs: Any,
+    ) -> Ax:
+        """Plot the cell boundaries as lines on a plane defined by one nonzero x,y,z coordinate.
+
+        This is a convenience method to visualize the simulation grid setup for
+        troubleshooting.
+
+        Parameters
+        ----------
+        x : float, optional
+            x-coordinate for the cross-section.
+        y : float, optional
+            y-coordinate for the cross-section.
+        z : float, optional
+            z-coordinate for the cross-section.
+        ax : matplotlib.axes.Axes, optional
+            Axes to plot on.
+        **kwargs
+            Keyword arguments passed to :meth:`.Simulation.plot_grid`.
+
+        Returns
+        -------
+        matplotlib.axes.Axes
+            The axes with the plot.
+        """
+        return self._sim_with_sources.plot_grid(x=x, y=y, z=z, ax=ax, **kwargs)
+
+    @equal_aspect
+    @add_ax_if_none
     def plot_sim_eps(
         self,
         x: Optional[float] = None,
@@ -330,9 +478,545 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
 
         return self._sim_with_sources.plot_eps(x=x, y=y, z=z, ax=ax, **kwargs)
 
+    @equal_aspect
+    @add_ax_if_none
+    def plot_port(
+        self,
+        port: Union[str, TerminalPortType],
+        ax: Ax = None,
+        label_font_size: Optional[float] = None,
+        **kwargs: Any,
+    ) -> Ax:
+        """Plot a :class:`.Simulation` on the port plane.
+
+        This is a convenience method to visualize the port setup.
+
+        Parameters
+        ----------
+        port : Union[str, TerminalPortType]
+            The name or port object to plot.
+        ax : matplotlib.axes.Axes, optional
+            Axes to plot on.
+        label_font_size : float, optional
+            Font size for labels. If ``None``, uses the default font size.
+        **kwargs
+            Keyword arguments passed to :meth:`.Simulation.plot`.
+
+        Returns
+        -------
+        matplotlib.axes.Axes
+            The axes with the plot.
+        """
+        if isinstance(port, TerminalPortType):
+            if port not in self.ports:
+                raise ValueError(f"Port {port} not found in the modeler.")
+        elif isinstance(port, str):
+            port = self.get_port_by_name(port)
+        else:
+            raise ValueError(
+                f"Invalid port type: {type(port)}. Must be a string or a TerminalPortType object."
+            )
+
+        injection_axis = port.injection_axis
+        plot_kwargs = {"ax": ax, **kwargs}
+        plot_kwargs.setdefault("monitor_alpha", 0)
+        plot_kwargs.setdefault("source_alpha", 0)
+        plot_kwargs["xyz"[injection_axis]] = port.center[injection_axis]
+        ax = self._sim_with_sources.plot(**plot_kwargs)
+
+        # Set default xlim and ylim based on port bounds in the transverse plane
+        from tidy3d.components.geometry.base import Box
+
+        _, (xmin, ymin) = Box.pop_axis(port.bounds[0], axis=injection_axis)
+        _, (xmax, ymax) = Box.pop_axis(port.bounds[1], axis=injection_axis)
+
+        # Add padding with shaded regions and set axis limits
+        self._add_port_padding_shading(ax, xmin, xmax, ymin, ymax)
+
+        # Plot bounding boxes and labels for TerminalWavePorts
+        if isinstance(port, TerminalWavePort):
+            ax = self._plot_terminal_wave_port(ax, port, label_font_size)
+
+        return ax
+
+    def mode_solver_for_port(self, port_name: str) -> ModeSolver:
+        """Get the mode solver object for a given port.
+
+        Parameters
+        ----------
+        port_name : str
+            Name of the port to get the mode solver for.
+
+        Returns
+        -------
+        ModeSolver
+            The mode solver for the given port.
+        """
+        port = self.get_port_by_name(port_name)
+        if not isinstance(port, WavePortType):
+            raise ValueError("Mode solver is only supported for TerminalWavePort and WavePort.")
+        return port.to_mode_solver(
+            self.base_sim, self.freqs, mode_spec=self._resolved_mode_specs.get(port_name)
+        )
+
+    def _add_port_padding_shading(
+        self, ax: Ax, xmin: float, xmax: float, ymin: float, ymax: float
+    ) -> None:
+        """Add padding with shaded regions around the port bounds and set axis limits.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes
+            Axes to plot on.
+        xmin : float
+            Minimum x-coordinate of the port.
+        xmax : float
+            Maximum x-coordinate of the port.
+        ymin : float
+            Minimum y-coordinate of the port.
+        ymax : float
+            Maximum y-coordinate of the port.
+        """
+        from matplotlib.patches import Rectangle
+
+        # Calculate padding based on port size
+        port_width = xmax - xmin
+        port_height = ymax - ymin
+        padding = TERMINAL_BOX_PADDING_FRACTION * max(port_width, port_height)
+
+        # Padded bounds (outer region)
+        xmin_padded = xmin - padding
+        xmax_padded = xmax + padding
+        ymin_padded = ymin - padding
+        ymax_padded = ymax + padding
+
+        # Add shaded rectangles for padding regions (top, bottom, left, right)
+        # Bottom padding region
+        bottom_rect = Rectangle(
+            (xmin_padded, ymin_padded),
+            xmax_padded - xmin_padded,
+            padding,
+            **plot_params_padding_shade,
+        )
+        ax.add_patch(bottom_rect)
+
+        # Top padding region
+        top_rect = Rectangle(
+            (xmin_padded, ymax),
+            xmax_padded - xmin_padded,
+            padding,
+            **plot_params_padding_shade,
+        )
+        ax.add_patch(top_rect)
+
+        # Left padding region
+        left_rect = Rectangle(
+            (xmin_padded, ymin),
+            padding,
+            port_height,
+            **plot_params_padding_shade,
+        )
+        ax.add_patch(left_rect)
+
+        # Right padding region
+        right_rect = Rectangle(
+            (xmax, ymin),
+            padding,
+            port_height,
+            **plot_params_padding_shade,
+        )
+        ax.add_patch(right_rect)
+
+        # Set the expanded limits
+        ax.set_xlim(xmin_padded, xmax_padded)
+        ax.set_ylim(ymin_padded, ymax_padded)
+
+    def _add_packed_label_lane(
+        self,
+        ax: Ax,
+        lane_y: float,
+        items: list[dict[str, float | str]],
+        label_params: dict[str, Any],
+        arrow_params: dict[str, Any],
+    ) -> None:
+        """Add a packed label lane with leader lines for the provided items.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes
+            Axes to plot on.
+        lane_y : float
+            Y-coordinate for the label lane.
+        items : list[dict[str, float | str]]
+            List of items with label info (label, x_anchor, y_anchor, x_min, x_max).
+        label_params : dict[str, Any]
+            Parameters for label styling.
+        arrow_params : dict[str, Any]
+            Parameters for arrow styling.
+        """
+        if not items:
+            return
+
+        fig = ax.figure
+
+        # Create temporary texts (single draw) to measure rendered extents.
+        temp_texts = [ax.text(0.0, 0.0, str(it["label"]), **label_params) for it in items]
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+
+        widths_px = np.array([t.get_window_extent(renderer=renderer).width for t in temp_texts])
+        for t in temp_texts:
+            t.remove()
+
+        # Axis bounds in display coordinates.
+        ax_bbox = ax.get_window_extent(renderer=renderer)
+        pad_px = max(4.0, 0.25 * float(label_params.get("fontsize", 12)))
+        x_min_px = ax_bbox.x0 + pad_px
+        x_max_px = ax_bbox.x1 - pad_px
+
+        # Desired anchor centers in display x.
+        anchors_x = np.array([float(it["x_anchor"]) for it in items])
+        lane_y_disp = ax.transData.transform((0.0, lane_y))[1]
+        anchors_disp = ax.transData.transform(
+            np.column_stack([anchors_x, np.full_like(anchors_x, lane_y)])
+        )
+        anchor_centers_px = anchors_disp[:, 0]
+
+        packed_centers_px = _pack_label_centers_1d(
+            anchor_centers_px=anchor_centers_px,
+            widths_px=widths_px,
+            x_min_px=x_min_px,
+            x_max_px=x_max_px,
+            pad_px=pad_px,
+        )
+
+        # Convert packed centers back to data x at y=lane_y.
+        packed_points_data = ax.transData.inverted().transform(
+            np.column_stack([packed_centers_px, np.full_like(packed_centers_px, lane_y_disp)])
+        )
+        packed_x_data = packed_points_data[:, 0]
+
+        # Use the lane y (data) to create a display-scale marker size.
+        marker_ms = max(3.0, 0.35 * float(label_params.get("fontsize", 12)))
+
+        for it, x_text in zip(items, packed_x_data):
+            # Connect to a point on the box edge that is closest to the label x.
+            # This makes the association clearer when adjacent boxes have similar centers.
+            x_min_box = float(it.get("x_min", it["x_anchor"]))
+            x_max_box = float(it.get("x_max", it["x_anchor"]))
+            x_conn = float(np.clip(x_text, x_min_box, x_max_box))
+            y_anchor = float(it["y_anchor"])
+
+            # Small marker at the connection point improves readability without heavy clutter.
+            ax.plot(
+                [x_conn],
+                [y_anchor],
+                marker="o",
+                markersize=marker_ms,
+                color=arrow_params.get("color", "k"),
+                alpha=arrow_params.get("alpha", 1.0),
+                zorder=float(label_params.get("zorder", 11)) + 0.1,
+                markeredgewidth=0.0,
+            )
+
+            ax.annotate(
+                str(it["label"]),
+                xy=(x_conn, y_anchor),
+                xytext=(float(x_text), float(lane_y)),
+                arrowprops=arrow_params,
+                annotation_clip=False,
+                **label_params,
+            )
+
+    def _plot_and_collect_terminal_info(
+        self,
+        ax: Ax,
+        port: TerminalWavePort,
+        impedance_specs: dict,
+        injection_axis: int,
+    ) -> tuple[list[dict[str, float | str]], list[float]]:
+        """Plot terminal paths and collect info for labeling.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes
+            Axes to plot on.
+        port : TerminalWavePort
+            The terminal wave port.
+        impedance_specs : dict
+            Impedance specifications for each terminal.
+        injection_axis : int
+            Injection axis (0, 1, or 2 for x, y, z).
+
+        Returns
+        -------
+        tuple[list[dict[str, float | str]], list[float]]
+            Terminal items for labeling and list of max y-coordinates.
+        """
+        from tidy3d.components.microwave.path_integrals.specs.impedance import (
+            CustomImpedanceSpec,
+        )
+
+        plot_coord = {0: "x", 1: "y", 2: "z"}[injection_axis]
+        plot_kwargs = {plot_coord: port.center[injection_axis], "ax": ax}
+
+        terminal_items: list[dict[str, float | str]] = []
+        terminal_box_ymax: list[float] = []
+
+        for terminal_label, impedance_spec in impedance_specs.items():
+            if isinstance(impedance_spec, CustomImpedanceSpec):
+                # Determine which spec to use (current takes priority)
+                path_spec = None
+                if impedance_spec.current_spec is not None:
+                    path_spec = impedance_spec.current_spec
+                    path_spec.plot(**plot_kwargs, color=TERMINAL_BOX_COLOR, plot_arrow=False)
+                elif impedance_spec.voltage_spec is not None:
+                    path_spec = impedance_spec.voltage_spec
+                    path_spec.plot(**plot_kwargs, color=TERMINAL_BOX_COLOR, plot_markers=False)
+
+                # Get bounding box from the path spec for labeling
+                if path_spec is not None:
+                    # Get bounds and convert to 2D coordinates based on injection axis
+                    bounds_3d = path_spec.bounds
+                    _, (xmin, ymin) = Box.pop_axis(bounds_3d[0], axis=injection_axis)
+                    _, (xmax, ymax) = Box.pop_axis(bounds_3d[1], axis=injection_axis)
+
+                    # Apply padding for visualization
+                    padding = TERMINAL_BOX_PADDING_FRACTION * max(xmax - xmin, ymax - ymin)
+                    box_xmin = xmin - padding
+                    box_xmax = xmax + padding
+                    box_ymax = ymax + padding
+
+                    terminal_box_ymax.append(box_ymax)
+
+                    box_center_x = (box_xmin + box_xmax) / 2
+                    terminal_items.append(
+                        {
+                            "label": str(terminal_label),
+                            "x_anchor": float(box_center_x),
+                            "y_anchor": float(box_ymax),
+                            "x_min": float(box_xmin),
+                            "x_max": float(box_xmax),
+                        }
+                    )
+
+        return terminal_items, terminal_box_ymax
+
+    def _plot_and_collect_diff_pair_info(
+        self,
+        ax: Ax,
+        port: TerminalWavePort,
+        impedance_specs: dict,
+        injection_axis: int,
+    ) -> tuple[list[dict[str, float | str]], list[float]]:
+        """Plot differential pair boxes and collect info for labeling.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes
+            Axes to plot on.
+        port : TerminalWavePort
+            The terminal wave port.
+        impedance_specs : dict
+            Impedance specifications for each terminal.
+        injection_axis : int
+            Injection axis (0, 1, or 2 for x, y, z).
+
+        Returns
+        -------
+        tuple[list[dict[str, float | str]], list[float]]
+            Differential pair items for labeling and list of min y-coordinates.
+        """
+        import matplotlib.patches as patches
+
+        diff_items: list[dict[str, float | str]] = []
+        diff_box_ymin: list[float] = []
+
+        if not port.differential_pairs:
+            return diff_items, diff_box_ymin
+
+        for pair_idx, (idx1, idx2) in enumerate(port.differential_pairs):
+            # Get impedance specs for both terminals in the pair
+            if idx1 in impedance_specs and idx2 in impedance_specs:
+                spec1 = impedance_specs[idx1]
+                spec2 = impedance_specs[idx2]
+
+                # Get path specs (current takes priority)
+                path_spec1 = (
+                    spec1.current_spec if spec1.current_spec is not None else spec1.voltage_spec
+                )
+                path_spec2 = (
+                    spec2.current_spec if spec2.current_spec is not None else spec2.voltage_spec
+                )
+
+                if path_spec1 is not None and path_spec2 is not None:
+                    # Get bounds for both specs and compute combined bounding box
+                    bounds1_3d = path_spec1.bounds
+                    bounds2_3d = path_spec2.bounds
+
+                    _, (xmin1, ymin1) = Box.pop_axis(bounds1_3d[0], axis=injection_axis)
+                    _, (xmax1, ymax1) = Box.pop_axis(bounds1_3d[1], axis=injection_axis)
+                    _, (xmin2, ymin2) = Box.pop_axis(bounds2_3d[0], axis=injection_axis)
+                    _, (xmax2, ymax2) = Box.pop_axis(bounds2_3d[1], axis=injection_axis)
+
+                    # Combined bounds
+                    xmin = min(xmin1, xmin2)
+                    xmax = max(xmax1, xmax2)
+                    ymin = min(ymin1, ymin2)
+                    ymax = max(ymax1, ymax2)
+
+                    # Apply padding
+                    padding = TERMINAL_BOX_PADDING_FRACTION * max(xmax - xmin, ymax - ymin)
+                    box_xmin = xmin - padding
+                    box_xmax = xmax + padding
+                    box_ymin = ymin - padding
+                    box_ymax = ymax + padding
+
+                    diff_box_ymin.append(box_ymin)
+
+                    # Create rectangle for differential pair with blue dashed border
+                    rect = patches.Rectangle(
+                        (box_xmin, box_ymin),
+                        box_xmax - box_xmin,
+                        box_ymax - box_ymin,
+                        **plot_params_diff_pair_box,
+                    )
+                    ax.add_patch(rect)
+
+                    box_center_x = (box_xmin + box_xmax) / 2
+                    diff_items.append(
+                        {
+                            "label": f"{DEFAULT_DIFFERENTIAL_PAIR_LABEL_PREFIX}{pair_idx}: ({idx1}⁺, {idx2}⁻)",
+                            "x_anchor": float(box_center_x),
+                            "y_anchor": float(box_ymin),
+                            "x_min": float(box_xmin),
+                            "x_max": float(box_xmax),
+                        }
+                    )
+
+        return diff_items, diff_box_ymin
+
+    def _place_labels_with_lane(
+        self,
+        ax: Ax,
+        items: list[dict[str, float | str]],
+        box_y_coords: list[float],
+        label_params: dict[str, Any],
+        arrow_params: dict[str, Any],
+        placement: str = "top",
+    ) -> None:
+        """Place labels on a lane above or below the items.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes
+            Axes to plot on.
+        items : list[dict[str, float | str]]
+            List of items with label info.
+        box_y_coords : list[float]
+            Y-coordinates to use for lane placement.
+        label_params : dict[str, Any]
+            Parameters for label styling.
+        arrow_params : dict[str, Any]
+            Parameters for arrow styling.
+        placement : str
+            Either "top" or "bottom" for label placement.
+        """
+        if not box_y_coords:
+            return
+
+        ylim0, ylim1 = ax.get_ylim()
+        yrange = float(ylim1 - ylim0) if ylim1 != ylim0 else 1.0
+        lane_margin = 0.08 * yrange
+
+        if placement == "top":
+            lane_y = max(box_y_coords) + lane_margin
+            if lane_y > ylim1:
+                ax.set_ylim(ylim0, lane_y + lane_margin)
+        else:  # bottom
+            lane_y = min(box_y_coords) - lane_margin
+            if lane_y < ylim0:
+                ax.set_ylim(lane_y - lane_margin, ylim1)
+
+        self._add_packed_label_lane(
+            ax=ax,
+            lane_y=lane_y,
+            items=items,
+            label_params=label_params,
+            arrow_params=arrow_params,
+        )
+
+    def _plot_terminal_wave_port(
+        self, ax: Ax, port: TerminalWavePort, label_font_size: Optional[float] = None
+    ) -> Ax:
+        """Plot bounding boxes and labels for TerminalWavePort terminals and differential pairs.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes
+            Axes to plot on.
+        port : TerminalWavePort
+            The terminal wave port to plot.
+        label_font_size : float, optional
+            Font size for labels. If ``None``, uses the default font size.
+
+        Returns
+        -------
+        matplotlib.axes.Axes
+            The axes with the plot.
+        """
+        mode_spec = self._resolved_mode_specs[port.name]
+        impedance_specs = mode_spec.impedance_specs
+        injection_axis = port.injection_axis
+
+        # Plot individual terminal paths and collect info for labeling
+        terminal_items, terminal_box_ymax = self._plot_and_collect_terminal_info(
+            ax, port, impedance_specs, injection_axis
+        )
+
+        # Place terminal labels on top lane
+        label_params = plot_params_terminal_label.copy()
+        if label_font_size is not None:
+            label_params["fontsize"] = label_font_size
+
+        self._place_labels_with_lane(
+            ax=ax,
+            items=terminal_items,
+            box_y_coords=terminal_box_ymax,
+            label_params=label_params,
+            arrow_params=plot_params_terminal_arrow,
+            placement="top",
+        )
+
+        # Plot differential pair boxes and collect info for labeling
+        diff_items, diff_box_ymin = self._plot_and_collect_diff_pair_info(
+            ax, port, impedance_specs, injection_axis
+        )
+
+        # Place differential pair labels on bottom lane
+        diff_label_params = plot_params_diff_pair_label.copy()
+        if label_font_size is not None:
+            diff_label_params["fontsize"] = label_font_size
+
+        self._place_labels_with_lane(
+            ax=ax,
+            items=diff_items,
+            box_y_coords=diff_box_ymin,
+            label_params=diff_label_params,
+            arrow_params=plot_params_diff_pair_arrow,
+            placement="bottom",
+        )
+
+        return ax
+
     @staticmethod
-    def network_index(port: TerminalPortType, mode_index: Optional[int] = None) -> NetworkIndex:
-        """Converts the port, and a ``mode_index`` when the port is a :class:`.WavePort`, to a unique string specifier.
+    def network_index(
+        port: TerminalPortType,
+        mode_index: Optional[int] = None,
+        terminal_label: Optional[str] = None,
+    ) -> NetworkIndex:
+        """Converts the port, and a ``mode_index`` when the port is a :class:`.WavePort`,
+        or a ``terminal_label`` when the port is a :class:`.TerminalWavePort`, to a unique string specifier.
 
         Parameters
         ----------
@@ -341,30 +1025,40 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         mode_index : Optional[int]
             Selects a single mode from those supported by the ``port``, which is only used when
             the ``port`` is a :class:`.WavePort`
-
+        terminal_label : Optional[str]
+            Selects a single terminal from those supported by the ``port``, which is only used when
+            the ``port`` is a :class:`.TerminalWavePort`
         Returns
         -------
         NetworkIndex
             A unique string that is used to identify the row/column of the scattering matrix.
         """
-        return TerminalComponentModeler.get_task_name(port=port, mode_index=mode_index)
+        return TerminalComponentModeler.get_task_name(
+            port=port, mode_index=mode_index, terminal_label=terminal_label
+        )
 
     @cached_property
-    def network_dict(self) -> dict[NetworkIndex, tuple[TerminalPortType, int]]:
-        """Dictionary associating each unique ``NetworkIndex`` to a port and mode index."""
+    def network_dict(self) -> dict[NetworkIndex, tuple[TerminalPortType, int | str]]:
+        """Dictionary associating each unique ``NetworkIndex`` to a port and mode/terminal index."""
         network_dict = {}
         for port in self.ports:
             if isinstance(port, WavePort):
-                for mode_index in port._mode_indices:
-                    key = self.network_index(port, mode_index)
+                for mode_index in port._mode_indices(
+                    mode_spec=self._resolved_mode_specs.get(port.name)
+                ):
+                    key = self.network_index(port, mode_index=mode_index)
                     network_dict[key] = (port, mode_index)
+            elif isinstance(port, TerminalWavePort):
+                for terminal_label in self._resolved_mode_specs[port.name]._terminal_indices:
+                    key = self.network_index(port, terminal_label=terminal_label)
+                    network_dict[key] = (port, terminal_label)
             else:
                 key = self.network_index(port, None)
                 network_dict[key] = (port, None)
         return network_dict
 
-    @staticmethod
     def _construct_matrix_indices_monitor(
+        self,
         ports: tuple[TerminalPortType, ...],
     ) -> tuple[NetworkIndex, ...]:
         """Construct matrix indices for monitoring from terminal ports.
@@ -372,7 +1066,7 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         Parameters
         ----------
         ports : tuple[TerminalPortType, ...]
-            Tuple of terminal port objects (LumpedPort, CoaxialLumpedPort, or WavePort).
+            Tuple of terminal port objects (LumpedPort, CoaxialLumpedPort, WavePort, or TerminalWavePort).
 
         Returns
         -------
@@ -382,10 +1076,15 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         matrix_indices = []
         for port in ports:
             if isinstance(port, WavePort):
-                for mode_index in port._mode_indices:
-                    matrix_indices.append(TerminalComponentModeler.network_index(port, mode_index))
+                for mode_index in port._mode_indices(
+                    mode_spec=self._resolved_mode_specs.get(port.name)
+                ):
+                    matrix_indices.append(self.network_index(port, mode_index=mode_index))
+            elif isinstance(port, TerminalWavePort):
+                for terminal_label in self._resolved_mode_specs[port.name]._terminal_indices:
+                    matrix_indices.append(self.network_index(port, terminal_label=terminal_label))
             else:
-                matrix_indices.append(TerminalComponentModeler.network_index(port))
+                matrix_indices.append(self.network_index(port))
         return tuple(matrix_indices)
 
     @cached_property
@@ -422,10 +1121,12 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         return SimulationMap(keys=tuple(sim_dict.keys()), values=tuple(sim_dict.values()))
 
     @cached_property
-    def _base_sim_no_radiation_monitors(self) -> Simulation:
-        """The intermediate base simulation with all grid refinement options, structure priority mode,
-        port loads (if present), and monitors added,
-        which is only missing the source excitations and radiation monitors.
+    def _base_sim_with_grid_and_lumped_elements(self) -> Simulation:
+        """Intermediate simulation with correct grid but without monitors/absorbers.
+
+        This simulation has the updated grid_spec, lumped elements, and mesh overrides,
+        but does not include monitors or absorbers (which require resolved mode_spec).
+        It's used to get the correct grid for terminal detection.
         """
         # internal mesh override and snapping points are automatically generated from lumped elements.
         lumped_resistors = [port.to_load() for port in self._lumped_ports]
@@ -444,11 +1145,50 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         if self.structure_priority_mode is not None:
             update_dict["structure_priority_mode"] = self.structure_priority_mode
         # Make an initial simulation with new grid_spec to determine where LumpedPorts are snapped
-        sim_wo_source = self.simulation.updated_copy(
+        sim_intermediate = self.simulation.updated_copy(
             **update_dict,
             validate=False,
             deep=False,
         )
+
+        # Snap lumped port centers
+        snap_centers = {}
+        for port in self._lumped_ports:
+            port_center_on_axis = port.center[port.injection_axis]
+            new_port_center = snap_coordinate_to_grid(
+                sim_intermediate.grid, port_center_on_axis, port.injection_axis
+            )
+            snap_centers[port.name] = new_port_center
+
+        # Add lumped elements with snapped centers
+        new_lumped_elements = list(self.simulation.lumped_elements) + [
+            port.to_load(snap_center=snap_centers[port.name]) for port in self._lumped_ports
+        ]
+
+        # Add mesh overrides for any wave ports present
+        mesh_overrides = list(sim_intermediate.grid_spec.override_structures)
+        for wave_port in self._wave_ports + self._terminal_wave_ports:
+            if wave_port.num_grid_cells is not None:
+                mesh_overrides.extend(wave_port.to_mesh_overrides())
+        new_grid_spec = sim_intermediate.grid_spec.updated_copy(override_structures=mesh_overrides)
+
+        # Update simulation (no monitors, no absorbers yet)
+        return sim_intermediate.updated_copy(
+            lumped_elements=new_lumped_elements,
+            grid_spec=new_grid_spec,
+            validate=False,
+            deep=False,
+        )
+
+    @cached_property
+    def _base_sim_no_radiation_monitors(self) -> Simulation:
+        """The intermediate base simulation with all grid refinement options, port loads (if present), and monitors added,
+        which is only missing the source excitations and radiation monitors.
+        """
+        # Start from the mode_spec-free simulation
+        sim_wo_source = self._base_sim_with_grid_and_lumped_elements
+
+        # Recompute snap_centers using the grid from _base_sim_with_grid_and_lumped_elements
         snap_centers = {}
         for port in self._lumped_ports:
             port_center_on_axis = port.center[port.injection_axis]
@@ -457,30 +1197,23 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
             )
             snap_centers[port.name] = new_port_center
 
-        # Create monitors and snap to the center positions
+        # Create monitors (NOW with resolved mode_spec available)
         field_monitors = [
             mon
             for port in self.ports
             for mon in port.to_monitors(
-                self.freqs, snap_center=snap_centers.get(port.name), grid=sim_wo_source.grid
+                self.freqs,
+                snap_center=snap_centers.get(port.name),
+                grid=sim_wo_source.grid,
+                mode_spec=self._resolved_mode_specs.get(port.name),
             )
         ]
 
         new_mnts = list(self.simulation.monitors) + field_monitors
 
-        new_lumped_elements = list(self.simulation.lumped_elements) + [
-            port.to_load(snap_center=snap_centers[port.name]) for port in self._lumped_ports
-        ]
-
-        # Add mesh overrides for any wave ports present
-        mesh_overrides = list(sim_wo_source.grid_spec.override_structures)
-        for wave_port in self._wave_ports:
-            if wave_port.num_grid_cells is not None:
-                mesh_overrides.extend(wave_port.to_mesh_overrides())
-        new_grid_spec = sim_wo_source.grid_spec.updated_copy(override_structures=mesh_overrides)
-
+        # Create absorbers (NOW with resolved mode_spec available)
         new_absorbers = list(sim_wo_source.internal_absorbers)
-        for wave_port in self._wave_ports:
+        for wave_port in self._wave_ports + self._terminal_wave_ports:
             if wave_port.absorber:
                 # absorbers are shifted together with sources
                 mode_src_pos = wave_port.center[
@@ -491,13 +1224,12 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
                     freq_spec=BroadbandModeABCSpec(
                         frequency_range=(np.min(self.freqs), np.max(self.freqs))
                     ),
+                    mode_spec=self._resolved_mode_specs[wave_port.name],
                 )
                 new_absorbers.append(port_absorber)
 
         update_dict = {
             "monitors": new_mnts,
-            "lumped_elements": new_lumped_elements,
-            "grid_spec": new_grid_spec,
             "internal_absorbers": new_absorbers,
         }
 
@@ -735,14 +1467,25 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
 
     def _add_source_to_sim(self, source_index: NetworkIndex) -> tuple[str, Simulation]:
         """Adds the source corresponding to the ``source_index`` to the base simulation."""
-        port, mode_index = self.network_dict[source_index]
-        if isinstance(port, WavePort):
+        port, selection_index = self.network_dict[source_index]
+        index_kwargs = {}
+        if isinstance(port, (WavePort, TerminalWavePort)):
             # Source is placed just before the field monitor of the port
             mode_src_pos = port.center[port.injection_axis] + self._shift_value_signed(port)
+            resolved_spec = self._resolved_mode_specs[port.name]
+            # use terminal_label if TerminalWavePort, otherwise use mode_index
+            if isinstance(port, TerminalWavePort):
+                index_kwargs["terminal_label"] = selection_index
+            else:
+                index_kwargs["mode_index"] = selection_index
             port_source = port.to_source(
-                self._source_time, snap_center=mode_src_pos, mode_index=mode_index
+                self._source_time,
+                snap_center=mode_src_pos,
+                mode_spec=resolved_spec,
+                **index_kwargs,
             )
         else:
+            # Lumped ports
             port_center_on_axis = port.center[port.injection_axis]
             new_port_center = snap_coordinate_to_grid(
                 self.base_sim.grid, port_center_on_axis, port.injection_axis
@@ -750,7 +1493,8 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
             port_source = port.to_source(
                 self._source_time, snap_center=new_port_center, grid=self.base_sim.grid
             )
-        task_name = self.get_task_name(port=port, mode_index=mode_index)
+
+        task_name = self.get_task_name(port=port, **index_kwargs)
 
         return (
             task_name,
@@ -841,6 +1585,88 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
 
         return self
 
+    @model_validator(mode="after")
+    def _validate_wave_ports(self) -> Self:
+        """Validate wave port settings after all fields are initialized."""
+        self._validate_wave_port_mode_selections()
+        self._validate_wave_port_mode_index()
+        self._warn_multimode_absorption()
+        return self
+
+    def _validate_wave_port_mode_selections(self) -> None:
+        """Validate that mode_selection indices are within range for WavePort instances.
+
+        This validation only happens for ports where mode_spec.num_modes was originally 'auto'.
+        """
+        for port in self._wave_ports:
+            mode_selection = port.mode_selection
+            if mode_selection is None:
+                continue
+
+            # Only validate if the original mode_spec.num_modes was 'auto'
+            # (if it was not 'auto', validation already happened in WavePort)
+            if port.mode_spec.num_modes != "auto":
+                continue
+
+            # Get the resolved mode spec for this port
+            resolved_mode_spec = self._resolved_mode_specs.get(port.name)
+            num_modes = resolved_mode_spec.num_modes
+
+            # Check that indices are within range of num_modes
+            invalid_indices = [idx for idx in mode_selection if idx >= num_modes]
+            if invalid_indices:
+                raise ValidationError(
+                    f"'mode_spec.mode_selection' contains indices {invalid_indices} that are >= "
+                    f"'mode_spec.num_modes' ({num_modes}) for port '{port.name}'. Valid range is 0 to {num_modes - 1}."
+                )
+
+    def _validate_wave_port_mode_index(self) -> None:
+        """Validate that mode_index is within range for WavePort instances.
+
+        This validation only happens for ports where mode_spec.num_modes was originally 'auto'.
+        """
+        for port in self._wave_ports:
+            mode_index = port.mode_index
+            if mode_index is None:
+                continue
+
+            # Only validate if the original mode_spec.num_modes was 'auto'
+            # (if it was not 'auto', validation already happened in WavePort)
+            if port.mode_spec.num_modes != "auto":
+                continue
+
+            num_modes = self._resolved_mode_specs[port.name].num_modes
+            if mode_index >= num_modes:
+                raise ValidationError(
+                    f"'mode_index' is >= "
+                    f"'mode_spec.num_modes' ({num_modes}) for port '{port.name}'. Valid range is 0 to {num_modes - 1}."
+                )
+
+    def _warn_multimode_absorption(self) -> None:
+        """Warn when absorber is enabled with multiple modes.
+
+        This validation happens after mode_spec is fully resolved with integer num_modes.
+        """
+        for port in self._wave_ports + self._terminal_wave_ports:
+            # Check if absorber is enabled (True or a boundary spec object)
+            if not port.absorber:
+                continue
+
+            # for waveport where num_modes is integer, it's already validated in WavePort.
+            if isinstance(port, WavePort) and port.mode_spec.num_modes != "auto":
+                continue
+
+            # Get the resolved mode spec for this port
+            resolved_mode_spec = self._resolved_mode_specs.get(port.name)
+
+            num_modes = resolved_mode_spec.num_modes
+            if num_modes > 1:
+                log.warning(
+                    f"Port '{port.name}': Absorber is enabled with {num_modes} modes. "
+                    "Absorption is not properly implemented for multimode cases yet and will be "
+                    "added in a future release. For now, please extend the transmission line into the PML region."
+                )
+
     @staticmethod
     def _check_grid_size_at_ports(
         simulation: Simulation, ports: list[Union[LumpedPort, CoaxialLumpedPort]]
@@ -880,8 +1706,54 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         """A list of all wave ports in the :class:`.TerminalComponentModeler`"""
         return [port for port in self.ports if isinstance(port, WavePort)]
 
+    @cached_property
+    def _terminal_wave_ports(self) -> list[TerminalWavePort]:
+        """A list of all terminal wave ports in the :class:`.TerminalComponentModeler`"""
+        return [port for port in self.ports if isinstance(port, TerminalWavePort)]
+
+    @cached_property
+    def _floating_isolated_conductors_at_waveport(
+        self,
+    ) -> dict[str, dict[str, tuple[Shapely, Box]]]:
+        """A dictionary mapping port names to isolated floating conductors at wave ports.
+        Queries both WavePort and TerminalWavePort.
+
+        Each conductor (terminal) is identified by its label and maps to a tuple of (shape, bounding_box).
+        """
+        conductors_dict = {}
+        sim = self._base_sim_with_grid_and_lumped_elements
+        interior_disjoint_geometries = ModePlaneAnalyzer.apply_interior_disjoint_geometries(
+            self.structure_priority_mode
+        )
+        for port in self._terminal_wave_ports + self._wave_ports:
+            conductors_dict[port.name] = port._get_isolated_floating_conductors(
+                sim.volumetric_structures,
+                sim.grid,
+                sim.symmetry,
+                sim.simulation_geometry,
+                interior_disjoint_geometries=interior_disjoint_geometries,
+            )
+        return conductors_dict
+
+    @cached_property
+    def _resolved_mode_specs(self) -> dict[str, MicrowaveModeSpecType]:
+        """Returns a dict mapping port names to their mode specs."""
+        mode_specs = {}
+
+        for port in self._wave_ports + self._terminal_wave_ports:
+            mode_spec = port._mode_spec
+            # handled unresolved mode spec here.
+            if mode_spec is None:
+                # Get number of conductors
+                conductors = self._floating_isolated_conductors_at_waveport[port.name]
+                mode_spec = port._mode_spec_from_isolated_floating_conductors(conductors)
+
+            mode_specs[port.name] = mode_spec
+
+        return mode_specs
+
     @staticmethod
-    def _set_port_data_array_attributes(data_array: PortDataArray) -> PortDataArray:
+    def _set_port_data_array_attributes(data_array: TerminalPortDataArray) -> TerminalPortDataArray:
         """Helper to set additional metadata for ``PortDataArray``."""
         data_array.name = "Z0"
         return data_array.assign_attrs(units=OHM, long_name="characteristic impedance")
@@ -911,8 +1783,13 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
 
     def task_name_from_index(self, source_index: NetworkIndex) -> str:
         """Compute task name for a given network index without constructing simulations."""
-        port, mode_index = self.network_dict[source_index]
-        return self.get_task_name(port=port, mode_index=mode_index)
+        port, selection_index = self.network_dict[source_index]
+        if isinstance(port, TerminalWavePort):
+            return self.get_task_name(port=port, terminal_label=selection_index)
+        elif isinstance(port, WavePort):
+            return self.get_task_name(port=port, mode_index=selection_index)
+        else:
+            return self.get_task_name(port=port)
 
     def _extrude_port_structures(self, sim: Simulation) -> Simulation:
         """

--- a/tidy3d/plugins/smatrix/component_modelers/viz.py
+++ b/tidy3d/plugins/smatrix/component_modelers/viz.py
@@ -1,0 +1,111 @@
+"""Utilities for plotting terminal component modeler elements"""
+
+from __future__ import annotations
+
+""" Constants """
+TERMINAL_BOX_COLOR = "tab:orange"
+TERMINAL_BOX_LINEWIDTH = 1.5
+TERMINAL_BOX_LINESTYLE = "--"
+TERMINAL_BOX_ZORDER = 10
+TERMINAL_LABEL_FONTSIZE = 12
+TERMINAL_LABEL_ZORDER = 11
+TERMINAL_ARROW_LINEWIDTH = 0.8
+TERMINAL_ARROW_ALPHA = 0.6
+
+DIFF_PAIR_BOX_COLOR = "tab:blue"
+DIFF_PAIR_BOX_LINEWIDTH = 1.5
+DIFF_PAIR_BOX_LINESTYLE = "--"
+DIFF_PAIR_BOX_ZORDER = 10
+DIFF_PAIR_LABEL_FONTSIZE = 12
+DIFF_PAIR_LABEL_ZORDER = 11
+DIFF_PAIR_ARROW_LINEWIDTH = 0.8
+DIFF_PAIR_ARROW_ALPHA = 0.6
+
+PADDING_SHADE_COLOR = "dimgray"
+PADDING_SHADE_ALPHA = 0.4
+PADDING_SHADE_HATCH = "x"
+PADDING_SHADE_ZORDER = 1000
+PADDING_SHADE_EDGECOLOR = "black"
+PADDING_SHADE_LINEWIDTH = 0
+
+# Plotting parameters for terminal bounding boxes
+plot_params_terminal_box = {
+    "linewidth": TERMINAL_BOX_LINEWIDTH,
+    "edgecolor": TERMINAL_BOX_COLOR,
+    "facecolor": "none",
+    "linestyle": TERMINAL_BOX_LINESTYLE,
+    "zorder": TERMINAL_BOX_ZORDER,
+}
+
+# Plotting parameters for terminal annotation labels (placed above boxes)
+plot_params_terminal_label = {
+    "fontsize": TERMINAL_LABEL_FONTSIZE,
+    "color": TERMINAL_BOX_COLOR,
+    "ha": "center",
+    "va": "bottom",
+    "zorder": TERMINAL_LABEL_ZORDER,
+    # Improve readability when labels overlap simulation geometry.
+    "bbox": {
+        "boxstyle": "round,pad=0.2",
+        "facecolor": "white",
+        "edgecolor": "none",
+        "alpha": 0.7,
+    },
+}
+
+# Arrow properties for terminal annotations
+plot_params_terminal_arrow = {
+    "arrowstyle": "-",
+    "color": TERMINAL_BOX_COLOR,
+    "lw": TERMINAL_ARROW_LINEWIDTH,
+    "alpha": TERMINAL_ARROW_ALPHA,
+    # Make leader lines look cleaner / less likely to intersect awkwardly.
+    "connectionstyle": "angle3",
+    "shrinkA": 2,
+    "shrinkB": 2,
+}
+
+# Plotting parameters for differential pair bounding boxes
+plot_params_diff_pair_box = {
+    "linewidth": DIFF_PAIR_BOX_LINEWIDTH,
+    "edgecolor": DIFF_PAIR_BOX_COLOR,
+    "facecolor": "none",
+    "linestyle": DIFF_PAIR_BOX_LINESTYLE,
+    "zorder": DIFF_PAIR_BOX_ZORDER,
+}
+
+# Plotting parameters for differential pair annotation labels (placed below boxes)
+plot_params_diff_pair_label = {
+    "fontsize": DIFF_PAIR_LABEL_FONTSIZE,
+    "color": DIFF_PAIR_BOX_COLOR,
+    "ha": "center",
+    "va": "top",
+    "zorder": DIFF_PAIR_LABEL_ZORDER,
+    "bbox": {
+        "boxstyle": "round,pad=0.2",
+        "facecolor": "white",
+        "edgecolor": "none",
+        "alpha": 0.7,
+    },
+}
+
+# Arrow properties for differential pair annotations
+plot_params_diff_pair_arrow = {
+    "arrowstyle": "-",
+    "color": DIFF_PAIR_BOX_COLOR,
+    "lw": DIFF_PAIR_ARROW_LINEWIDTH,
+    "alpha": DIFF_PAIR_ARROW_ALPHA,
+    "connectionstyle": "angle3",
+    "shrinkA": 2,
+    "shrinkB": 2,
+}
+
+# Plotting parameters for padding region shading (outside port bounds)
+plot_params_padding_shade = {
+    "facecolor": PADDING_SHADE_COLOR,
+    "alpha": PADDING_SHADE_ALPHA,
+    "hatch": PADDING_SHADE_HATCH,
+    "edgecolor": PADDING_SHADE_EDGECOLOR,
+    "linewidth": PADDING_SHADE_LINEWIDTH,
+    "zorder": PADDING_SHADE_ZORDER,
+}

--- a/tidy3d/plugins/smatrix/data/terminal.py
+++ b/tidy3d/plugins/smatrix/data/terminal.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 from pydantic import Field
@@ -27,22 +27,28 @@ from tidy3d.plugins.smatrix.utils import (
 )
 
 if TYPE_CHECKING:
-    from typing import Union
-
     from tidy3d.components.data.monitor_data import MonitorData
     from tidy3d.components.data.sim_data import SimulationData
     from tidy3d.components.microwave.data.monitor_data import AntennaMetricsData
     from tidy3d.plugins.smatrix.data.data_array import PortNameDataArray
     from tidy3d.plugins.smatrix.types import NetworkIndex
 
+# Accepted types for the renormalized_reference_impedance field.
+# - complex: uniform impedance applied to all ports (diagonal matrix)
+# - PortDataArray: per-port impedance with dims (f, port) → diagonal matrix
+# - TerminalPortDataArray: full impedance matrix with dims (f, port_out, port_in)
+RenormalizedReferenceImpedance = Union[complex, TerminalPortDataArray, PortDataArray]
+
 
 class MicrowaveSMatrixData(MicrowaveBaseModel):
     """Stores the computed S-matrix and reference impedances for the terminal ports."""
 
-    port_reference_impedances: Optional[PortDataArray] = Field(
+    port_reference_impedances: Optional[TerminalPortDataArray] = Field(
         None,
         title="Port Reference Impedances",
-        description="Reference impedance for each port used in the S-parameter calculation. This is optional and may not be present if not specified or computed.",
+        description="Reference impedance matrix for each port used in the S-parameter calculation. "
+        "Has dimensions (f, port_out, port_in) to support coupled impedances from TerminalWavePort. "
+        "For WavePort and LumpedPort, the impedance matrix is diagonal.",
     )
 
     data: TerminalPortDataArray = Field(
@@ -106,6 +112,92 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
         description="The original :class:`.TerminalComponentModeler` object that defines the simulation setup "
         "and from which this data was generated.",
     )
+
+    renormalized_reference_impedance: Optional[RenormalizedReferenceImpedance] = Field(
+        None,
+        title="Renormalized Reference Impedance",
+        description="When set, overrides port_reference_impedances for all S-matrix computations. "
+        "Accepts: complex (uniform), PortDataArray (per-port diagonal), "
+        "or TerminalPortDataArray (full matrix).",
+    )
+
+    def renormalize(
+        self, reference_impedance: RenormalizedReferenceImpedance
+    ) -> TerminalComponentModelerData:
+        """Return a new instance whose S-matrix is renormalized to a different reference impedance.
+
+        The returned object recomputes wave amplitudes from the cached voltage/current
+        data using the new reference impedance, so all downstream methods
+        (:meth:`smatrix`, :meth:`s_to_z`, :meth:`compute_port_wave_amplitude_matrices`, etc.)
+        automatically reflect the new impedance.
+
+        Parameters
+        ----------
+        reference_impedance : RenormalizedReferenceImpedance
+            The new reference impedance. Accepts:
+
+            - ``complex`` — uniform impedance applied to all ports (e.g. ``50``)
+            - :class:`.PortDataArray` — per-port impedance with dims ``(f, port)``
+            - :class:`.TerminalPortDataArray` — full impedance matrix ``(f, port_out, port_in)``
+
+        Returns
+        -------
+        :class:`.TerminalComponentModelerData`
+            A copy of this object with the new reference impedance applied.
+
+        Examples
+        --------
+        >>> s_50 = modeler_data.renormalize(50).smatrix()  # doctest: +SKIP
+        """
+        return self.updated_copy(renormalized_reference_impedance=reference_impedance)
+
+    def _build_reference_impedance_matrix(
+        self, value: RenormalizedReferenceImpedance
+    ) -> TerminalPortDataArray:
+        """Convert any accepted impedance input to a full ``TerminalPortDataArray``.
+
+        Parameters
+        ----------
+        value : RenormalizedReferenceImpedance
+            The reference impedance value to convert.
+
+        Returns
+        -------
+        :class:`.TerminalPortDataArray`
+            Impedance matrix with dimensions ``(f, port_out, port_in)``.
+        """
+        network_indices = list(self.modeler.matrix_indices_monitor)
+        num_ports = len(network_indices)
+        freqs = np.array(self.modeler.freqs)
+        num_freqs = len(freqs)
+
+        coords = {
+            "f": freqs,
+            "port_out": network_indices,
+            "port_in": network_indices,
+        }
+
+        if isinstance(value, TerminalPortDataArray):
+            return value
+
+        if isinstance(value, PortDataArray):
+            # Per-port diagonal: PortDataArray has dims (f, port)
+            values = np.zeros((num_freqs, num_ports, num_ports), dtype=complex)
+            for i, port_name in enumerate(network_indices):
+                values[:, i, i] = value.sel(port=port_name).values
+            return TerminalPortDataArray(values, coords=coords)
+
+        if isinstance(value, (int, float, complex)):
+            # Uniform scalar → diagonal matrix
+            values = np.zeros((num_freqs, num_ports, num_ports), dtype=complex)
+            for i in range(num_ports):
+                values[:, i, i] = complex(value)
+            return TerminalPortDataArray(values, coords=coords)
+
+        raise TypeError(
+            f"Unsupported type for renormalized_reference_impedance: {type(value).__name__}. "
+            "Expected complex, PortDataArray, TerminalPortDataArray, or 'Z0'."
+        )
 
     def smatrix(
         self,
@@ -215,7 +307,9 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
             else:
                 # Collect corresponding mode_data
                 mode_data = mode_map[port._mode_monitor_name]
-                for mode_index in port._mode_indices:
+                for mode_index in port._mode_indices(
+                    mode_spec=self.modeler._resolved_mode_specs.get(port.name)
+                ):
                     network_index = self.modeler.network_index(port, mode_index)
                     idx = smatrix.data.indexes["port_in"].get_loc(network_index)
                     shifts_vec[idx] = port_shifts.sel(port=shift_name).values
@@ -280,8 +374,8 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
         :class:`.MonitorData`
             Normalized monitor data scaled to the desired port amplitude.
         """
-        port, mode_index = self.modeler.network_dict[port_index]
-        sim_data_port = self.data[self.modeler.get_task_name(port, mode_index)]
+        task_name = self.modeler.task_name_from_index(port_index)
+        sim_data_port = self.data[task_name]
         monitor_data = sim_data_port[monitor_name]
         if not isinstance(a_port, FreqDataArray):
             freqs = list(monitor_data.monitor.freqs)
@@ -337,19 +431,24 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
         return antenna_metrics_data
 
     @cached_property
-    def port_reference_impedances(self) -> PortDataArray:
-        """Calculates the reference impedance for each port across all frequencies.
+    def port_reference_impedances(self) -> TerminalPortDataArray:
+        """Calculates the reference impedance matrix for each port across all frequencies.
 
         This function determines the characteristic impedance for every port defined
-        in the modeler. It handles two types of ports differently: for a
-        :class:`.WavePort`, the impedance is frequency-dependent and computed from
-        modal properties, while for other types like :class:`.LumpedPort`, the
-        impedance is a user-defined constant value.
+        in the modeler. It returns a matrix with dimensions (f, port_out, port_in)
+        to support coupled impedances from :class:`.TerminalWavePort`. For
+        :class:`.WavePort` and :class:`.LumpedPort`, the impedance matrix is diagonal.
+
+        When :attr:`renormalized_reference_impedance` is set, returns the
+        user-specified impedance instead of the simulation-derived one.
 
         Returns:
-            A data array containing the complex impedance for each port at each
-            frequency.
+            A :class:`.TerminalPortDataArray` containing the complex impedance matrix
+            with dimensions (f, port_out, port_in) for each frequency.
         """
+        if self.renormalized_reference_impedance is not None:
+            return self._build_reference_impedance_matrix(self.renormalized_reference_impedance)
+
         from tidy3d.plugins.smatrix.analysis.terminal import port_reference_impedances
 
         return port_reference_impedances(self)
@@ -357,7 +456,7 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
     def compute_wave_amplitudes_at_each_port(
         self,
         sim_data: SimulationData,
-        port_reference_impedances: Optional[PortDataArray] = None,
+        port_reference_impedances: Optional[TerminalPortDataArray] = None,
         s_param_def: SParamDef = "pseudo",
     ) -> tuple[PortDataArray, PortDataArray]:
         """Compute the incident and reflected amplitudes at each port.
@@ -367,8 +466,9 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
         ----------
         sim_data : :class:`.SimulationData`
             Results from the simulation.
-        port_reference_impedances : :class:`.PortDataArray`, optional
-            Reference impedance at each port. If not provided, it is computed from the cached
+        port_reference_impedances : :class:`.TerminalPortDataArray`, optional
+            Reference impedance matrix with dimensions (f, port_out, port_in).
+            If not provided, it is computed from the cached
             property :meth:`.port_reference_impedances`. Defaults to ``None``.
         s_param_def : SParamDef
             Wave definition: "pseudo", "power", or "symmetric_pseudo".
@@ -397,7 +497,7 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
     def compute_power_wave_amplitudes_at_each_port(
         self,
         sim_data: SimulationData,
-        port_reference_impedances: Optional[PortDataArray] = None,
+        port_reference_impedances: Optional[TerminalPortDataArray] = None,
     ) -> tuple[PortDataArray, PortDataArray]:
         """Compute the incident and reflected power wave amplitudes at each port.
         The computed amplitudes have not been normalized.
@@ -406,8 +506,9 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
         ----------
         sim_data : :class:`.SimulationData`
             Results from the simulation.
-        port_reference_impedances : :class:`.PortDataArray`, optional
-            Reference impedance at each port. If not provided, it is computed from the cached
+        port_reference_impedances : :class:`.TerminalPortDataArray`, optional
+            Reference impedance matrix with dimensions (f, port_out, port_in).
+            If not provided, it is computed from the cached
             property :meth:`.port_reference_impedances`. Defaults to ``None``.
 
         Returns
@@ -421,28 +522,17 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
 
     def s_to_z(
         self,
-        reference: Union[complex, PortDataArray],
         assume_ideal_excitation: Optional[bool] = None,
         s_param_def: SParamDef = "pseudo",
     ) -> TerminalPortDataArray:
-        """Converts the S-matrix to the Z-matrix using a specified reference impedance.
+        """Converts the S-matrix to the Z-matrix using the port reference impedances.
 
         This method first computes the S-matrix of the device and then transforms it into the
-        corresponding impedance matrix (Z-matrix). The conversion can be performed using either a
-        single, uniform reference impedance for all ports or a more general set of per-port,
-        frequency-dependent reference impedances.
-
-        This method :meth:`.TerminalComponentModelerData.s_to_z` is called on a
-        :class:`.TerminalComponentModelerData` object, which contains the S-matrix and other
-        simulation data internally.
+        corresponding impedance matrix (Z-matrix), using the reference impedances from
+        :meth:`port_reference_impedances`.
 
         Parameters
         ----------
-        reference : Union[complex, :class:`.PortDataArray`]
-            The reference impedance(s) to use for the conversion. If a single complex value is
-            provided, it is assumed to be the reference impedance for all ports. If a
-            :class:`.PortDataArray` is given, it should contain the specific reference
-            impedance for each port.
         assume_ideal_excitation: If ``True``, assumes that exciting one port
             does not produce incident waves at other ports. This simplifies the
             S-matrix calculation and is required if not all ports are excited. If not
@@ -459,7 +549,7 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
 
         Examples
         --------
-        >>> z_matrix = component_modeler_data.s_to_z(reference=50) # doctest: +SKIP
+        >>> z_matrix = component_modeler_data.s_to_z() # doctest: +SKIP
         >>> z_11 = z_matrix.sel(port_out="port_1@0", port_in="port_1@0") # doctest: +SKIP
 
         See Also
@@ -469,7 +559,11 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
         s_matrix = self.smatrix(
             assume_ideal_excitation=assume_ideal_excitation, s_param_def=s_param_def
         )
-        return s_to_z(s_matrix=s_matrix.data, reference=reference, s_param_def=s_param_def)
+        return s_to_z(
+            s_matrix=s_matrix.data,
+            reference=self.port_reference_impedances,
+            s_param_def=s_param_def,
+        )
 
     @cached_property
     def port_voltage_current_matrices(self) -> tuple[TerminalPortDataArray, TerminalPortDataArray]:
@@ -507,8 +601,7 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
         port_current_matrix = port_voltage_matrix.copy(deep=True)
 
         for source_index in self.modeler.matrix_indices_run_sim:
-            port, mode_index = self.modeler.network_dict[source_index]
-            task_name = self.modeler.get_task_name(port, mode_index)
+            task_name = self.modeler.task_name_from_index(source_index)
             sim_data = self.data[task_name]
             port_voltages, port_currents = _compute_port_voltages_currents(self.modeler, sim_data)
             indexer = {"port_in": source_index}

--- a/tidy3d/plugins/smatrix/ports/base_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/base_lumped.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import Field, PositiveInt
 
@@ -75,18 +75,22 @@ class AbstractLumpedPort(AbstractTerminalPort):
 
     @abstractmethod
     def to_voltage_monitor(
-        self, freqs: FreqArray, snap_center: Optional[float] = None
+        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Optional[Grid] = None
     ) -> FieldMonitor:
         """Field monitor to compute port voltage."""
 
     @abstractmethod
     def to_current_monitor(
-        self, freqs: FreqArray, snap_center: Optional[float] = None
+        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Optional[Grid] = None
     ) -> FieldMonitor:
         """Field monitor to compute port current."""
 
     def to_monitors(
-        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Grid = None
+        self,
+        freqs: FreqArray,
+        snap_center: Optional[float] = None,
+        grid: Optional[Grid] = None,
+        **kwargs: Any,
     ) -> list[FieldMonitor]:
         """Field monitors to compute port voltage and current."""
         return [

--- a/tidy3d/plugins/smatrix/ports/base_terminal.py
+++ b/tidy3d/plugins/smatrix/ports/base_terminal.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.microwave.base import MicrowaveBaseModel
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from tidy3d.components.grid.grid import Grid
     from tidy3d.components.monitor import FieldMonitor, ModeMonitor
     from tidy3d.components.source.base import Source
-    from tidy3d.components.source.time import GaussianPulse
+    from tidy3d.components.source.time import SourceTimeType
     from tidy3d.components.types import FreqArray
 
 
@@ -35,12 +35,16 @@ class AbstractTerminalPort(AbstractBasePort, MicrowaveBaseModel):
 
     @abstractmethod
     def to_source(
-        self, source_time: GaussianPulse, snap_center: Optional[float] = None, grid: Grid = None
+        self,
+        source_time: SourceTimeType,
+        snap_center: Optional[float] = None,
+        grid: Optional[Grid] = None,
+        **kwargs: Any,
     ) -> Source:
         """Create a current source from a terminal-based port."""
 
     def to_field_monitors(
-        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Grid = None
+        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Optional[Grid] = None
     ) -> Union[list[FieldMonitor], list[ModeMonitor]]:
         """DEPRECATED: Monitors used to compute the port voltage and current."""
         log.warning(
@@ -51,7 +55,11 @@ class AbstractTerminalPort(AbstractBasePort, MicrowaveBaseModel):
 
     @abstractmethod
     def to_monitors(
-        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Grid = None
+        self,
+        freqs: FreqArray,
+        snap_center: Optional[float] = None,
+        grid: Optional[Grid] = None,
+        **kwargs: Any,
     ) -> Union[list[FieldMonitor], list[ModeMonitor]]:
         """Monitors used to compute the port voltage and current."""
 

--- a/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from pydantic import Field, PositiveFloat, field_validator, model_validator
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from tidy3d.components.data.data_array import FreqDataArray
     from tidy3d.components.data.sim_data import SimulationData
     from tidy3d.components.grid.grid import Grid, YeeGrid
-    from tidy3d.components.source.time import GaussianPulse
+    from tidy3d.components.source.time import SourceTimeType
     from tidy3d.components.types import FreqArray, Size
 
 DEFAULT_COAX_SOURCE_NUM_POINTS = 11
@@ -115,7 +115,11 @@ class CoaxialLumpedPort(AbstractLumpedPort, AbstractAxesRH):
         return self
 
     def to_source(
-        self, source_time: GaussianPulse, snap_center: Optional[float] = None, grid: Grid = None
+        self,
+        source_time: SourceTimeType,
+        snap_center: Optional[float] = None,
+        grid: Optional[Grid] = None,
+        **kwargs: Any,
     ) -> CustomCurrentSource:
         """Create a current source from the lumped port."""
         # Discretized source amps are manually zeroed out later if they
@@ -225,7 +229,7 @@ class CoaxialLumpedPort(AbstractLumpedPort, AbstractAxesRH):
         )
 
     def to_voltage_monitor(
-        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Grid = None
+        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Optional[Grid] = None
     ) -> FieldMonitor:
         """Field monitor to compute port voltage."""
         center = list(self.center)
@@ -249,7 +253,7 @@ class CoaxialLumpedPort(AbstractLumpedPort, AbstractAxesRH):
         )
 
     def to_current_monitor(
-        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Grid = None
+        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Optional[Grid] = None
     ) -> FieldMonitor:
         """Field monitor to compute port current."""
         center = list(self.center)

--- a/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from tidy3d.components.data.sim_data import SimulationData
     from tidy3d.components.grid.grid import Grid, YeeGrid
     from tidy3d.components.lumped_element import LumpedResistor
-    from tidy3d.components.source.time import GaussianPulse
+    from tidy3d.components.source.time import SourceTimeType
     from tidy3d.components.structure import Structure
     from tidy3d.components.types import FreqArray
 
@@ -116,7 +116,11 @@ class LumpedPort(AbstractLumpedPort, Box):
         return 3 - self.injection_axis - self.voltage_axis
 
     def to_source(
-        self, source_time: GaussianPulse, snap_center: Optional[float] = None, grid: Grid = None
+        self,
+        source_time: SourceTimeType,
+        snap_center: Optional[float] = None,
+        grid: Optional[Grid] = None,
+        **kwargs: Any,
     ) -> UniformCurrentSource:
         """Create a current source from the lumped port."""
         if grid:
@@ -166,7 +170,7 @@ class LumpedPort(AbstractLumpedPort, Box):
         )
 
     def to_voltage_monitor(
-        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Grid = None
+        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Optional[Grid] = None
     ) -> FieldMonitor:
         """Field monitor to compute port voltage."""
         if grid:
@@ -194,7 +198,7 @@ class LumpedPort(AbstractLumpedPort, Box):
         )
 
     def to_current_monitor(
-        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Grid = None
+        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Optional[Grid] = None
     ) -> FieldMonitor:
         """Field monitor to compute port current."""
         if grid:

--- a/tidy3d/plugins/smatrix/ports/types.py
+++ b/tidy3d/plugins/smatrix/ports/types.py
@@ -11,10 +11,11 @@ from tidy3d.components.data.data_array import (
 from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
 from tidy3d.plugins.smatrix.ports.modal import Port
 from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
-from tidy3d.plugins.smatrix.ports.wave import WavePort
+from tidy3d.plugins.smatrix.ports.wave import TerminalWavePort, WavePort
 
 LumpedPortType = Union[LumpedPort, CoaxialLumpedPort]
-TerminalPortType = Union[LumpedPortType, WavePort]
+WavePortType = Union[WavePort, TerminalWavePort]
+TerminalPortType = Union[LumpedPortType, WavePortType]
 PortType = Union[Port, TerminalPortType]
 PortVoltageType = Union[VoltageFreqDataArray, VoltageFreqModeDataArray]
 PortCurrentType = Union[CurrentFreqDataArray, CurrentFreqModeDataArray]

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -2,54 +2,79 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
+import numpy as np
+import xarray as xr
 from pydantic import Field, NonNegativeInt, field_validator, model_validator
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.boundary import ABCBoundary, InternalAbsorber, ModeABCBoundary
+from tidy3d.components.data.data_array import (
+    FreqModeDataArray,
+    ImpedanceFreqModeModeDataArray,
+    ImpedanceFreqTerminalTerminalDataArray,
+    ImpedanceModeDataArray,
+    ImpedanceTerminalDataArray,
+)
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.geometry.base import Box
-from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
+from tidy3d.components.microwave.mode_spec import (
+    MONITOR_COLOCATE,
+    MicrowaveModeSpec,
+    MicrowaveTerminalModeSpec,
+)
 from tidy3d.components.microwave.monitor import MicrowaveModeMonitor
+from tidy3d.components.microwave.path_integrals.mode_plane_analyzer import ModePlaneAnalyzer
+from tidy3d.components.microwave.path_integrals.specs.impedance import (
+    AutoImpedanceSpec,
+    CustomImpedanceSpec,
+)
+from tidy3d.components.microwave.source import MicrowaveTerminalSource
 from tidy3d.components.source.field import ModeSource
 from tidy3d.components.source.frame import PECFrame
 from tidy3d.components.structure import MeshOverrideStructure
-from tidy3d.components.types import Direction
+from tidy3d.components.types import Complex, Direction
+from tidy3d.components.validators import assert_plane
+from tidy3d.constants import OHM
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 from tidy3d.plugins.mode import ModeSolver
 from tidy3d.plugins.smatrix.ports.base_terminal import AbstractTerminalPort
 
 if TYPE_CHECKING:
-    from pydantic import NonNegativeFloat
+    from pydantic import NonNegativeFloat, ValidationInfo
 
     from tidy3d.compat import Self
-    from tidy3d.components.data.data_array import FreqDataArray, FreqModeDataArray
+    from tidy3d.components.data.data_array import (
+        CurrentFreqTerminalDataArray,
+        VoltageFreqTerminalDataArray,
+    )
     from tidy3d.components.grid.grid import Grid
     from tidy3d.components.microwave.data.monitor_data import MicrowaveModeData
+    from tidy3d.components.microwave.mode_spec import MicrowaveModeSpecType
     from tidy3d.components.simulation import Simulation
-    from tidy3d.components.source.time import GaussianPulse
-    from tidy3d.components.types import Axis, FreqArray
+    from tidy3d.components.source.time import SourceTimeType
+    from tidy3d.components.structure import Structure
+    from tidy3d.components.types import Axis, FreqArray, Shapely, Symmetry
 
 DEFAULT_WAVE_PORT_NUM_CELLS = 5
 MIN_WAVE_PORT_NUM_CELLS = 3
 DEFAULT_WAVE_PORT_FRAME = PECFrame()
+DEFAULT_REFERENCE_IMPEDANCE_VALUE = 50
+DEFAULT_TERMINAL_LABEL_PREFIX = "T"
+DEFAULT_DIFFERENTIAL_PAIR_LABEL_PREFIX = "Diff"
 
 
-class WavePort(AbstractTerminalPort, Box):
-    """Class representing a single wave port"""
+class AbstractWavePort(AbstractTerminalPort, Box):
+    """Class representing a single terminal-based port that requires 2D mode solving."""
+
+    _plane_validator = assert_plane()
 
     direction: Direction = Field(
         title="Direction",
         description="'+' or '-', defining which direction is considered 'input'.",
-    )
-
-    mode_spec: MicrowaveModeSpec = Field(
-        default_factory=MicrowaveModeSpec._default_without_license_warning,
-        title="Mode Specification",
-        description="Parameters to feed to mode solver which determine modes and how transmission line "
-        "quantities, e.g., charateristic impedance, are computed.",
     )
 
     num_grid_cells: Optional[int] = Field(
@@ -86,22 +111,141 @@ class WavePort(AbstractTerminalPort, Box):
         description="Extrudes structures that intersect the wave port plane by a few grid cells when ``True``, improving mode injection accuracy.",
     )
 
-    mode_index: Optional[NonNegativeInt] = Field(
-        None,
-        title="Mode Index (deprecated)",
-        description="Index into the collection of modes returned by mode solver. "
-        "Specifies which mode to inject using this port. "
-        "Deprecated. Use the 'mode_selection' field instead.",
+    reference_impedance: Union[
+        Literal["Z0"], Complex, ImpedanceModeDataArray, ImpedanceTerminalDataArray
+    ] = Field(
+        "Z0",
+        title="Reference Impedance",
+        description="User-specified reference impedance for S-parameter computation. "
+        "If ``Z0`` (default), the characteristic impedance "
+        "is used. Otherwise, it can be a single complex value applied to all modes, or a data array "
+        f"specified for each. If the data array misses some modes, {DEFAULT_REFERENCE_IMPEDANCE_VALUE} "
+        "Ohm is applied to the missing ones.",
+        json_schema_extra={"units": OHM},
     )
 
-    mode_selection: Optional[tuple[int, ...]] = Field(
-        None,
-        title="Mode Selection",
-        description="Selects specific mode(s) to use from the mode solver. "
-        "Can be a single integer for one mode, or a tuple of integers for multiple modes. "
-        "If ``None`` (default), all modes from the ``mode_spec`` are used. "
-        "Indices must be non-negative and less than ``mode_spec.num_modes``.",
-    )
+    @field_validator("reference_impedance")
+    @classmethod
+    def _validate_reference_impedance_positive(
+        cls, val: Union[Literal["Z0"], Complex, ImpedanceModeDataArray, ImpedanceTerminalDataArray]
+    ) -> Union[Literal["Z0"], Complex, ImpedanceModeDataArray, ImpedanceTerminalDataArray]:
+        """Validate that reference impedance has positive real part."""
+        # Skip validation for "Z0"
+        if val == "Z0":
+            return val
+
+        # Handle scalar complex values
+        if isinstance(val, (int, float, complex)):
+            if not np.isfinite(val):
+                raise ValidationError(f"Reference impedance must be finite. Got {val}.")
+            if np.real(val) <= 0:
+                raise ValidationError(
+                    f"Reference impedance must have positive real part. Got {val} with real part {np.real(val)}."
+                )
+            return val
+
+        # Handle DataArray (ImpedanceModeDataArray or ImpedanceTerminalDataArray)
+        values = val.values
+        if not np.all(np.isfinite(values)):
+            raise ValidationError("All reference impedance values must be finite (no NaN or inf).")
+        # Check all values have positive real part
+        real_parts = np.real(values)
+        if np.any(real_parts <= 0):
+            min_real = np.min(real_parts)
+            raise ValidationError(
+                f"All reference impedance values must have positive real part. "
+                f"Found minimum real part: {min_real}."
+            )
+        return val
+
+    def get_reference_impedance_matrix(
+        self, sim_mode_data: Union[SimulationData, MicrowaveModeData]
+    ) -> Union[ImpedanceFreqModeModeDataArray, ImpedanceFreqTerminalTerminalDataArray]:
+        """Retrieve the reference impedance of the port. In general, it's a diagonal matrix; but
+        it can be a full matrix when the terminals in the port are coupled.
+        """
+        computed_Z0 = self.get_characteristic_impedance_matrix(sim_mode_data)
+
+        # If "Z0", return computed characteristic impedance matrix
+        if self.reference_impedance == "Z0":
+            return computed_Z0
+
+        # User-specified reference impedance - build diagonal matrix
+        # Detect whether computed_Z0 is mode-based or terminal-based
+        is_mode_based = "mode_index_out" in computed_Z0.dims
+
+        if is_mode_based:
+            dim_prefix = "mode"
+            result_cls = ImpedanceFreqModeModeDataArray
+        else:
+            dim_prefix = "terminal"
+            result_cls = ImpedanceFreqTerminalTerminalDataArray
+
+        suffix = "index" if is_mode_based else "label"
+        dim_1d, dim_out, dim_in = (f"{dim_prefix}_{suffix}{s}" for s in ("", "_out", "_in"))
+
+        indices = computed_Z0.coords[dim_out].values
+        num_indices = len(indices)
+
+        # Create identity matrix as xarray DataArray for broadcasting
+        eye = xr.DataArray(
+            np.eye(num_indices),
+            coords={dim_out: indices, dim_in: indices},
+        )
+
+        # Handle scalar Complex vs DataArray reference impedance
+        if isinstance(self.reference_impedance, (int, float, complex)):
+            # Scalar case: create uniform reference values for all indices
+            ref_values = xr.DataArray(
+                np.full(num_indices, self.reference_impedance),
+                coords={dim_1d: indices},
+            )
+        else:
+            # Data array: use values for each mode/terminal, fallback to default for missing ones
+            # Reindex to match indices, filling missing with default value
+            ref_values = self.reference_impedance.reindex(
+                {dim_1d: indices}, fill_value=DEFAULT_REFERENCE_IMPEDANCE_VALUE
+            )
+
+        # Rename and broadcast to diagonal matrix
+        ref_diag = ref_values.rename({dim_1d: dim_out}) * eye
+
+        return result_cls(ref_diag)
+
+    @abstractmethod
+    def get_characteristic_impedance_matrix(
+        self, sim_mode_data: Union[SimulationData, MicrowaveModeData]
+    ) -> Union[ImpedanceFreqModeModeDataArray, ImpedanceFreqTerminalTerminalDataArray]:
+        """Retrieve the characteristic impedance matrix of the port."""
+
+    @cached_property
+    @abstractmethod
+    def _mode_spec(self) -> Optional[MicrowaveModeSpecType]:
+        """Internal mode specification for the port. Return ``None`` if
+        it cannot be resolved in WavePort alone.
+        """
+
+    @abstractmethod
+    def _mode_spec_from_isolated_floating_conductors(
+        self, conductors: dict[str, tuple[Shapely, Box]]
+    ) -> MicrowaveModeSpecType:
+        """Generate a mode specification from isolated floating conductors."""
+
+    @abstractmethod
+    def _mode_indices(self, mode_spec: Optional[MicrowaveModeSpecType] = None) -> tuple[int, ...]:
+        """Return the tuple of mode indices that will be excited and monitored by this port.
+
+        Parameters
+        ----------
+        mode_spec : MicrowaveModeSpecType, optional
+            Resolved mode specification whose ``num_modes`` is an integer.
+            When ``None``, the implementation should fall back to ``self._mode_spec``.
+
+        Returns
+        -------
+        tuple[int, ...]
+            Ordered mode indices for this port.
+        """
 
     @cached_property
     def injection_axis(self) -> Axis:
@@ -120,84 +264,173 @@ class WavePort(AbstractTerminalPort, Box):
         return f"{self.name}_mode"
 
     @cached_property
-    def _mode_indices(self) -> tuple[int, ...]:
-        """Mode indices that will be excited/monitored by this port."""
-        if self.mode_index is not None and self.mode_selection is None:
-            return (self.mode_index,)
-        if self.mode_selection is not None:
-            # User specified specific modes
-            return self.mode_selection
-        # Default: use all modes
-        return tuple(range(self.mode_spec.num_modes))
-
-    def to_source(
-        self,
-        source_time: GaussianPulse,
-        snap_center: Optional[float] = None,
-        mode_index: int = 0,
-    ) -> ModeSource:
-        """Create a mode source from the wave port."""
-        center = list(self.center)
-        if snap_center:
-            center[self.injection_axis] = snap_center
-        return ModeSource(
-            center=tuple(center),
+    def _mode_plane_analyzer(self) -> ModePlaneAnalyzer:
+        """Mode plane analyzer for the port."""
+        return ModePlaneAnalyzer(
+            center=self.center,
             size=self.size,
-            source_time=source_time,
-            mode_spec=self.mode_spec,
-            mode_index=mode_index,
-            direction=self.direction,
-            name=self.name,
-            frame=self.frame,
+            field_data_colocated=MONITOR_COLOCATE,
         )
 
+    def _get_isolated_floating_conductors(
+        self,
+        structures: list[Structure],
+        grid: Grid,
+        symmetry: tuple[Symmetry, Symmetry, Symmetry],
+        sim_box: Box,
+        interior_disjoint_geometries: bool = True,
+    ) -> dict[str, tuple[Shapely, Box]]:
+        """Get isolated floating conductors (terminals) on the port plane.
+
+        Parameters
+        ----------
+        structures : list
+            List of structures in the simulation.
+        grid : Grid
+            Simulation grid for snapping paths.
+        symmetry : tuple[Symmetry, Symmetry, Symmetry]
+            Symmetry conditions for the simulation in (x, y, z) directions.
+        sim_box : Box
+            Simulation domain box used for boundary conditions.
+        interior_disjoint_geometries : bool = True
+            If ``True``, conductors on the plane will not be overridden by other materials,
+            allowing a faster merging path that skips overlap removal.
+
+        Returns
+        -------
+        dict[str, tuple[Shapely, Box]]:
+            Mapping from terminal name to terminal shape and bounding box.
+        """
+        bounding_boxes, shapes = self._mode_plane_analyzer.get_conductor_bounding_boxes(
+            structures,
+            grid,
+            symmetry,
+            sim_box,
+            interior_disjoint_geometries=interior_disjoint_geometries,
+        )
+        labels = [f"{DEFAULT_TERMINAL_LABEL_PREFIX}{i}" for i in range(len(shapes))]
+
+        return {label: (shape, bbox) for label, shape, bbox in zip(labels, shapes, bounding_boxes)}
+
+    def _validate_resolved_mode_spec(
+        self, mode_spec: Optional[MicrowaveModeSpecType] = None
+    ) -> MicrowaveModeSpecType:
+        """If the resolved mode_spec is not provided, validate that self._mode_spec not None."""
+        if mode_spec is not None:
+            if mode_spec.num_modes == "auto":
+                raise SetupError(
+                    "The supplied mode specification has num_modes='auto'. "
+                    "Please pass a mode_spec with an explicit number of modes."
+                )
+            return mode_spec
+
+        if self._mode_spec is None:
+            raise SetupError(
+                "Mode specification cannot be resolved in WavePort alone. "
+                "Please pass a mode_spec with an explicit number of modes."
+            )
+        return self._mode_spec
+
     def to_monitors(
-        self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Grid = None
+        self,
+        freqs: FreqArray,
+        snap_center: Optional[float] = None,
+        grid: Optional[Grid] = None,
+        mode_spec: Optional[MicrowaveModeSpecType] = None,
     ) -> list[MicrowaveModeMonitor]:
-        """The wave port uses a :class:`.MicrowaveModeMonitor` to compute the characteristic impedance
-        and the port voltages and currents."""
+        """Create monitors from the wave port.
+
+        The wave port uses a :class:`.MicrowaveModeMonitor` to compute the characteristic impedance
+        and the port voltages and currents.
+
+        Parameters
+        ----------
+        freqs : FreqArray
+            Frequencies to monitor.
+        snap_center : float, optional
+            Position to snap the monitor center to along injection axis.
+        grid : Grid, optional
+            Simulation grid (unused but kept for API compatibility).
+        mode_spec : MicrowaveModeSpecType, optional
+            Resolved mode specification with integer num_modes. If None,
+            uses self._mode_spec but raises SetupError if num_modes='auto'.
+        """
         center = list(self.center)
         if snap_center:
             center[self.injection_axis] = snap_center
+        # Use provided mode_spec if given, otherwise fall back to self._mode_spec
+        mode_spec = self._validate_resolved_mode_spec(mode_spec)
         mode_mon = MicrowaveModeMonitor(
             center=self.center,
             size=self.size,
             freqs=freqs,
             name=self._mode_monitor_name,
-            colocate=False,
-            mode_spec=self.mode_spec,
+            colocate=MONITOR_COLOCATE,
+            mode_spec=mode_spec,
             store_fields_direction=self.direction,
             conjugated_dot_product=self.conjugated_dot_product,
         )
         return [mode_mon]
 
-    def to_mode_solver(self, simulation: Simulation, freqs: FreqArray) -> ModeSolver:
-        """Helper to create a :class:`.ModeSolver` instance."""
+    def to_mode_solver(
+        self,
+        simulation: Simulation,
+        freqs: FreqArray,
+        mode_spec: Optional[MicrowaveModeSpecType] = None,
+    ) -> ModeSolver:
+        """Helper to create a :class:`.ModeSolver` instance.
+
+        Parameters
+        ----------
+        simulation : Simulation
+            Simulation to solve modes for.
+        freqs : FreqArray
+            Frequencies to solve at.
+        mode_spec : MicrowaveModeSpecType, optional
+            Resolved mode specification with integer num_modes. If None,
+            uses self._mode_spec but raises SetupError if num_modes='auto'.
+        """
+        mode_spec = self._validate_resolved_mode_spec(mode_spec)
         mode_solver = ModeSolver(
             simulation=simulation,
             plane=self.geometry,
-            mode_spec=self.mode_spec,
+            mode_spec=mode_spec,
             freqs=freqs,
             direction=self.direction,
-            colocate=False,
+            colocate=MONITOR_COLOCATE,
         )
         return mode_solver
 
     def to_absorber(
-        self, snap_center: Optional[float] = None, freq_spec: Optional[NonNegativeFloat] = None
+        self,
+        snap_center: Optional[float] = None,
+        freq_spec: Optional[NonNegativeFloat] = None,
+        mode_spec: Optional[MicrowaveModeSpecType] = None,
     ) -> InternalAbsorber:
-        """Create an internal absorber from the wave port."""
+        """Create an internal absorber from the wave port.
+
+        Parameters
+        ----------
+        snap_center : float, optional
+            Position to snap the absorber center to along injection axis.
+        freq_spec : float, optional
+            Frequency specification for the mode ABC boundary.
+        mode_spec : MicrowaveModeSpecType, optional
+            Resolved mode specification with integer num_modes. If None,
+            uses self._mode_spec but raises SetupError if num_modes='auto'.
+        """
         center = list(self.center)
         if snap_center:
             center[self.injection_axis] = snap_center
         if isinstance(self.absorber, (ABCBoundary, ModeABCBoundary)):
             boundary_spec = self.absorber
         else:
+            mode_spec = self._validate_resolved_mode_spec(mode_spec)
             # TODO: ModeABCBoundary currently only accepts one mode, so
-            # we choose the first mode for now
-            mode_index = self._mode_indices[0]
+            # we choose the first mode for now until we have multimodal absorber support.
+            mode_index = self._mode_indices(mode_spec)[0]
             boundary_spec = ModeABCBoundary(
-                mode_spec=self.mode_spec,
+                mode_spec=mode_spec,
                 mode_index=mode_index,
                 plane=self.geometry,
                 freq_spec=freq_spec,
@@ -211,61 +444,6 @@ class WavePort(AbstractTerminalPort, Box):
             else "+",  # absorb in the opposite direction of source
             grid_shift=1,  # absorb in the next pixel
         )
-
-    def compute_voltage(self, sim_data: SimulationData) -> FreqDataArray:
-        """Helper to compute voltage across the port."""
-        mode_data: MicrowaveModeData = sim_data[self._mode_monitor_name]
-        voltage_coeffs = mode_data.transmission_line_data.voltage_coeffs
-        amps = mode_data.amps
-        fwd_amps = amps.sel(direction="+").squeeze()
-        bwd_amps = amps.sel(direction="-").squeeze()
-        return voltage_coeffs * (fwd_amps + bwd_amps)
-
-    def compute_current(self, sim_data: SimulationData) -> FreqDataArray:
-        """Helper to compute current flowing through the port."""
-        mode_data: MicrowaveModeData = sim_data[self._mode_monitor_name]
-        current_coeffs = mode_data.transmission_line_data.current_coeffs
-        amps = mode_data.amps
-        fwd_amps = amps.sel(direction="+").squeeze()
-        bwd_amps = amps.sel(direction="-").squeeze()
-        # In ModeData, fwd_amps and bwd_amps are not relative to
-        # the direction fields are stored
-        sign = 1.0
-        if self.direction == "-":
-            sign = -1.0
-        return sign * current_coeffs * (fwd_amps - bwd_amps)
-
-    def get_port_impedance(
-        self, sim_mode_data: Union[SimulationData, MicrowaveModeData], mode_index: int
-    ) -> FreqModeDataArray:
-        """Retrieve the characteristic impedance of the port for a specific mode.
-
-        The port impedance is computed from the transmission line mode characteristics,
-        which should ideally be TEM (Transverse Electromagnetic) or at least quasi-TEM.
-        The impedance is extracted from the transmission line data computed by the
-        mode solver.
-
-        Parameters
-        ----------
-        sim_mode_data : Union[:class:`.SimulationData`, :class:`.MicrowaveModeData`]
-            Simulation data containing the mode monitor results, or the mode data directly.
-            If :class:`.SimulationData` is provided, the mode data is extracted using the
-            port's mode monitor name.
-        mode_index : int
-            Index of the mode for which to compute the impedance. This selects a specific
-            mode from the mode spectrum computed by the mode solver.
-
-        Returns
-        -------
-        :class:`.FreqModeDataArray`
-            Frequency-dependent characteristic impedance Z0 for the specified mode.
-            The impedance is complex-valued and varies with frequency.
-        """
-        if isinstance(sim_mode_data, SimulationData):
-            mode_data = sim_mode_data[self._mode_monitor_name]
-        else:
-            mode_data = sim_mode_data
-        return mode_data.transmission_line_data.Z0.sel(mode_index=[mode_index])
 
     def to_mesh_overrides(self) -> list[MeshOverrideStructure]:
         """Creates a list of :class:`.MeshOverrideStructure` for mesh refinement in the transverse
@@ -286,24 +464,139 @@ class WavePort(AbstractTerminalPort, Box):
             )
         ]
 
+    def _get_mode_data(
+        self, sim_mode_data: Union[SimulationData, MicrowaveModeData]
+    ) -> MicrowaveModeData:
+        """Get the mode data from the simulation data or mode data directly."""
+        if isinstance(sim_mode_data, SimulationData):
+            return sim_mode_data[self._mode_monitor_name]
+        return sim_mode_data
+
+    @property
+    def _is_using_mesh_refinement(self) -> bool:
+        """Check if this wave port is using mesh refinement options.
+
+        Returns ``True`` if a custom grid cell count is specified.
+        """
+        return self.num_grid_cells is not None
+
     @model_validator(mode="after")
-    def _validate_path_integrals_within_port(self) -> Self:
+    def _check_absorber_if_extruding_structures(self) -> Self:
+        """Raise validation error when ``extrude_structures`` is set to ``True``
+        while ``absorber`` is set to ``False``."""
+
+        if self.extrude_structures and not self.absorber:
+            raise ValidationError(
+                "Structure extrusion for a waveport requires an internal absorber. Set `absorber=True` to enable it."
+            )
+
+        return self
+
+
+class WavePort(AbstractWavePort):
+    """Class representing a single modal-driven wave port.
+
+    Notes
+    -----
+    By default, the characteristic impedance of each mode is used as the reference impedance
+    for S-parameter calculations.
+    """
+
+    mode_spec: MicrowaveModeSpec = Field(
+        default_factory=MicrowaveModeSpec._default_without_license_warning,
+        title="Mode Specification",
+        description="Parameters to feed to mode solver which determine modes and how transmission line "
+        "quantities, e.g., characteristic impedance, are computed.",
+    )
+
+    mode_index: Optional[NonNegativeInt] = Field(
+        None,
+        title="Mode Index (deprecated)",
+        description="Index into the collection of modes returned by mode solver. "
+        "Specifies which mode to inject using this port. "
+        "Deprecated. Use the 'mode_selection' field instead.",
+    )
+
+    mode_selection: Optional[tuple[int, ...]] = Field(
+        None,
+        title="Mode Selection",
+        description="Selects specific mode(s) to use from the mode solver. "
+        "Can be a single integer for one mode, or a tuple of integers for multiple modes. "
+        "If ``None`` (default), all modes from the ``mode_spec`` are used. "
+        "Indices must be non-negative and less than ``mode_spec.num_modes``.",
+    )
+
+    def _mode_indices(self, mode_spec: Optional[MicrowaveModeSpecType] = None) -> tuple[int, ...]:
+        """Return the tuple of mode indices that will be excited and monitored by this port.
+
+        Resolution order:
+
+        1. If ``mode_index`` is set (deprecated), return ``(mode_index,)``.
+        2. If ``mode_selection`` is set, return that tuple directly.
+        3. Otherwise, fall back to ``range(mode_spec.num_modes)``.
+
+        Parameters
+        ----------
+        mode_spec : MicrowaveModeSpecType, optional
+            Resolved mode specification whose ``num_modes`` is an integer.
+            When ``None``, falls back to ``self._mode_spec``; raises
+            ``SetupError`` if ``num_modes`` is still ``'auto'``.
+
+        Returns
+        -------
+        tuple[int, ...]
+            Ordered mode indices for this port.
+        """
+        if self.mode_index is not None and self.mode_selection is None:
+            return (self.mode_index,)
+        if self.mode_selection is not None:
+            return self.mode_selection
+
+        mode_spec = self._validate_resolved_mode_spec(mode_spec)
+        return tuple(range(mode_spec.num_modes))
+
+    @cached_property
+    def _mode_spec(self) -> Optional[MicrowaveModeSpec]:
+        """Mode specification for the port. Return None if it cannot be resolved in WavePort alone."""
+        num_modes = self.mode_spec.num_modes
+        # 1) num_modes already specified
+        if num_modes != "auto":
+            return self.mode_spec
+        # 2) num_modes='auto', and can be refered from the size of impedance_specs
+        impedance_specs = self.mode_spec.impedance_specs
+        if isinstance(impedance_specs, (list, tuple)):
+            return self.mode_spec.updated_copy(num_modes=len(impedance_specs))
+        # 3) num_modes='auto', and cannot be refered from the size of impedance_specs
+        return None
+
+    def _mode_spec_from_isolated_floating_conductors(
+        self, conductors: dict[str, tuple[Shapely, Box]]
+    ) -> MicrowaveModeSpec:
+        """Update num_modes from the number of isolated floating conductors."""
+        return self.mode_spec.updated_copy(num_modes=len(conductors))
+
+    @field_validator("mode_spec", mode="after")
+    @classmethod
+    def _validate_path_integrals_within_port(
+        cls, val: MicrowaveModeSpec, info: ValidationInfo
+    ) -> MicrowaveModeSpec:
         """Validate that the microwave mode spec contains path specs all within the port bounds."""
-        val = self.mode_spec
-        center = self.center
-        size = self.size
+        center = info.data.get("center")
+        size = info.data.get("size")
         self_plane = Box(size=size, center=center)
         try:
             val._check_path_integrals_within_box(self_plane)
         except SetupError as e:
             raise SetupError(
-                f"Failed to setup '{self.__class__.__name__}' with the suppled 'MicrowaveModeSpec'. {e!s}"
+                f"Failed to setup '{cls.__name__}' with the suppled 'MicrowaveModeSpec'. {e!s}"
             ) from e
-        return self
+        return val
 
     @model_validator(mode="after")
     def _validate_mode_selection(self) -> Self:
-        """Validate that mode_selection contains valid, unique indices within range."""
+        """Validate that mode_selection contains valid, unique indices within range.
+        if mode_spec.num_modes is 'auto', it'll be validated in the component modeler.
+        """
         if self.mode_spec is None:
             return self
         val = self.mode_selection
@@ -329,6 +622,8 @@ class WavePort(AbstractTerminalPort, Box):
         # Check that indices are within range of num_modes
         mode_spec = self.mode_spec
         num_modes = mode_spec.num_modes
+        if num_modes == "auto":
+            return self
         invalid_indices = [idx for idx in indices if idx >= num_modes]
         if invalid_indices:
             raise ValidationError(
@@ -338,21 +633,9 @@ class WavePort(AbstractTerminalPort, Box):
 
         return self
 
-    @model_validator(mode="after")
-    def _check_absorber_if_extruding_structures(self) -> Self:
-        """Raise validation error when ``extrude_structures`` is set to ``True``
-        while ``absorber`` is set to ``False``."""
-
-        if self.extrude_structures and not self.absorber:
-            raise ValidationError(
-                "Structure extrusion for a waveport requires an internal absorber. Set `absorber=True` to enable it."
-            )
-
-        return self
-
-    @field_validator("mode_index")
+    @field_validator("mode_index", mode="after")
     @classmethod
-    def _mode_index_deprecated(cls, val: Optional[int]) -> Optional[int]:
+    def _mode_index_deprecated(cls, val: Optional[NonNegativeInt]) -> Optional[NonNegativeInt]:
         """Warn that 'mode_index' is deprecated in favor of 'mode_selection'."""
         if val is not None:
             log.warning(
@@ -363,11 +646,13 @@ class WavePort(AbstractTerminalPort, Box):
 
     @model_validator(mode="after")
     def _validate_mode_index(self) -> Self:
-        """Validate that mode_selection contains valid, unique indices within range."""
+        """Validate that mode_selection contains valid, unique indices within range.
+        if mode_spec.num_modes is 'auto', it'll be validated in the component modeler.
+        """
         val = self.mode_index
         if val is None:
             return self
-        if self.mode_spec is None:
+        if self.mode_spec is None or self.mode_spec.num_modes == "auto":
             return self
         num_modes = self.mode_spec.num_modes
         if val >= num_modes:
@@ -377,10 +662,445 @@ class WavePort(AbstractTerminalPort, Box):
             )
         return self
 
-    @property
-    def _is_using_mesh_refinement(self) -> bool:
-        """Check if this wave port is using mesh refinement options.
-
-        Returns ``True`` if a custom grid cell count is specified.
+    @model_validator(mode="after")
+    def _warn_multimode_absorber(self) -> Self:
+        """Warn when absorber is enabled with multiple modes.
+        if mode_spec.num_modes is 'auto', it'll be validated in the component modeler.
         """
-        return self.num_grid_cells is not None
+        if not self.absorber:
+            return self
+        num_modes = self.mode_spec.num_modes
+        if num_modes != "auto" and num_modes > 1:
+            log.warning(
+                f"Absorber is enabled with {num_modes} modes. "
+                "Absorption is not properly implemented for multimode cases yet and will be "
+                "added in a future release. For now, please extend the transmission line into the PML region."
+            )
+        return self
+
+    def to_source(
+        self,
+        source_time: SourceTimeType,
+        snap_center: Optional[float] = None,
+        mode_index: int = 0,
+        mode_spec: Optional[MicrowaveModeSpecType] = None,
+    ) -> ModeSource:
+        """Create a mode source from the wave port.
+
+        Parameters
+        ----------
+        source_time : SourceTimeType
+            Source time specification.
+        snap_center : float, optional
+            Position to snap the source center to along injection axis.
+        mode_index : int
+            Mode index to inject.
+        mode_spec : MicrowaveModeSpecType, optional
+            Resolved mode specification with integer num_modes. If None,
+            uses self._mode_spec but raises SetupError if num_modes='auto'.
+        """
+        center = list(self.center)
+        if snap_center:
+            center[self.injection_axis] = snap_center
+        # Use provided mode_spec if given, otherwise fall back to self._mode_spec
+        mode_spec = self._validate_resolved_mode_spec(mode_spec)
+        return ModeSource(
+            center=center,
+            size=self.size,
+            source_time=source_time,
+            mode_spec=mode_spec,
+            mode_index=mode_index,
+            direction=self.direction,
+            name=self.name,
+            frame=self.frame,
+        )
+
+    def get_characteristic_impedance_matrix(
+        self, sim_mode_data: Union[SimulationData, MicrowaveModeData]
+    ) -> ImpedanceFreqModeModeDataArray:
+        """Retrieve the characteristic impedance matrix of the port."""
+        mode_data = self._get_mode_data(sim_mode_data)
+        return mode_data.transmission_line_data.Z0_matrix
+
+    def compute_voltage(self, sim_data: SimulationData) -> FreqModeDataArray:
+        """Helper to compute voltage across the port."""
+        mode_data: MicrowaveModeData = sim_data[self._mode_monitor_name]
+        voltage_coeffs = mode_data.transmission_line_data.voltage_coeffs
+        amps = mode_data.amps
+        fwd_amps = amps.sel(direction="+").squeeze()
+        bwd_amps = amps.sel(direction="-").squeeze()
+        return voltage_coeffs * (fwd_amps + bwd_amps)
+
+    def compute_current(self, sim_data: SimulationData) -> FreqModeDataArray:
+        """Helper to compute current flowing through the port."""
+        mode_data: MicrowaveModeData = sim_data[self._mode_monitor_name]
+        current_coeffs = mode_data.transmission_line_data.current_coeffs
+        amps = mode_data.amps
+        fwd_amps = amps.sel(direction="+").squeeze()
+        bwd_amps = amps.sel(direction="-").squeeze()
+        # In ModeData, fwd_amps and bwd_amps are not relative to
+        # the direction fields are stored
+        sign = 1.0
+        if self.direction == "-":
+            sign = -1.0
+        return sign * current_coeffs * (fwd_amps - bwd_amps)
+
+    def get_port_impedance(
+        self, sim_mode_data: Union[SimulationData, MicrowaveModeData], mode_index: int
+    ) -> FreqModeDataArray:
+        """Retrieve the reference impedance of the port for a specific mode.
+
+        Returns the diagonal element of the reference impedance matrix for the given
+        mode. When ``reference_impedance`` is set to ``"Z0"``, this equals the
+        characteristic impedance; otherwise it returns the user-specified reference
+        impedance.
+
+        Parameters
+        ----------
+        sim_mode_data : Union[:class:`.SimulationData`, :class:`.MicrowaveModeData`]
+            Simulation data containing the mode monitor results, or the mode data directly.
+            If :class:`.SimulationData` is provided, the mode data is extracted using the
+            port's mode monitor name.
+        mode_index : int
+            Index of the mode for which to compute the impedance. This selects a specific
+            mode from the mode spectrum computed by the mode solver.
+
+        Returns
+        -------
+        :class:`.FreqModeDataArray`
+            Frequency-dependent reference impedance for the specified mode.
+            The impedance is complex-valued and varies with frequency.
+        """
+        reference_impedance_matrix = self.get_reference_impedance_matrix(sim_mode_data)
+        # Select diagonal element and reshape to (f, mode_index) format
+        Z0_selected = reference_impedance_matrix.sel(
+            mode_index_out=mode_index, mode_index_in=mode_index
+        )
+        # Expand dims to add mode_index dimension and cast to FreqModeDataArray
+        return FreqModeDataArray(Z0_selected.expand_dims(mode_index=[mode_index]))
+
+
+class TerminalWavePort(AbstractWavePort):
+    """Class representing a single terminal-driven wave port.
+
+    Notes
+    -----
+    - By default, the terminals are single-ended, specified by ``terminal_specs`` parameters. They are
+    labeled by ``T0``, ``T1``, ..., ``Tn``, where the order is defined by their order in ``terminal_specs``
+    if it's a tuple/list, or their location from left to right and bottom to top if ``terminal_specs``
+    is an ``AutoImpedanceSpec``.
+    - Differential pairs are defined by selecting a pair of single-ended terminals based on their labels.
+    The differential pair itself is labeled by "Diff0@comm", "Diff0@diff", "Diff1@comm", "Diff1@diff", ...,
+    where the order is defined by their order in ``differential_pairs``.
+    - The terminals are ordered so that the single-ended terminal labels come first, followed by differential pairs.
+    - By default, a reference impedance of 50 Ohm is used for S-parameter calculations unless otherwise specified.
+    """
+
+    reference_impedance: Union[Literal["Z0"], Complex, ImpedanceTerminalDataArray] = Field(
+        DEFAULT_REFERENCE_IMPEDANCE_VALUE,
+        title="Reference Impedance",
+        description="User-specified reference impedance for S-parameter computation. "
+        "If ``Z0``, the characteristic impedance "
+        "is used. Otherwise, it can be a single complex value applied to all terminals, or a data array "
+        f"specified for each terminal. If the data array misses some terminals, {DEFAULT_REFERENCE_IMPEDANCE_VALUE} "
+        f"Ohm is applied to the missing terminals. By default, {DEFAULT_REFERENCE_IMPEDANCE_VALUE} Ohm is used. "
+        "Note in the case of single complex value, it defines the reference impedance for single-ended terminals; appropriate transformation is "
+        "applied to the differential pairs.",
+        json_schema_extra={"units": OHM},
+    )
+
+    absorber: Union[bool, ABCBoundary, ModeABCBoundary] = Field(
+        False,
+        title="Absorber",
+        description="Place a mode absorber in the port. If ``True``, an automatically generated mode absorber is placed in the port. "
+        "If :class:`.ABCBoundary` or :class:`.ModeABCBoundary`, a mode absorber is placed in the port with the specified boundary conditions.",
+    )
+
+    terminal_specs: Union[
+        AutoImpedanceSpec,
+        tuple[CustomImpedanceSpec, ...],
+    ] = Field(
+        default_factory=AutoImpedanceSpec._default_without_license_warning,
+        title="Terminal Specification",
+        description="Parameters to feed to terminal solver which determine single-ended terminals "
+        "and how transmission line "
+        "quantities for each single-ended terminal, e.g., charateristic impedance, are computed.",
+    )
+
+    differential_pairs: tuple[tuple[str, str], ...] = Field(
+        (),
+        title="Differential Pair",
+        description="Differential pairs defined by a pair of single-ended terminals based "
+        "on their labels, which can be "
+        "found out through :class:`~tidy3d.plugins.smatrix.TerminalComponentModeler`.plot_port() method. "
+        "In each pair, the first termial is positive, while the second is negative.",
+    )
+
+    @field_validator("differential_pairs", mode="after")
+    @classmethod
+    def _validate_differential_pairs(
+        cls, val: tuple[tuple[str, str], ...]
+    ) -> tuple[tuple[str, str], ...]:
+        """Validate no duplicate terminals in differential pairs."""
+        # Check for duplicates - flatten all terminal labels from all pairs
+        terminals_present = set()
+        terminals_duplicates = set()
+        for pair in val:
+            for terminal_label in pair:
+                if terminal_label in terminals_present:
+                    terminals_duplicates.add(terminal_label)
+                terminals_present.add(terminal_label)
+
+        if terminals_duplicates:
+            raise ValidationError(
+                f"Terminal labels {sorted(terminals_duplicates)} appear more than once in differential_pairs. "
+                "Each terminal can only be used in one differential pair."
+            )
+        return val
+
+    @model_validator(mode="after")
+    def _validate_terminal_specs(self) -> Self:
+        """Validate terminal_specs: if it's a list of CustomImpedanceSpec, validate that current and voltage specs
+        are defined consistently: if one of them is None, it must be None for all CustomImpedanceSpec in the list.
+        """
+        val = self.terminal_specs
+        # Skip validation for AutoImpedanceSpec
+        if not isinstance(val, (tuple, list)):
+            return self
+
+        # Check for empty tuple/list
+        if len(val) == 0:
+            raise ValidationError(
+                "Empty 'terminal_specs' tuple is not allowed. "
+                "Please provide at least one CustomImpedanceSpec, or use AutoImpedanceSpec "
+                "for automatic terminal detection."
+            )
+
+        # Check consistency of voltage_spec and current_spec across all CustomImpedanceSpec
+        has_voltage_spec = []
+        has_current_spec = []
+
+        for spec in val:
+            has_voltage_spec.append(spec.voltage_spec is not None)
+            has_current_spec.append(spec.current_spec is not None)
+
+        # Check if voltage_spec consistency: all None or all not None
+        if not all(has_voltage_spec) and any(has_voltage_spec):
+            raise ValidationError(
+                "Inconsistent voltage specifications in terminal_specs: "
+                "If voltage_spec is defined for one terminal, it must be defined for all terminals."
+            )
+
+        # Check if current_spec consistency: all None or all not None
+        if not all(has_current_spec) and any(has_current_spec):
+            raise ValidationError(
+                "Inconsistent current specifications in terminal_specs: "
+                "If current_spec is defined for one terminal, it must be defined for all terminals."
+            )
+
+        return self
+
+    @cached_property
+    def _mode_spec(self) -> Optional[MicrowaveTerminalModeSpec]:
+        """Mode specification for the port if it can be resolved in this module;
+        otherwise, return None.
+        """
+        # 1) in auto mode, needs more information to be determined
+        if not isinstance(self.terminal_specs, (list, tuple)):
+            return None
+        # 2) manual definition
+        num_modes = len(self.terminal_specs)
+        terminal_labels = [f"{DEFAULT_TERMINAL_LABEL_PREFIX}{i}" for i in range(num_modes)]
+        impedance_specs = dict(zip(terminal_labels, self.terminal_specs))
+        terminals_mapping = self._get_terminals_mapping(terminal_labels)
+        mode_spec = MicrowaveTerminalModeSpec(
+            impedance_specs=impedance_specs,
+            num_modes=num_modes,
+            terminals_mapping=terminals_mapping,
+        )
+        return mode_spec
+
+    def _mode_spec_from_isolated_floating_conductors(
+        self, conductors: dict[str, tuple[Shapely, Box]]
+    ) -> MicrowaveTerminalModeSpec:
+        """Construct mode specification from isolated floating conductors
+        when terminal_specs is an AutoImpedanceSpec.
+        """
+        terminal_labels = list(conductors)
+        impedance_specs = {
+            label: CustomImpedanceSpec.from_bounding_box(box)
+            for label, (_, box) in conductors.items()
+        }
+        terminals_mapping = self._get_terminals_mapping(terminal_labels)
+        return MicrowaveTerminalModeSpec(
+            impedance_specs=impedance_specs,
+            num_modes=len(terminal_labels),
+            terminals_mapping=terminals_mapping,
+        )
+
+    def _mode_indices(self, mode_spec: Optional[MicrowaveModeSpecType] = None) -> tuple[int, ...]:
+        """Return the tuple of mode indices that will be excited and monitored by this port.
+
+        All terminal modes are always included, so this returns
+        ``range(mode_spec.num_modes)`` (one index per terminal).
+
+        Parameters
+        ----------
+        mode_spec : MicrowaveModeSpecType, optional
+            Resolved mode specification whose ``num_modes`` is an integer.
+            When ``None``, falls back to ``self._mode_spec``; raises
+            ``SetupError`` if ``num_modes`` is still ``'auto'``.
+
+        Returns
+        -------
+        tuple[int, ...]
+            Ordered mode indices for this port.
+        """
+        mode_spec = self._validate_resolved_mode_spec(mode_spec)
+        return tuple(range(mode_spec.num_modes))
+
+    @cached_property
+    def _differential_pair_mapping(self) -> dict[str, tuple[str, str]]:
+        """Get a mapping from differential pairs to single-ended terminals.
+
+        Returns
+        -------
+        dict[str, tuple[str, str]]: Mapping from differential pairs to single-ended terminals.
+        """
+        mapping = {}
+        for pair_idx, (label1, label2) in enumerate(self.differential_pairs):
+            # Create labels for common mode and differential mode
+            comm_label = f"{DEFAULT_DIFFERENTIAL_PAIR_LABEL_PREFIX}{pair_idx}@comm"
+            diff_label = f"{DEFAULT_DIFFERENTIAL_PAIR_LABEL_PREFIX}{pair_idx}@diff"
+
+            # Map both modes to the same pair of single-ended terminals
+            mapping[comm_label] = (label1, label2)
+            mapping[diff_label] = (label1, label2)
+
+        return mapping
+
+    def _get_active_single_ended_terminals(self, single_ended_labels: list[str]) -> list[str]:
+        """Get the single-ended terminals for S-parameter computation (excluding the
+        ones used in differential pairs).
+
+        Parameters
+        ----------
+        single_ended_labels : list[str]
+            Labels of the single-ended terminals.
+
+        Returns
+        -------
+        list[str]
+            List of single-ended terminal labels not used in any differential pair.
+        """
+        active_terminals = single_ended_labels.copy()
+        for pair_idx, pair in enumerate(self.differential_pairs):
+            for label in pair:
+                try:
+                    active_terminals.remove(label)
+                except ValueError:
+                    raise SetupError(
+                        f"Port '{self.name}': Differential pair {pair_idx} references terminal "
+                        f"label '{label}' that is not present in the available single-ended "
+                        f"terminals: {single_ended_labels}. "
+                        f"Please ensure all differential pair labels match detected terminals."
+                    ) from None
+        return active_terminals
+
+    def _get_terminals_mapping(
+        self, single_ended_labels: list[str]
+    ) -> dict[str, Union[str, tuple[str, str]]]:
+        """Get a mapping from terminals (single-ended terminals or differential pairs) to single-ended terminals.
+
+        The terminals are ordered such that single-ended terminal labels come first, followed by
+        differential pairs. This ordering ensures consistent indexing in transformation matrices.
+
+        Parameters
+        ----------
+        single_ended_labels : list[str]
+            Labels of the single-ended terminals.
+
+        Returns
+        -------
+        dict[str, Union[str, tuple[str, str]]]:
+            Mapping from terminal (single-ended terminal or differential pair) to single-ended terminals.
+            Keys are ordered with single-ended terminals first, followed by differential pairs.
+        """
+        # Start with single-ended terminals (these come first in the ordering)
+        mapping = {
+            label: label for label in self._get_active_single_ended_terminals(single_ended_labels)
+        }
+        # Then add differential pairs (these come after single-ended terminals)
+        mapping.update(self._differential_pair_mapping)
+        return mapping
+
+    def to_source(
+        self,
+        source_time: SourceTimeType,
+        snap_center: Optional[float] = None,
+        terminal_label: Optional[str] = None,
+        mode_spec: Optional[MicrowaveModeSpecType] = None,
+    ) -> MicrowaveTerminalSource:
+        """Create a microwave terminal source from the wave port.
+
+        Parameters
+        ----------
+        source_time : SourceTimeType
+            Source time specification.
+        snap_center : float, optional
+            Position to snap the source center to along injection axis.
+        terminal_label : str, optional
+            Terminal label to inject. If None, uses the first terminal in mode_spec.
+        mode_spec : MicrowaveModeSpecType, optional
+            Resolved mode specification with integer num_modes. If None,
+            uses self._mode_spec but raises SetupError if num_modes='auto'.
+        """
+        center = list(self.center)
+        if snap_center:
+            center[self.injection_axis] = snap_center
+        # Use provided mode_spec if given, otherwise fall back to self._mode_spec
+        mode_spec = self._validate_resolved_mode_spec(mode_spec)
+        if terminal_label is None:
+            terminal_label = mode_spec._terminal_indices[0]
+        return MicrowaveTerminalSource(
+            center=center,
+            size=self.size,
+            source_time=source_time,
+            mode_spec=mode_spec,
+            terminal_label=terminal_label,
+            direction=self.direction,
+            name=self.name,
+            frame=self.frame,
+        )
+
+    def get_characteristic_impedance_matrix(
+        self, sim_mode_data: Union[SimulationData, MicrowaveModeData]
+    ) -> ImpedanceFreqTerminalTerminalDataArray:
+        """Retrieve the characteristic impedance matrix of the port."""
+        mode_data = self._get_mode_data(sim_mode_data)
+        return mode_data.transmission_line_terminal_data.Z0_matrix
+
+    def compute_voltage(self, sim_data: SimulationData) -> VoltageFreqTerminalDataArray:
+        """Helper to compute voltage across the port."""
+        mode_data: MicrowaveModeData = sim_data[self._mode_monitor_name]
+        voltage_transform = mode_data.transmission_line_terminal_data.voltage_transform
+        amps = mode_data.amps
+        fwd_amps = amps.sel(direction="+").squeeze()
+        bwd_amps = amps.sel(direction="-").squeeze()
+        # Matrix multiply: voltage_transform[f, terminal_label, mode_index] @ amps[f, mode_index]
+        # to get voltage[f, terminal_label]
+        return voltage_transform.dot(fwd_amps + bwd_amps, dim="mode_index")
+
+    def compute_current(self, sim_data: SimulationData) -> CurrentFreqTerminalDataArray:
+        """Helper to compute current flowing through the port."""
+        mode_data: MicrowaveModeData = sim_data[self._mode_monitor_name]
+        current_transform = mode_data.transmission_line_terminal_data.current_transform
+        amps = mode_data.amps
+        fwd_amps = amps.sel(direction="+").squeeze()
+        bwd_amps = amps.sel(direction="-").squeeze()
+        # In ModeData, fwd_amps and bwd_amps are not relative to
+        # the direction fields are stored
+        sign = 1.0
+        if self.direction == "-":
+            sign = -1.0
+        return sign * current_transform.dot(fwd_amps - bwd_amps, dim="mode_index")

--- a/tidy3d/plugins/smatrix/utils.py
+++ b/tidy3d/plugins/smatrix/utils.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+from scipy import linalg
 
+from tidy3d.constants import dp_eps
 from tidy3d.exceptions import Tidy3dError
-from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
+from tidy3d.plugins.smatrix.data.data_array import TerminalPortDataArray
 
 if TYPE_CHECKING:
     from typing import Union
@@ -21,7 +23,6 @@ if TYPE_CHECKING:
 
     from tidy3d.components.data.data_array import DataArray, FreqDataArray
     from tidy3d.components.data.sim_data import SimulationData
-    from tidy3d.components.types import ArrayFloat1D
     from tidy3d.plugins.smatrix.ports.types import (
         LumpedPortType,
         PortCurrentType,
@@ -108,35 +109,178 @@ def check_port_impedance_sign(Z_numpy: np.ndarray) -> None:
             )
 
 
-def compute_F(Z_numpy: ArrayFloat1D, s_param_def: SParamDef = "pseudo") -> float:
-    r"""Helper to convert port impedance matrix to F, which is used for
-    computing scattering parameters and represents the scaling factor
-    applied to forward and backward waves.
-
-    The matrix F is used when converting between S and Z parameters for circuits
-    with differing port impedances.
+def _is_diagonal_matrix(Z_numpy: np.ndarray, atol: float = dp_eps) -> bool:
+    """Check if Z matrix is diagonal (off-diagonal elements are negligible).
 
     Parameters
     ----------
-    Z_numpy : ArrayFloat1D
-        NumPy array of complex port impedances.
-    s_param_def : SParamDef, optional
-        Wave definition: "pseudo", "power", or "symmetric_pseudo". Default is "pseudo".
-        See :class:`.TerminalComponentModeler` for details.
+    Z_numpy : np.ndarray
+        Impedance matrix with shape (f, port, port).
+    atol : float
+        Absolute tolerance for comparison. Default is double precision epsilon.
 
     Returns
     -------
-    ArrayFloat1D
-        NumPy array containing the computed F values.
+    bool
+        True if all off-diagonal elements are negligible.
     """
-    # Defined in [2] after equation 4.67
+    _, num_ports, _ = Z_numpy.shape
+    # Create a mask for off-diagonal elements
+    mask = ~np.eye(num_ports, dtype=bool)
+    # Extract off-diagonal elements for all frequencies
+    off_diag = Z_numpy[:, mask]
+    # Check if all off-diagonal elements are negligible
+    return np.allclose(off_diag, 0, atol=atol)
+
+
+def compute_F(
+    Z_numpy: np.ndarray, s_param_def: SParamDef = "pseudo", compute_Finv: bool = False
+) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+    r"""Helper to convert port impedance matrix to F (and optionally its inverse),
+    which are used for computing scattering parameters. F represents the scaling
+    factor applied to forward and backward waves.
+
+    The matrix F is used when converting between S and Z parameters for circuits
+    with differing port impedances. This function automatically detects whether
+    Z is diagonal and uses optimized element-wise operations for diagonal matrices
+    or full matrix operations for non-diagonal matrices.
+
+    Parameters
+    ----------
+    Z_numpy : np.ndarray
+        NumPy array of complex port impedance matrix with shape (f, port_out, port_in),
+        where f is number of frequencies, port_out is number of output ports, and
+        port_in is number of input ports. Z is assumed to be symmetric and positive
+        semi-definite.
+    s_param_def : SParamDef, optional
+        Wave definition: "pseudo", "power", or "symmetric_pseudo". Default is "pseudo".
+        See :class:`.TerminalComponentModeler` for details.
+    compute_Finv : bool, optional
+        If True, also compute and return F^{-1}. Default is False.
+
+    Returns
+    -------
+    np.ndarray or tuple[np.ndarray, np.ndarray]
+        F array with shape (f, port_out, port_in), or (F, Finv) tuple if
+        ``compute_Finv`` is True.
+
+    Notes
+    -----
+    The F matrix definitions for each wave formulation are:
+
+    - ``"power"``: :math:`F = 0.5 \cdot (\mathrm{Re}[Z])^{-1/2}`
+    - ``"pseudo"``: :math:`F = 0.5 \cdot (\mathrm{Re}(Z^{-1}))^{1/2}`
+    - ``"symmetric_pseudo"``: :math:`F = 0.5 \cdot Z^{-1/2}`
+
+    where :math:`A^{1/2}` denotes the matrix square root and :math:`A^{-1/2}` denotes
+    the matrix inverse square root.
+    """
+    # Automatically detect if Z is diagonal and use appropriate method
+    if _is_diagonal_matrix(Z_numpy):
+        return _compute_F_diagonal(Z_numpy, s_param_def, compute_Finv)
+    return _compute_F_full(Z_numpy, s_param_def, compute_Finv)
+
+
+def _compute_F_diagonal(
+    Z_numpy: np.ndarray, s_param_def: SParamDef, compute_Finv: bool = False
+) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+    """Compute F matrix (and optionally Finv) assuming Z is diagonal.
+
+    Parameters
+    ----------
+    Z_numpy : np.ndarray
+        Impedance matrix with shape (f, port_out, port_in). Only diagonal elements are used.
+    s_param_def : SParamDef
+        Wave definition.
+    compute_Finv : bool, optional
+        If True, also compute and return Finv. Default is False.
+
+    Returns
+    -------
+    np.ndarray or tuple[np.ndarray, np.ndarray]
+        F matrix, or (F, Finv) tuple if ``compute_Finv`` is True.
+    """
+    num_freqs, num_ports, _ = Z_numpy.shape
+    # Extract diagonal elements: shape (f, port)
+    Z_diag = np.diagonal(Z_numpy, axis1=1, axis2=2)
+
     if s_param_def == "power":
-        return 1.0 / (2.0 * np.sqrt(np.real(Z_numpy)))
+        sqrt_Re_Z = np.sqrt(np.real(Z_diag))
+        F_diag = 0.5 / sqrt_Re_Z
+        Finv_diag = 2.0 * sqrt_Re_Z if compute_Finv else None
     elif s_param_def == "pseudo":
-        # Equation 75 from [1]
-        return np.sqrt(np.real(Z_numpy)) / (2.0 * np.abs(Z_numpy))
+        sqrt_Re_Z = np.sqrt(np.real(Z_diag))
+        abs_Z = np.abs(Z_diag)
+        F_diag = sqrt_Re_Z / (2.0 * abs_Z)
+        Finv_diag = 2.0 * abs_Z / sqrt_Re_Z if compute_Finv else None
     elif s_param_def == "symmetric_pseudo":
-        return 1.0 / (2.0 * np.sqrt(Z_numpy))
+        sqrt_Z = np.sqrt(Z_diag)
+        F_diag = 0.5 / sqrt_Z
+        Finv_diag = 2.0 * sqrt_Z if compute_Finv else None
+    else:
+        raise ValueError(
+            f"Unsupported S-parameter definition '{s_param_def}'. "
+            "Supported values are 'pseudo', 'symmetric_pseudo', and 'power'."
+        )
+
+    # Convert back to diagonal matrices: shape (f, port, port)
+    idx = range(num_ports)
+    F = np.zeros((num_freqs, num_ports, num_ports), dtype=F_diag.dtype)
+    F[:, idx, idx] = F_diag
+    if not compute_Finv:
+        return F
+    Finv = np.zeros((num_freqs, num_ports, num_ports), dtype=Finv_diag.dtype)
+    Finv[:, idx, idx] = Finv_diag
+    return F, Finv
+
+
+def _compute_F_full(
+    Z_numpy: np.ndarray, s_param_def: SParamDef, compute_Finv: bool = False
+) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+    """Compute F matrix (and optionally Finv) for full (non-diagonal) Z.
+
+    Parameters
+    ----------
+    Z_numpy : np.ndarray
+        Full impedance matrix with shape (f, port_out, port_in).
+    s_param_def : SParamDef
+        Wave definition.
+    compute_Finv : bool, optional
+        If True, also compute and return Finv. Default is False.
+
+    Returns
+    -------
+    np.ndarray or tuple[np.ndarray, np.ndarray]
+        F matrix, or (F, Finv) tuple if ``compute_Finv`` is True.
+    """
+    num_freqs = Z_numpy.shape[0]
+
+    if s_param_def == "power":
+        # F = 0.5 * Re(Z)^{-1/2}, Finv = 2 * Re(Z)^{1/2}
+        Z_real = np.real(Z_numpy)
+        sqrt_Re_Z = np.array([linalg.sqrtm(Z_real[f_idx]) for f_idx in range(num_freqs)])
+        F = np.array([0.5 * linalg.inv(sqrt_Re_Z[f_idx]) for f_idx in range(num_freqs)])
+        if not compute_Finv:
+            return F
+        return F, 2.0 * sqrt_Re_Z
+    elif s_param_def == "pseudo":
+        # F = 0.5 * Re(Z^{-1})^{1/2}, Finv = 2 * Re(Z^{-1})^{-1/2}
+        sqrt_Re_Zinv = np.array(
+            [linalg.sqrtm(np.real(np.linalg.inv(Z_numpy[f_idx]))) for f_idx in range(num_freqs)]
+        )
+        F = 0.5 * sqrt_Re_Zinv
+        if not compute_Finv:
+            return F
+        # Finv still requires matrix inversion
+        Finv = np.array([2.0 * linalg.inv(sqrt_Re_Zinv[f_idx]) for f_idx in range(num_freqs)])
+        return F, Finv
+    elif s_param_def == "symmetric_pseudo":
+        # F = 0.5 * Z^{-1/2}, Finv = 2 * Z^{1/2}
+        sqrt_Z = np.array([linalg.sqrtm(Z_numpy[f_idx]) for f_idx in range(num_freqs)])
+        F = np.array([0.5 * linalg.inv(sqrt_Z[f_idx]) for f_idx in range(num_freqs)])
+        if not compute_Finv:
+            return F
+        return F, 2.0 * sqrt_Z
     else:
         raise ValueError(
             f"Unsupported S-parameter definition '{s_param_def}'. "
@@ -224,20 +368,21 @@ def compute_power_delivered_by_port(
 
 def s_to_z(
     s_matrix: TerminalPortDataArray,
-    reference: Union[complex, PortDataArray],
+    reference: Union[complex, TerminalPortDataArray],
     s_param_def: SParamDef = "pseudo",
 ) -> DataArray:
     """Get the impedance matrix given the scattering matrix and a reference impedance.
 
     This function converts an S-matrix to a Z-matrix. It handles both a single
-    uniform reference impedance and generalized per-port reference impedances.
+    uniform reference impedance and a generalized per-frequency reference impedance matrix.
 
     Parameters
     ----------
     s_matrix : :class:`.TerminalPortDataArray`
         Scattering matrix computed using either the pseudo or power wave formulation.
-    reference : Union[complex, :class:`.PortDataArray`]
-        The reference impedance used at each port.
+    reference : Union[complex, :class:`.TerminalPortDataArray`]
+        The reference impedance. Either a scalar (uniform across all ports) or a
+        full impedance matrix per frequency.
     s_param_def : SParamDef, optional
         Wave definition: "pseudo", "power", or "symmetric_pseudo". Default is "pseudo".
         See :class:`.TerminalComponentModeler` for details.
@@ -261,18 +406,16 @@ def s_to_z(
     z_matrix = s_matrix.transpose(*TerminalPortDataArray._dims).copy(deep=True)
     s_vals = z_matrix.values
     eye = np.eye(len(s_matrix.port_out.values), len(s_matrix.port_in.values))[np.newaxis, :, :]
-    # Ensure that Zport, F, and Finv act as diagonal matrices when multiplying by left or right
-    shape_left = (len(s_matrix.f), len(s_matrix.port_out), 1)
-    shape_right = (len(s_matrix.f), 1, len(s_matrix.port_in))
-    # Setup the port reference impedance array (scalar)
-    if isinstance(reference, PortDataArray):
-        Zport = reference.values.reshape(shape_right)
-        F = compute_F(Zport, s_param_def).reshape(shape_right)
-        Finv = (1.0 / F).reshape(shape_left)
+
+    if isinstance(reference, TerminalPortDataArray):
+        Zport = reference.transpose(*TerminalPortDataArray._dims).values
+        F, Finv = compute_F(Zport, s_param_def, compute_Finv=True)
+        FinvSF = np.matmul(np.matmul(Finv, s_vals), F)
     else:
         Zport = reference
-        F = compute_F(Zport, s_param_def)
-        Finv = 1.0 / F
+        # F^{-1} S F = S when F is the same scalar for all ports
+        FinvSF = s_vals
+
     # Use conjugate when S matrix is power-wave based
     if s_param_def == "power":
         Zport_mod = np.conj(Zport)
@@ -281,8 +424,10 @@ def s_to_z(
 
     # From equation 74 from [1] for pseudo waves
     # From Equation 4.68 - Pozar - Microwave Engineering 4ed for power waves
-    FinvSF = Finv * s_vals * F
-    RHS = eye * Zport_mod + FinvSF * Zport
+    if isinstance(reference, TerminalPortDataArray):
+        RHS = Zport_mod + np.matmul(FinvSF, Zport)
+    else:
+        RHS = eye * Zport_mod + FinvSF * Zport
     LHS = eye - FinvSF
     z_vals = np.linalg.solve(LHS, RHS)
 

--- a/tidy3d/rf.py
+++ b/tidy3d/rf.py
@@ -85,6 +85,9 @@ from tidy3d.components.microwave.path_integrals.specs.voltage import (
     Custom2DVoltageIntegralSpec,
 )
 
+# Microwave sources
+from tidy3d.components.microwave.source import MicrowaveTerminalSource
+
 # Baseband source times
 from tidy3d.components.microwave.time import (
     BasebandCustomSourceTime,
@@ -134,7 +137,7 @@ from tidy3d.plugins.smatrix.data.terminal import (
 from tidy3d.plugins.smatrix.data.types import ComponentModelerDataType
 from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
 from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
-from tidy3d.plugins.smatrix.ports.wave import WavePort
+from tidy3d.plugins.smatrix.ports.wave import TerminalWavePort, WavePort
 
 # Backwards compatibility
 CurrentIntegralTypes = CurrentIntegralType
@@ -201,6 +204,7 @@ __all__ = [
     "MicrowaveModeSolverMonitor",
     "MicrowaveModeSpec",
     "MicrowaveSMatrixData",
+    "MicrowaveTerminalSource",
     "ModelerLowFrequencySmoothingSpec",
     "PECFrame",
     "PortDataArray",
@@ -215,6 +219,7 @@ __all__ = [
     "TerminalComponentModeler",
     "TerminalComponentModelerData",
     "TerminalPortDataArray",
+    "TerminalWavePort",
     "VoltageIntegralTypes",
     "WavePort",
     "models",


### PR DESCRIPTION
## Summary
- Add `TerminalWavePort` for terminal-based S-parameter extraction with automatic transmission line mode computation
- Implement `TerminalComponentModeler` for multi-port S-parameter extraction with differential pair support
- Migrate performance-critical computations (terminal transforms, `snap_box_to_grid`) to C++ via `tidy3d_extras`
- Add visualization utilities for terminal and differential pair annotations

## Test plan
- [x] Unit tests for terminal detection and labeling
- [x] Unit tests for differential pair transformation (Q-matrix)
- [x] Integration tests for `TerminalComponentModeler`
- [x] Visualization label packing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RF port excitation, impedance/reference handling, and mode-solver post-processing/serialization paths; while well-covered by new tests, mistakes could silently skew computed S/Z parameters or terminal transforms.
> 
> **Overview**
> Adds **terminal-driven wave port excitation** via `TerminalWavePort`, including differential-pair support and per-port `reference_impedance` control (also added to `WavePort`) to compute S-parameters against user-chosen reference impedances.
> 
> Extends the microwave mode/terminal data model: introduces `MicrowaveTerminalModeSpec`, `MicrowaveTerminalSource`, terminal-indexed `DataArray`/datasets (`TransmissionLineTerminalDataset`, `TerminalFieldDataset`), and updates mode-solver post-processing to preserve/propagate terminal transmission-line data through frequency interpolation, mode reordering, and group-index filtering.
> 
> Improves robustness and usability around post-processing and geometry: enables S-matrix **renormalization** to arbitrary scalar/per-port/full-matrix impedances, updates `s_to_z` to accept diagonal matrix references, adds non-overlap terminal label packing for plots, expands HDF5 support for string coordinates, fixes pydantic serialization loss of mode-spec fields, and makes 2D geometry merging handle zero-area shapes (lines/points).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b268fa377edf7c729c36dec5f41a06355e3230f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->