### PR TITLE
feat(tidy3d): FXC-5401-default-to-local-caching-true-in-tidy-3-d-2-11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added deprecation warning for `TemperatureMonitor` and `SteadyPotentialMonitor` when `unstructured` parameter is not explicitly set. The default value of `unstructured` will change from `False` to `True` in the next release.
 - Added deprecation warning for ``TemperatureMonitor`` and ``SteadyPotentialMonitor`` when ``unstructured`` parameter is not explicitly set. The default value of ``unstructured`` will change from ``False`` to ``True`` after the 2.11 release.
 - Added validation to `GaussianDoping` to ensure `ref_con < concentration`, validate `source` face identifier, and warn the user when the box size is not sufficient for the specified transition width.
+- Local caching is now enabled by default (set `td.config.local_cache.enabled=False` to opt out).
 
 ### Fixed
 - Fixed intermittent "API key not found" errors in parallel job launches by making configuration directory detection race-safe.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -162,7 +162,7 @@ You can now postprocess simulation data using the same python session, or view t
    :class: tip
 
    Repeated runs of the same simulation can reuse solver results by enabling the
-   local cache: ``td.config.local_cache.enabled = True``. You may configure the cache directory
+   local cache with ``td.config.local_cache.enabled = True`` which is the default. You may configure the cache directory
    with ``local_cache.directory``. If the number of entries (``local_cache.max_entries``) or the storage size
    (``local_cache.max_size_gb``) is exceeded, cache entries are evicted by least-recently-used (LRU) order.
    You can clear all stored artifacts with ``td.web.cache.clear()``.

--- a/tidy3d/config/sections.py
+++ b/tidy3d/config/sections.py
@@ -474,7 +474,7 @@ class LocalCacheConfig(ConfigSection):
     """Settings controlling the optional local simulation cache."""
 
     enabled: bool = Field(
-        False,
+        True,
         title="Enable cache",
         description="Enable or disable the local simulation cache.",
         json_schema_extra={"persist": True},


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default runtime behavior to persist simulation artifacts locally, which can increase disk usage and expose new cache-related edge cases in environments with restricted filesystems.
> 
> **Overview**
> **Local simulation caching is now on by default.** The default for `td.config.local_cache.enabled` is flipped from `False` to `True`, and docs/changelog are updated to reflect the new opt-out behavior.
> 
> This affects new installs and users who never explicitly set the flag, as repeated runs may start writing cache entries to the configured cache directory automatically.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45263607046829edf61a9eb45f999c48066722bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->