### PR TITLE
Fxc 5438 trim generated docstrings for pydantic v 2 models

### DIFF
--- a/docs/_templates/module.rst
+++ b/docs/_templates/module.rst
@@ -6,35 +6,50 @@
    :show-inheritance:
    :undoc-members:
    :member-order: bysource
-   :exclude-members: __hash__
+   :exclude-members: attrs, model_config, model_post_init, type
 
    {% block attributes %}
    {% if attributes %}
+   {% set ns_attrs = namespace(items=[]) %}
+   {% for item in attributes %}
+   {% if item not in inherited_members
+         and item != "attrs"
+         and item not in ("model_config", "type")
+         and not item.startswith("_") %}
+   {% set ns_attrs.items = ns_attrs.items + [item] %}
+   {% endif %}
+   {%- endfor %}
+   {% if ns_attrs.items %}
    .. rubric:: Attributes
 
    .. autosummary::
-      :toctree:
-      {% for item in attributes %}
-      {% if item not in inherited_members %}
-        {{ item }}
-      {% endif %}
+      {% for item in ns_attrs.items %}
+        ~{{ fullname }}.{{ item }}
       {%- endfor %}
-      {% endif %}
-      {% endblock %}
+   {% endif %}
+   {% endif %}
+   {% endblock %}
 
    {% block methods %}
    {% if methods %}
+   {% set ns_methods = namespace(items=[]) %}
+   {% for item in methods %}
+   {% if item not in inherited_members
+         and item not in ("model_post_init",)
+         and not item.startswith("_") %}
+   {% set ns_methods.items = ns_methods.items + [item] %}
+   {% endif %}
+   {%- endfor %}
+   {% if ns_methods.items %}
    .. rubric:: Methods
 
    .. autosummary::
-       :toctree:
-       {% for item in methods %}
-          {% if item not in inherited_members %}
-            {{ item }}
-          {% endif %}
+       {% for item in ns_methods.items %}
+            ~{{ fullname }}.{{ item }}
        {%- endfor %}
-       {% endif %}
-       {% endblock %}
+   {% endif %}
+   {% endif %}
+   {% endblock %}
 
 
    .. rubric:: Inherited Common Usage

--- a/docs/api/abstract_base.rst
+++ b/docs/api/abstract_base.rst
@@ -11,16 +11,22 @@ Base classes that represent abstractions of common components. Provide inherited
    :template: module.rst
 
    tidy3d.components.base_sim.data.sim_data.AbstractSimulationData
+   tidy3d.components.base_sim.data.monitor_data.AbstractMonitorData
+   tidy3d.components.tcad.data.monitor_data.abstract.HeatChargeMonitorData
    tidy3d.components.base_sim.monitor.AbstractMonitor
    tidy3d.components.base_sim.simulation.AbstractSimulation
    tidy3d.components.base_sim.source.AbstractSource
    tidy3d.components.data.dataset.AbstractFieldDataset
+   tidy3d.components.data.dataset.AuxFieldTimeDataset
+   tidy3d.components.data.dataset.ElectromagneticFieldDataset
+   tidy3d.components.data.data_array.AbstractSpatialDataArray
+   tidy3d.components.data.monitor_data.AbstractFieldData
    tidy3d.components.data.monitor_data.AbstractFieldProjectionData
    tidy3d.components.parameter_perturbation.AbstractPerturbation
    tidy3d.components.parameter_perturbation.AbstractPerturbation
    tidy3d.components.medium.AbstractCustomMedium
    tidy3d.components.medium.AbstractMedium
+   tidy3d.components.microwave.base.MicrowaveBaseModel
    tidy3d.components.simulation.AbstractYeeGridSimulation
    tidy3d.components.structure.AbstractStructure
    tidy3d.components.time.AbstractTimeDependence
-

--- a/docs/api/abstract_models.rst
+++ b/docs/api/abstract_models.rst
@@ -11,69 +11,72 @@ These are some of the classes that are used to organize Tidy3D components, but a
    :template: module.rst
 
    tidy3d.Geometry
+   tidy3d.Tidy3dBaseModel
    tidy3d.components.geometry.base.Centered
-   tidy3d.components.geometry.base.Planar
    tidy3d.components.geometry.base.Circular
+   tidy3d.components.geometry.base.Planar
+   tidy3d.components.geometry.base.SimplePlaneIntersection
+   tidy3d.components.geometry.polyslab.ComplexPolySlabBase
+   tidy3d.components.structure.AbstractStructure
    tidy3d.components.medium.AbstractMedium
    tidy3d.components.medium.AbstractCustomMedium
    tidy3d.components.medium.DispersiveMedium
    tidy3d.components.medium.CustomDispersiveMedium
-   tidy3d.components.structure.AbstractStructure
-   tidy3d.components.source.SourceTime
-   tidy3d.components.source.Source
-   tidy3d.components.source.FieldSource
-   tidy3d.components.source.CurrentSource
-   tidy3d.components.source.ReverseInterpolatedSource
-   tidy3d.components.source.AngledFieldSource
-   tidy3d.components.source.PlanarSource
-   tidy3d.components.source.DirectionalSource
-   tidy3d.components.source.BroadbandSource
-   tidy3d.components.source.VolumeSource
-   tidy3d.components.source.Pulse
-   tidy3d.components.monitor.Monitor
+   tidy3d.components.medium.AnisotropicMediumFromMedium2D
+   tidy3d.components.source.time.SourceTime
+   tidy3d.components.source.time.Pulse
+   tidy3d.components.source.base.Source
+   tidy3d.components.source.field.FieldSource
+   tidy3d.components.source.field.PlanarSource
+   tidy3d.components.source.field.VolumeSource
+   tidy3d.components.source.field.DirectionalSource
+   tidy3d.components.source.field.BroadbandSource
+   tidy3d.components.source.field.AngledFieldSource
+   tidy3d.components.source.current.CurrentSource
+   tidy3d.components.source.current.ReverseInterpolatedSource
+   tidy3d.Monitor
+   tidy3d.components.tcad.monitors.abstract.HeatChargeMonitor
    tidy3d.components.monitor.FreqMonitor
    tidy3d.components.monitor.TimeMonitor
    tidy3d.components.monitor.AbstractFieldMonitor
    tidy3d.components.monitor.AbstractFluxMonitor
    tidy3d.components.monitor.PlanarMonitor
+   tidy3d.components.monitor.SurfaceIntegrationMonitor
    tidy3d.components.monitor.AbstractFieldProjectionMonitor
    tidy3d.components.lumped_element.LumpedElement
    tidy3d.components.lumped_element.RectangularLumpedElement
    tidy3d.components.grid.grid_spec.GridSpec1d
-   tidy3d.components.base_sim.data.sim_data.SimulationData
    tidy3d.components.data.sim_data.AbstractYeeGridSimulationData
    tidy3d.components.data.sim_data.SimulationData
-   tidy3d.components.base.Tidy3dBaseModel
    tidy3d.components.boundary.AbsorberSpec
+   tidy3d.components.tcad.boundary.abstract.HeatChargeBC
+   tidy3d.components.subpixel_spec.AbstractSubpixelAveragingMethod
    tidy3d.components.data.data_array.DataArray
    tidy3d.components.data.dataset.FieldDataset
    tidy3d.components.data.dataset.FieldTimeDataset
    tidy3d.components.data.dataset.ModeSolverDataset
    tidy3d.components.data.monitor_data.ElectromagneticFieldData
    tidy3d.components.data.monitor_data.MonitorData
-   tidy3d.components.data.sim_data.SimulationData
-   tidy3d.components.geometry.base.Centered
-   tidy3d.components.geometry.base.Circular
-   tidy3d.components.geometry.base.Planar
-   tidy3d.components.geometry.base.SimplePlaneIntersection
-   tidy3d.components.grid.grid_spec.GridSpec1d
-   tidy3d.components.lumped_element.LumpedElement
-   tidy3d.components.medium.CustomDispersiveMedium
-   tidy3d.components.medium.DispersiveMedium
-   tidy3d.components.monitor.FreqMonitor
-   tidy3d.components.monitor.Monitor
-   tidy3d.components.monitor.PlanarMonitor
-   tidy3d.components.monitor.TimeMonitor
-   tidy3d.components.source.AngledFieldSource
-   tidy3d.components.source.BroadbandSource
-   tidy3d.components.source.CurrentSource
-   tidy3d.components.source.DirectionalSource
-   tidy3d.components.source.FieldSource
-   tidy3d.components.source.PlanarSource
-   tidy3d.components.source.Pulse
-   tidy3d.components.source.ReverseInterpolatedSource
-   tidy3d.components.source.Source
-   tidy3d.components.source.SourceTime
-   tidy3d.components.source.VolumeSource
-
-
+   tidy3d.components.spice.analysis.ac.AbstractSSACAnalysis
+   tidy3d.components.bc_placement.AbstractBCPlacement
+   tidy3d.components.boundary.AbstractABCBoundary
+   tidy3d.components.grid.grid_spec.AbstractAutoGrid
+   tidy3d.components.material.tcad.charge.AbstractChargeMedium
+   tidy3d.components.material.tcad.heat.AbstractHeatMedium
+   tidy3d.components.medium.AbstractSurfaceRoughness
+   tidy3d.components.mode_spec.AbstractModeSpec
+   tidy3d.components.base_sim.monitor.AbstractMonitor
+   tidy3d.components.monitor.AbstractGaussianOverlapMonitor
+   tidy3d.components.monitor.AbstractMediumPropertyMonitor
+   tidy3d.components.monitor.AbstractModeMonitor
+   tidy3d.components.microwave.monitor.MicrowaveModeMonitorBase
+   tidy3d.components.microwave.path_integrals.specs.base.AbstractAxesRH
+   tidy3d.components.source.field.AbstractAngularSpec
+   tidy3d.components.tcad.data.sim_data.AbstractHeatChargeSimulationData
+   tidy3d.components.tcad.doping.AbstractDopingBox
+   tidy3d.plugins.autograd.invdes.filters.AbstractFilter
+   tidy3d.plugins.invdes.base.InvdesBaseModel
+   tidy3d.plugins.invdes.design.AbstractInverseDesign
+   tidy3d.plugins.microwave.array_factor.AbstractAntennaArrayCalculator
+   tidy3d.plugins.smatrix.ports.base_lumped.AbstractLumpedPort
+   tidy3d.plugins.smatrix.ports.base_terminal.AbstractTerminalPort

--- a/docs/api/geometry.rst
+++ b/docs/api/geometry.rst
@@ -292,9 +292,8 @@ Working with GDS
    tidy3d.Geometry.to_gds_file
    tidy3d.Geometry.to_gds
    tidy3d.Geometry.to_gdstk
-   tidy3d.Geometry.to_gdspy
 
-The GDSII file format is commonly used in integrated circuit design to specify geometric shapes, labels, and other simulation metadata. Tidy3D supports the creation, import, and export of GDSII files via the third party packages ``gdstk`` or ``gdspy``. Please find detailed usage instructions in the linked articles below. 
+The GDSII file format is commonly used in integrated circuit design to specify geometric shapes, labels, and other simulation metadata. Tidy3D supports the creation, import, and export of GDSII files via the third party package ``gdstk``. Please find detailed usage instructions in the linked articles below.
 
 .. seealso::
 
@@ -333,4 +332,3 @@ Use the ``from_stl()`` class method to import from an external STL file, or ``fr
    + `Defining complex geometries using trimesh <../notebooks/CreatingGeometryUsingTrimesh.html>`_
 
 ~~~~
-

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -31,3 +31,5 @@ API |:computer:|
     abstract_base
     abstract_models
     viz
+
+.. toctree::

--- a/docs/api/mediums.rst
+++ b/docs/api/mediums.rst
@@ -83,7 +83,7 @@ There are many different models that can be used to describe dispersive mediums.
 
    tidy3d.plugins.dispersion.FastDispersionFitter
 
-Alternatively, the :class:`FastDispersionFitter` plugin can be used to generate a dispersive medium from external data. The data can be provided as a local text file or a web URL from the materials database `refractiveindex.info <https://refractiveindex.info>`_.
+Alternatively, the :class:`~tidy3d.plugins.dispersion.FastDispersionFitter` plugin can be used to generate a dispersive medium from external data. The data can be provided as a local text file or a web URL from the materials database `refractiveindex.info <https://refractiveindex.info>`_.
 
 .. code-block:: python
 
@@ -139,7 +139,7 @@ Anisotropic
    :template: module.rst
 
    tidy3d.AnisotropicMedium
-   tidy3d.AnisotropicMediumFromMedium2D
+   tidy3d.components.medium.AnisotropicMediumFromMedium2D
    tidy3d.FullyAnisotropicMedium
    tidy3d.Medium2D
 
@@ -190,10 +190,10 @@ Metallic/PEC/PMC
 
    tidy3d.PECMedium
    tidy3d.PMCMedium
-   tidy3d.LossyMetalMedium
-   tidy3d.SurfaceImpedanceFitterParam
-   tidy3d.HammerstadSurfaceRoughness
-   tidy3d.HuraySurfaceRoughness
+   tidy3d.rf.LossyMetalMedium
+   tidy3d.rf.SurfaceImpedanceFitterParam
+   tidy3d.rf.HammerstadSurfaceRoughness
+   tidy3d.rf.HuraySurfaceRoughness
 
 At lower frequencies, the EM field typically does not penetrate very far into the metallic medium. In this regime, metallic structures are commonly modeled as boundary conditions. In Tidy3D, a metallic medium is assigned to a structure and the corresponding boundary conditions are automatically applied to its geometric boundaries.
 
@@ -205,11 +205,11 @@ At lower frequencies, the EM field typically does not penetrate very far into th
    # lossy metal (conductivity in S/um)
    my_lossy_metal = LossyMetalMedium(conductivity=58, freq_range=(1e9, 10e9))
 
-The :class:`.LossyMetalMedium` class implements the surface impedance boundary condition (SIBC). It can also accept surface roughness specifications using the Hammerstad or Huray models. Please refer to its documentation page for details.
+The :class:`~tidy3d.rf.LossyMetalMedium` class implements the surface impedance boundary condition (SIBC). It can also accept surface roughness specifications using the Hammerstad or Huray models. Please refer to its documentation page for details.
 
 .. note::
    
-   For lossy metallic mediums, always be sure to check the skin depth --- if the skin depth is not negligible compared to the structure size, then :class:`.LossyMetalMedium` may be not accurate. In that case, use a regular dispersive medium instead.
+   For lossy metallic mediums, always be sure to check the skin depth --- if the skin depth is not negligible compared to the structure size, then :class:`~tidy3d.rf.LossyMetalMedium` may be not accurate. In that case, use a regular dispersive medium instead.
 
 ~~~~
 
@@ -286,6 +286,8 @@ Perturbation (Multiphysics)
    tidy3d.PerturbationPoleResidue
    tidy3d.NedeljkovicSorefMashanovich
    tidy3d.ParameterPerturbation
+   tidy3d.PermittivityPerturbation
+   tidy3d.IndexPerturbation
 
 When performing a multiphysics simulation, the temperature or carrier density field will result in a perturbation to the optical medium.
 

--- a/docs/api/microwave/impedance_calculator.rst
+++ b/docs/api/microwave/impedance_calculator.rst
@@ -124,7 +124,7 @@ The impedance calculator and path integral classes work with various types of fi
 * :class:`~tidy3d.ModeSolverData`: Mode field profiles from 2D mode solver
 * :class:`~tidy3d.FieldData`: Frequency-domain field data from monitors
 * :class:`~tidy3d.FieldTimeData`: Time-domain field data from monitors
-* :class:`~tidy3d.MicrowaveModeSolverData`: Microwave mode solver data (includes pre-computed integrals)
+* :class:`~tidy3d.rf.MicrowaveModeSolverData`: Microwave mode solver data (includes pre-computed integrals)
 
 .. code-block:: python
 

--- a/docs/api/microwave/path_integrals.rst
+++ b/docs/api/microwave/path_integrals.rst
@@ -7,7 +7,7 @@ Path integrals compute voltage and current from electromagnetic field data by in
 
 .. note::
 
-   For information on how path integrals are used to calculate characteristic impedance in transmission line mode analysis, see :ref:`microwave_mode_solver`. For the corresponding specification classes (``*Spec``) used in :class:`~tidy3d.MicrowaveModeSpec`, see the end of this page.
+   For information on how path integrals are used to calculate characteristic impedance in transmission line mode analysis, see :ref:`microwave_mode_solver`. For the corresponding specification classes (``*Spec``) used in :class:`~tidy3d.rf.MicrowaveModeSpec`, see the end of this page.
 
 Voltage Path Integrals
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -212,7 +212,7 @@ Additional Information
 
 **Path Integral Specification Classes**
 
-The classes documented above (``*Integral``) are **execution classes** that perform actual computations on field data. For use in :class:`~tidy3d.MicrowaveModeSpec` impedance specifications, corresponding **specification classes** (``*Spec``) exist:
+The classes documented above (``*Integral``) are **execution classes** that perform actual computations on field data. For use in :class:`~tidy3d.rf.MicrowaveModeSpec` impedance specifications, corresponding **specification classes** (``*Spec``) exist:
 
 .. autosummary::
    :toctree: ../_autosummary/
@@ -224,7 +224,7 @@ The classes documented above (``*Integral``) are **execution classes** that perf
    tidy3d.rf.Custom2DCurrentIntegralSpec
    tidy3d.rf.CompositeCurrentIntegralSpec
 
-These specification classes have the same parameters but are used for configuration (in :class:`~tidy3d.CustomImpedanceSpec`) rather than direct computation. See :ref:`microwave_mode_solver` for their usage in mode analysis.
+These specification classes have the same parameters but are used for configuration (in :class:`~tidy3d.rf.CustomImpedanceSpec`) rather than direct computation. See :ref:`microwave_mode_solver` for their usage in mode analysis.
 
 .. seealso::
 

--- a/docs/api/microwave/ports/lumped.rst
+++ b/docs/api/microwave/ports/lumped.rst
@@ -10,7 +10,7 @@ Lumped Port & Elements
    tidy3d.rf.LumpedPort
    tidy3d.rf.CoaxialLumpedPort
 
-The :class:`LumpedPort` feature represents a planar, uniform current excitation with a fixed impedance termination.
+The :class:`~tidy3d.rf.LumpedPort` feature represents a planar, uniform current excitation with a fixed impedance termination.
 
 .. code-block:: python
 
@@ -23,7 +23,7 @@ The :class:`LumpedPort` feature represents a planar, uniform current excitation 
        impedance=50,   # port impedance
    )
 
-The :class:`LumpedPort` must be planar (exactly one zero-size dimension). Only axis-aligned planes are supported at this time. If you need a narrow port, provide a small but finite width along the lateral axis. Only real ``impedance`` values are supported at this time. 
+The :class:`~tidy3d.rf.LumpedPort` must be planar (exactly one zero-size dimension). Only axis-aligned planes are supported at this time. If you need a narrow port, provide a small but finite width along the lateral axis. Only real ``impedance`` values are supported at this time.
 
 .. note::
 

--- a/docs/api/monitors.rst
+++ b/docs/api/monitors.rst
@@ -184,6 +184,20 @@ For more detailed examples, please refer to the demo models linked below.
 
 ~~~~
 
+Gaussian Overlap
+----------------
+
+.. autosummary::
+   :toctree: _autosummary/
+   :template: module.rst
+
+   tidy3d.GaussianOverlapMonitor
+   tidy3d.AstigmaticGaussianOverlapMonitor
+
+These monitors decompose fields onto Gaussian beams to record overlap amplitudes.
+
+~~~~
+
 Far-field
 ---------
 
@@ -194,7 +208,7 @@ Far-field
    tidy3d.FieldProjectionCartesianMonitor
    tidy3d.FieldProjectionAngleMonitor
    tidy3d.FieldProjectionKSpaceMonitor
-   tidy3d.DirectivityMonitor
+   tidy3d.rf.DirectivityMonitor
    tidy3d.AuxFieldTimeMonitor
 
 The far-field monitor records the near-field within the simulation domain in order to project it to some far away location. This can be a very efficient way to simulate the scattering or radiative response of devices such as lenses and antenna.

--- a/docs/api/output_data.rst
+++ b/docs/api/output_data.rst
@@ -59,7 +59,7 @@ List of Monitor Data Types
    tidy3d.FieldProjectionCartesianData
    tidy3d.FieldProjectionKSpaceData
    tidy3d.DiffractionData
-   tidy3d.DirectivityData
+   tidy3d.rf.DirectivityData
    tidy3d.AuxFieldTimeData
 
 
@@ -77,6 +77,8 @@ List of Dataset Types
    tidy3d.ScalarFieldDataArray
    tidy3d.ScalarModeFieldDataArray
    tidy3d.ScalarFieldTimeDataArray
+   tidy3d.components.data.data_array.FreqDataArray
+   tidy3d.components.data.data_array.FreqModeDataArray
    tidy3d.ModeAmpsDataArray
    tidy3d.ModeIndexDataArray
    tidy3d.FluxDataArray
@@ -85,6 +87,4 @@ List of Dataset Types
    tidy3d.FieldProjectionCartesianDataArray
    tidy3d.FieldProjectionKSpaceDataArray
    tidy3d.DiffractionDataArray
-   tidy3d.DirectivityDataArray
-   tidy3d.AxialRatioDataArray
    tidy3d.SteadyVoltageDataArray

--- a/docs/api/plugins/klayout.rst
+++ b/docs/api/plugins/klayout.rst
@@ -41,7 +41,7 @@ DRC Results
    :template: module.rst
 
     tidy3d.plugins.klayout.DRCResults
-    tidy3d.plugins.klayout.drc.DRCViolation
+    tidy3d.plugins.klayout.drc.results.DRCViolation
 
 DRC Markers
 ^^^^^^^^^^^
@@ -50,9 +50,9 @@ DRC Markers
    :toctree: ../_autosummary/
    :template: module.rst
 
-    tidy3d.plugins.klayout.drc.EdgeMarker
-    tidy3d.plugins.klayout.drc.EdgePairMarker
-    tidy3d.plugins.klayout.drc.MultiPolygonMarker
+    tidy3d.plugins.klayout.drc.results.EdgeMarker
+    tidy3d.plugins.klayout.drc.results.EdgePairMarker
+    tidy3d.plugins.klayout.drc.results.MultiPolygonMarker
 
 Utilities
 ~~~~~~~~~

--- a/docs/api/plugins/smatrix.rst
+++ b/docs/api/plugins/smatrix.rst
@@ -6,7 +6,7 @@ S-Matrix Component Modelers Plugin
 This plugin provides component modelers for computing S-parameters (scattering parameters) for both **photonics** and **RF/microwave** applications. The plugin supports:
 
 * **Photonics**: Modal component modelers for photonic devices (waveguides, splitters, filters, etc.)
-* **RF/Microwave**: Terminal component modelers for microwave circuits and antennas (available in :class:`tidy3d.rf` subpackage as well)
+* **RF/Microwave**: Terminal component modelers for microwave circuits and antennas (available in the :mod:`~tidy3d.rf` subpackage as well)
 
 .. warning::
 
@@ -69,6 +69,6 @@ Further Details
    :template: module.rst
 
    tidy3d.plugins.smatrix.AbstractComponentModeler
-   tidy3d.plugins.smatrix.AbstractComponentModelerData
+   tidy3d.plugins.smatrix.data.base.AbstractComponentModelerData
    tidy3d.SimulationMap
    tidy3d.SimulationDataMap

--- a/docs/api/spice.rst
+++ b/docs/api/spice.rst
@@ -24,7 +24,7 @@ Analysis
 
    tidy3d.SteadyChargeDCAnalysis
    tidy3d.IsothermalSteadyChargeDCAnalysis
-   tidy3d.AbstractSSACAnalysis
+   tidy3d.components.spice.analysis.ac.AbstractSSACAnalysis
    tidy3d.SSACAnalysis
    tidy3d.IsothermalSSACAnalysis
    tidy3d.SteadyChargeDCAnalysis

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,11 +20,14 @@
 from __future__ import annotations
 
 import datetime
+import inspect
 import logging
 import os
 import re
 import subprocess
 import sys
+from pathlib import Path
+from typing import get_args, get_origin
 
 import tidy3d
 
@@ -62,6 +65,7 @@ master_doc = "index"  # The master toctree document.s
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 add_module_names = False  # Remove namespaces from class/method signatures
 autosummary_generate = full_build  # Turn on sphinx.ext.autosummary
+autosummary_generate_overwrite = True  # Regenerate autosummary stubs to match templates
 # autoclass_content = "both"  # Add __init__ doc (ie. params) to class summaries
 # autodoc_inherit_docstrings = True  # If no docstring, inherit from base class
 autodoc_class_signature = "separated"
@@ -69,7 +73,9 @@ autodoc_default_options = {
     "members": True,
     "member-order": "bysource",
     "undoc-members": True,
-    "exclude-members": "__hash__",
+    # Keep this list short and focused on public-named internals.
+    # Private/dunder members are filtered via autodoc_skip_member.
+    "exclude-members": ("attrs, model_config, model_post_init, type"),
 }
 autodoc_typehints = "none"
 ## TODO DEBATE KEEP
@@ -118,6 +124,11 @@ extensions = [
     "custom-sitemap",  # In _ext, these need to be at the end of the extensions list
     "custom-robots",  # In _ext, these need to be at the end of the extensions list
 ]
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "pydantic": ("https://docs.pydantic.dev/latest/", None),
+    "xarray": ("https://docs.xarray.dev/en/stable/", None),
+}
 extlinks = {}
 favicons = [
     {
@@ -183,10 +194,13 @@ napoleon_google_docstring = False
 napoleon_numpy_docstring = True
 napoleon_include_init_with_doc = False
 napoleon_include_private_with_doc = False
-napoleon_include_special_with_doc = True
+# Don't include dunder ("special") methods like __get_pydantic_core_schema__ in API docs.
+# These are implementation details and tend to be very noisy.
+napoleon_include_special_with_doc = False
 napoleon_use_admonition_for_examples = False
 napoleon_use_admonition_for_notes = False
 napoleon_use_admonition_for_references = False
+napoleon_preprocess_types = False
 napoleon_use_ivar = False
 napoleon_use_param = True
 napoleon_use_rtype = True
@@ -309,7 +323,271 @@ def add_autosummary_filter(app):
     logger.addFilter(AutosummaryFilter())
 
 
+_PYDANTIC_MODEL_DOCS: dict[str, str] | None = None
+_ALIAS_TYPE_DOCS: dict[str, str] | None = None
+_ALIAS_ROLE_RE = re.compile(r":class:`([^`]+)`")
+_TIDY3D_CLASS_MAP: dict[str, str] | None = None
+_DOC_TARGETS: set[str] | None = None
+_MAX_ALIAS_REWRITE_DEPTH = 8
+
+
+def _get_pydantic_model_docs() -> dict[str, str]:
+    """Cache default Pydantic model_* docstrings to detect generic entries."""
+    global _PYDANTIC_MODEL_DOCS
+    if _PYDANTIC_MODEL_DOCS is not None:
+        return _PYDANTIC_MODEL_DOCS
+    docs: dict[str, str] = {}
+    try:
+        from pydantic import BaseModel
+
+        for attr_name in dir(BaseModel):
+            if not attr_name.startswith("model_"):
+                continue
+            doc = getattr(getattr(BaseModel, attr_name, None), "__doc__", None)
+            if doc:
+                docs[attr_name] = doc.strip()
+    except Exception:
+        docs = {}
+    _PYDANTIC_MODEL_DOCS = docs
+    return docs
+
+
+def _get_alias_type_docs() -> dict[str, str]:
+    """Cache formatted representations for tidy3d.components.types aliases."""
+    global _ALIAS_TYPE_DOCS
+    if _ALIAS_TYPE_DOCS is not None:
+        return _ALIAS_TYPE_DOCS
+    docs: dict[str, str] = {}
+    try:
+        from tidy3d.components import types as td_types
+        from tidy3d.components.docstrings import _fmt_ann_literal
+
+        for name in getattr(td_types, "__all__", []):
+            if name.startswith("_"):
+                continue
+            val = getattr(td_types, name, None)
+            if val is None:
+                continue
+            if isinstance(val, type):
+                continue
+            docs[name] = _fmt_ann_literal(val)
+    except Exception:
+        docs = {}
+    _ALIAS_TYPE_DOCS = docs
+    return docs
+
+
+def _get_tidy3d_class_map() -> dict[str, str]:
+    """Return a map of unique class names to fully qualified modules."""
+    global _TIDY3D_CLASS_MAP
+    if _TIDY3D_CLASS_MAP is not None:
+        return _TIDY3D_CLASS_MAP
+    class_map: dict[str, str] = {}
+    ambiguous: set[str] = set()
+    root = Path(tidy3d.__file__).resolve().parent
+    for path in root.rglob("*.py"):
+        # Build a python module path relative to the tidy3d package root.
+        rel = path.relative_to(root).with_suffix("")
+        # package/__init__.py should map to package, not package.__init__.
+        if rel.name == "__init__":
+            rel = rel.parent
+        module = "tidy3d"
+        if rel.parts:
+            module += "." + ".".join(rel.parts)
+        try:
+            text = path.read_text(errors="ignore")
+        except Exception:
+            continue
+        for match in re.finditer(r"^class\s+(\w+)\b", text, re.M):
+            name = match.group(1)
+            full = f"{module}.{name}"
+            if name in class_map and class_map[name] != full:
+                ambiguous.add(name)
+            else:
+                class_map[name] = full
+    for name in ambiguous:
+        class_map.pop(name, None)
+    _TIDY3D_CLASS_MAP = class_map
+    return class_map
+
+
+def _get_doc_targets() -> set[str]:
+    """Collect documented object names to avoid emitting dead xrefs."""
+    global _DOC_TARGETS
+    if _DOC_TARGETS is not None:
+        return _DOC_TARGETS
+    targets: set[str] = set()
+    api_root = Path(here) / "api"
+    for path in api_root.rglob("_autosummary/*.rst"):
+        stem = path.stem.lstrip("\ufeff")
+        targets.add(stem)
+    xref_targets = api_root / "xref_targets.rst"
+    if xref_targets.exists():
+        for line in xref_targets.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith("tidy3d."):
+                targets.add(stripped)
+    _DOC_TARGETS = targets
+    return targets
+
+
+def autodoc_skip_member(app, what, name, obj, skip, options):
+    short_name = name.rsplit(".", 1)[-1]
+    if short_name.startswith("_"):
+        return True
+    return None
+
+
+def autodoc_process_docstring(app, what, name, obj, options, lines):
+    obj_module = getattr(obj, "__module__", "") or ""
+    short_name = name.rsplit(".", 1)[-1]
+    # Keep model_* methods listed, but clear their default Pydantic docstrings.
+    # Otherwise Sphinx renders the verbose "Usage Documentation" blocks.
+    if obj_module.startswith("pydantic") and short_name.startswith("model_"):
+        doc = (getattr(obj, "__doc__", "") or "").strip()
+        if not doc or _get_pydantic_model_docs().get(short_name) == doc:
+            lines.clear()
+            return
+        if doc.startswith('!!! abstract "Usage Documentation"'):
+            # Strip the default Pydantic MyST admonition so it doesn't render as a noisy block.
+            while lines and lines[0].strip() != "":
+                lines.pop(0)
+            while lines and lines[0].strip() == "":
+                lines.pop(0)
+            return
+    alias_docs = _get_alias_type_docs()
+    if not alias_docs:
+        return
+
+    owner_module = sys.modules.get(obj_module)
+    class_map = _get_tidy3d_class_map()
+    doc_targets = _get_doc_targets()
+
+    def _format_annotation_value(value: object) -> str | None:
+        try:
+            if isinstance(value, type) or get_origin(value) is not None or get_args(value):
+                from tidy3d.components.docstrings import _fmt_ann_literal
+
+                return _fmt_ann_literal(value)
+        except Exception:
+            return None
+        return None
+
+    for idx, line in enumerate(lines):
+
+        def _substitute_roles(text: str, depth: int = 0, seen: tuple[str, ...] = ()) -> str:
+            def _callback(match: re.Match[str]) -> str:
+                return _replace(match, depth=depth, seen=seen)
+
+            return _ALIAS_ROLE_RE.sub(_callback, text)
+
+        def _replace(
+            match: re.Match[str],
+            *,
+            depth: int = 0,
+            seen: tuple[str, ...] = (),
+        ) -> str:
+            raw_target = match.group(1).strip()
+            target = raw_target.lstrip("~")
+            is_relative = target.startswith(".")
+            if is_relative:
+                target = target[1:]
+            name_only = target.split(".")[-1]
+            if depth >= _MAX_ALIAS_REWRITE_DEPTH or target in seen:
+                return f"``{name_only}``"
+            tidy_alias = f"tidy3d.{name_only}"
+            rf_alias = f"tidy3d.rf.{name_only}"
+
+            def _best_doc_target(prefer: str | None = None) -> str | None:
+                """Pick a documented target for a name based on shared prefixes."""
+                candidates = [
+                    cand
+                    for cand in doc_targets
+                    if cand == tidy_alias or cand == rf_alias or cand.endswith(f".{name_only}")
+                ]
+                if not candidates:
+                    return None
+                if prefer:
+                    parts = prefer.split(".")[:-1]
+                    for i in range(len(parts), 0, -1):
+                        prefix = ".".join(parts[:i]) + "."
+                        pref = [cand for cand in candidates if cand.startswith(prefix)]
+                        if pref:
+                            return min(pref, key=len)
+                return min(candidates, key=len)
+
+            replacement = alias_docs.get(name_only)
+            if replacement is not None:
+                # Avoid dumping extremely long type aliases inline (hurts readability).
+                if len(replacement) > 200:
+                    return f"``{name_only}``"
+                # If the formatted alias contains xrefs, don't wrap it in a literal block
+                # (otherwise the roles won't be parsed and will render as raw text).
+                if ":class:`" in replacement:
+                    return _substitute_roles(replacement, depth=depth + 1, seen=(*seen, target))
+                return f"``{replacement}``"
+
+            if owner_module is None:
+                return match.group(0)
+            if "." in target and not is_relative:
+                if target.startswith("tidy3d."):
+                    if target in doc_targets:
+                        return match.group(0)
+                    if tidy_alias in doc_targets:
+                        return f":class:`~{tidy_alias}`"
+                    if rf_alias in doc_targets:
+                        return f":class:`~{rf_alias}`"
+                    best = _best_doc_target(target)
+                    if best is not None:
+                        return f":class:`~{best}`"
+                    return f"``{name_only}``"
+                return f"``{target}``"
+            candidate = getattr(owner_module, name_only, None)
+            if candidate is None:
+                full = class_map.get(name_only)
+                if full is None:
+                    return f"``{name_only}``"
+                if full in doc_targets:
+                    return f":class:`~{full}`"
+                if tidy_alias in doc_targets:
+                    return f":class:`~{tidy_alias}`"
+                if rf_alias in doc_targets:
+                    return f":class:`~{rf_alias}`"
+                best = _best_doc_target(full)
+                if best is not None:
+                    return f":class:`~{best}`"
+                return f"``{name_only}``"
+
+            if inspect.isclass(candidate) and candidate.__module__.startswith("tidy3d"):
+                full = f"{candidate.__module__}.{candidate.__name__}"
+                if full in doc_targets:
+                    return f":class:`~{full}`"
+                if tidy_alias in doc_targets:
+                    return f":class:`~{tidy_alias}`"
+                if rf_alias in doc_targets:
+                    return f":class:`~{rf_alias}`"
+                best = _best_doc_target(full)
+                if best is not None:
+                    return f":class:`~{best}`"
+                return f"``{candidate.__name__}``"
+
+            formatted = _format_annotation_value(candidate)
+            if formatted is not None:
+                if len(formatted) > 200:
+                    return f"``{name_only}``"
+                if ":class:`" in formatted:
+                    return _substitute_roles(formatted, depth=depth + 1, seen=(*seen, target))
+                return f"``{formatted}``"
+
+            return f"``{name_only}``"
+
+        lines[idx] = _substitute_roles(line)
+
+
 def setup(app):
     # Apply the custom filter early in the build process
     app.connect("builder-inited", add_autosummary_filter)
     app.connect("builder-inited", add_import_warning_filter)
+    # Run before napoleon's own skip-member hook so private/dunder members stay hidden.
+    app.connect("autodoc-skip-member", autodoc_skip_member, priority=0)
+    app.connect("autodoc-process-docstring", autodoc_process_docstring)

--- a/docs/configuration/reference.rst
+++ b/docs/configuration/reference.rst
@@ -251,29 +251,6 @@ Controls the optional on-disk cache for simulation artifacts.
      - Maximum number of cached simulations retained. ``0`` means no limit and eviction falls back to size constraints.
 
 
-Batch Data Cache (``config.batch_data_cache``)
-----------------------------------------------
-
-Controls the in-memory cache used when accessing entries in ``BatchData``.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 24 18 10 48
-
-   * - Option
-     - Default
-     - Persisted
-     - Description
-   * - ``enabled``
-     - ``True``
-     - No
-     - Cache batch results in memory when all task data files are below the size threshold.
-   * - ``max_total_size_gb``
-     - ``1.0``
-     - No
-     - Cache batch task data only when the combined size of all task data files is at or below this threshold. ``0`` disables caching.
-
-
 Plugins (``config.plugins``)
 ----------------------------
 

--- a/docs/development/documentation.rst
+++ b/docs/development/documentation.rst
@@ -103,4 +103,3 @@ Writing Documentation
     - for subsections
     ^ for subsubsections
     " for paragraphs
-

--- a/scripts/make_script.py
+++ b/scripts/make_script.py
@@ -57,21 +57,31 @@ def main(args):
 
     # new we need to get rid of all the "type" info that isn't needed
 
-    # remove type='...', in middle
-    pattern = r"type='([A-Za-z0-9_\./\\-]*)', "
+    # Remove only the discriminator field named exactly `type=...` without touching
+    # unrelated fields like `simulation_type=...`.
+    #
+    # We handle four positions separately to preserve valid python syntax:
+    # - start:  (type='Foo', x=1) -> (x=1)
+    # - middle: (x=1, type='Foo', y=2) -> (x=1, y=2)
+    # - end:    (x=1, type='Foo') -> (x=1)
+    # - only:   (type='Foo') -> ()
+    type_value_pattern = r"(?:'[^']*'|\"[^\"]*\")"
+
+    # remove `type=...` at start of argument list
+    pattern = rf"(?<=\()\s*type={type_value_pattern}\s*,\s*"
     sim_string = re.sub(pattern, "", sim_string)
 
-    # remove , type='...')
-    pattern = r", type='([A-Za-z0-9_\./\\-]*)'\)"
+    # remove `type=...` in the middle of argument list
+    pattern = rf"(?<=,)\s*type={type_value_pattern}\s*,\s*"
+    sim_string = re.sub(pattern, "", sim_string)
+
+    # remove `type=...` at end of argument list
+    pattern = rf",\s*type={type_value_pattern}\s*\)"
     sim_string = re.sub(pattern, ")", sim_string)
 
-    # remove (type='...'),
-    pattern = r"\(type='([A-Za-z0-9_\./\\-]*)'\)"
+    # remove `type=...` as the only argument
+    pattern = rf"\(\s*type={type_value_pattern}\s*\)"
     sim_string = re.sub(pattern, "()", sim_string)
-
-    # remove (type='...',
-    pattern = r"\(type='([A-Za-z0-9_\./\\-]*)', "
-    sim_string = re.sub(pattern, "(", sim_string)
 
     # write sim_string to a temporary file
     with tempfile.NamedTemporaryFile(

--- a/tests/test_components/test_docstrings.py
+++ b/tests/test_components/test_docstrings.py
@@ -1,0 +1,49 @@
+"""Regression checks for generated docstrings."""
+
+from __future__ import annotations
+
+import tidy3d as td
+
+
+def _assert_clean_docstring(cls: type[td.Tidy3dBaseModel], expected_snippets: list[str]) -> None:
+    doc = cls.generate_docstring()
+    assert "Annotated[" not in doc
+    assert "discriminated_union" not in doc
+    assert "typing_extensions." not in doc
+    for snippet in expected_snippets:
+        assert snippet in doc
+
+
+def test_docstring_type_formatting() -> None:
+    _assert_clean_docstring(
+        td.Box,
+        [
+            "center : Optional[tuple[Union[float, autograd.tracer.Box]",
+            "size : tuple[Union[NonNegativeFloat, autograd.tracer.Box]",
+        ],
+    )
+    _assert_clean_docstring(
+        td.GridSpec,
+        [
+            "grid_x : Union[:class:`~tidy3d.components.grid.grid_spec.UniformGrid`",
+            "wavelength : Optional[PositiveFloat]",
+        ],
+    )
+    _assert_clean_docstring(
+        td.ModeSpec,
+        [
+            "num_modes : PositiveInt = 1",
+            "bend_axis : Optional[Literal[0, 1]]",
+            "sort_spec : :class:`~tidy3d.components.mode_spec.ModeSortSpec` = ModeSortSpec()",
+        ],
+    )
+    _assert_clean_docstring(
+        td.BoundarySpec,
+        ["x : :class:`~tidy3d.components.boundary.Boundary` = Boundary()"],
+    )
+
+
+def test_docstring_updated_after_model_rebuild() -> None:
+    doc = td.ClipOperation.__doc__ or ""
+    assert "discriminated_union" not in doc
+    assert "Union[" in doc

--- a/tests/test_components/test_repr.py
+++ b/tests/test_components/test_repr.py
@@ -1,0 +1,21 @@
+"""Regression checks for model __repr__ implementations."""
+
+from __future__ import annotations
+
+import tidy3d as td
+
+
+def test_required_field_model_repr_is_clean() -> None:
+    """__repr__ should not recurse when the class can't be instantiated with no args."""
+    b = td.Box(center=(1, 2, 3), size=(2, 2, 2))
+    r = repr(b)
+
+    # These are implementation details injected by Tidy3dBaseModel and shouldn't
+    # leak into the concise repr.
+    assert "type=" not in r
+    assert "attrs=" not in r
+
+    # Sanity check that we still include key information.
+    assert r.startswith("Box(")
+    assert "center=" in r
+    assert "size=" in r

--- a/tests/test_material_library/test_material_library.py
+++ b/tests/test_material_library/test_material_library.py
@@ -63,7 +63,7 @@ def test_medium_repr():
     test_media = [
         td.Medium(permittivity=1.5**2),
         td.Medium(permittivity=1.5**2, name=material_name),
-        td.material_library["SiO2"]["Horiba"].updated_copy(name=None),
+        td.material_library["SiO2"]["Horiba"],
     ]
     noname_medium_in_dict = {"medium": test_media[0]}
 
@@ -72,7 +72,7 @@ def test_medium_repr():
     str_noname_medium_dict = str(noname_medium_in_dict)
 
     assert "name=None," in str_noname_medium, "Expected medium information in string"
-    assert "name=None" in repr_noname_medium, "Expected medium information in repr"
+    assert "permittivity=" in repr_noname_medium, "Expected medium information in repr"
     assert repr_noname_medium in str_noname_medium_dict, "Expected repr in dictionary string"
 
     for medium in test_media:

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -196,6 +196,8 @@ from .components.data.data_array import (
     FieldProjectionKSpaceDataArray,
     FluxDataArray,
     FluxTimeDataArray,
+    FreqDataArray,
+    FreqModeDataArray,
     GroupIndexDataArray,
     HeatDataArray,
     IndexedDataArray,
@@ -405,7 +407,6 @@ from .components.parameter_perturbation import (
 # run time spec
 from .components.run_time_spec import RunTimeSpec
 
-# scene
 # scene
 from .components.scene import Scene
 
@@ -642,7 +643,6 @@ __all__ = [
     "EMEScalarModeFieldDataArray",
     "EMESimulation",
     "EMESimulationData",
-    "EMESweepSpec",
     "EMEUniformGrid",
     "FieldData",
     "FieldDataset",
@@ -674,6 +674,8 @@ __all__ = [
     "FluxTimeDataArray",
     "FluxTimeMonitor",
     "FossumCarrierLifetime",
+    "FreqDataArray",
+    "FreqModeDataArray",
     "FreqRange",
     "FrequencyUtils",
     "FullyAnisotropicMedium",

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -8,7 +8,6 @@ import json
 import math
 import os
 import tempfile
-import typing as _t
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from functools import total_ordering, wraps
@@ -16,7 +15,17 @@ from math import ceil
 from os import PathLike
 from pathlib import Path
 from types import UnionType
-from typing import TYPE_CHECKING, Any, Literal, Optional, TypeVar, Union, get_args, get_origin
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Literal,
+    Optional,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
 
 import h5py
 import numpy as np
@@ -33,6 +42,12 @@ from tidy3d.log import log
 from .autograd.types import TracedDict
 from .autograd.utils import get_static
 from .data.data_array import DATA_ARRAY_MAP
+from .docstrings import (
+    _DOCSTRING_RAW_ATTR,
+    _clean_default_repr,
+    _fmt_ann_literal,
+    _format_model_default,
+)
 from .file_util import compress_file_to_gzip, extract_gzip_file
 from .types import TYPE_TAG_STR, Undefined
 
@@ -145,15 +160,6 @@ def _get_valid_extension(fname: PathLike) -> str:
     )
 
 
-def _fmt_ann_literal(ann: Any) -> str:
-    """Spell the annotation exactly as written."""
-    if ann is None:
-        return "Any"
-    if isinstance(ann, _t._GenericAlias):
-        return str(ann).replace("typing.", "")
-    return ann.__name__ if hasattr(ann, "__name__") else str(ann)
-
-
 T = TypeVar("T", bound="Tidy3dBaseModel")
 
 
@@ -190,6 +196,9 @@ class Tidy3dBaseModel(BaseModel):
         extra="forbid",
         frozen=True,
     )
+
+    _DOCSTRING_SHOW_DEFAULT_ARGS: ClassVar[bool] = False
+    _DOCSTRING_INCLUDE_ATTRS: ClassVar[bool] = False
 
     attrs: dict = Field(
         default_factory=dict,
@@ -253,7 +262,29 @@ class Tidy3dBaseModel(BaseModel):
         super().__pydantic_init_subclass__(**kwargs)
 
         # add docstring once pydantic is done constructing the class
+        if _DOCSTRING_RAW_ATTR not in cls.__dict__:
+            setattr(cls, _DOCSTRING_RAW_ATTR, cls.__doc__ or "")
         cls.__doc__ = cls.generate_docstring()
+
+    @classmethod
+    def model_rebuild(
+        cls,
+        *,
+        force: bool = False,
+        raise_errors: bool = True,
+        _parent_namespace_depth: int = 2,
+        _types_namespace: Mapping[str, Any] | None = None,
+    ) -> bool | None:
+        rebuilt = super().model_rebuild(
+            force=force,
+            raise_errors=raise_errors,
+            _parent_namespace_depth=_parent_namespace_depth + 1,
+            _types_namespace=_types_namespace,
+        )
+        if _DOCSTRING_RAW_ATTR not in cls.__dict__:
+            setattr(cls, _DOCSTRING_RAW_ATTR, cls.__doc__ or "")
+        cls.__doc__ = cls.generate_docstring()
+        return rebuilt
 
     @model_validator(mode="wrap")
     @classmethod
@@ -648,12 +679,12 @@ class Tidy3dBaseModel(BaseModel):
         Recursively traverses a model structure yielding Tidy3dBaseModel instances and their paths.
 
         This is an internal helper method used by :meth:`find_paths` and :meth:`find_submodels`
-        to navigate nested :class:`Tidy3dBaseModel` structures.
+        to navigate nested :class:`~tidy3d.Tidy3dBaseModel` structures.
 
         Parameters
         ----------
         current_obj : Any
-            The current object in the traversal, which can be a :class:`Tidy3dBaseModel`,
+            The current object in the traversal, which can be a :class:`~tidy3d.Tidy3dBaseModel`,
             list, tuple, or other type.
         current_path_segments : tuple[str, ...]
             A tuple of strings representing the path segments from the initial model
@@ -662,7 +693,7 @@ class Tidy3dBaseModel(BaseModel):
         Returns
         -------
         Iterator[tuple[Self, tuple[str, ...]]]
-            An iterator yielding tuples, where the first element is a found :class:`Tidy3dBaseModel` instance
+            An iterator yielding tuples, where the first element is a found :class:`~tidy3d.Tidy3dBaseModel` instance
             and the second is a tuple of strings representing the path to that instance
             from the initial object. The path for the top-level model itself will be an empty tuple.
         """
@@ -699,7 +730,7 @@ class Tidy3dBaseModel(BaseModel):
         ----------
         target_field_name : str
             The name of the attribute (field) to search for within nested
-            :class:`Tidy3dBaseModel` instances. For example, ``"name"`` or ``"permittivity"``.
+            :class:`~tidy3d.Tidy3dBaseModel` instances. For example, ``"name"`` or ``"permittivity"``.
         target_field_value : Any, optional
             If provided, only paths to model instances where ``target_field_name`` also has this
             specific value will be returned. If omitted, paths are returned if the
@@ -709,7 +740,7 @@ class Tidy3dBaseModel(BaseModel):
         -------
         list[str]
             A sorted list of unique string paths. Each path points to a
-            :class:`Tidy3dBaseModel` instance that possesses the ``target_field_name``
+            :class:`~tidy3d.Tidy3dBaseModel` instance that possesses the ``target_field_name``
             (and optionally matches ``target_field_value``).
 
         Example
@@ -753,7 +784,7 @@ class Tidy3dBaseModel(BaseModel):
         ----------
         target_type : Tidy3dBaseModel
             The specific Tidy3D class (e.g., ``Structure``, ``Medium``, ``Box``) to search for.
-            This class must be a subclass of :class:`Tidy3dBaseModel`.
+            This class must be a subclass of :class:`~tidy3d.Tidy3dBaseModel`.
 
         Returns
         -------
@@ -790,7 +821,7 @@ class Tidy3dBaseModel(BaseModel):
         return list(found_models_dict.keys())
 
     def help(self, methods: bool = False) -> None:
-        """Prints message describing the fields and methods of a :class:`Tidy3dBaseModel`.
+        """Prints message describing the fields and methods of a :class:`~tidy3d.Tidy3dBaseModel`.
 
         Parameters
         ----------
@@ -812,12 +843,12 @@ class Tidy3dBaseModel(BaseModel):
         on_load: Optional[Callable[[Any], None]] = None,
         **parse_obj_kwargs: Any,
     ) -> Self:
-        """Loads a :class:`Tidy3dBaseModel` from .yaml, .json, .hdf5, or .hdf5.gz file.
+        """Loads a :class:`~tidy3d.Tidy3dBaseModel` from .yaml, .json, .hdf5, or .hdf5.gz file.
 
         Parameters
         ----------
         fname : PathLike
-            Full path to the file to load the :class:`Tidy3dBaseModel` from.
+            Full path to the file to load the :class:`~tidy3d.Tidy3dBaseModel` from.
         group_path : Optional[str] = None
             Path to a group inside the file to use as the base level. Only for hdf5 files.
             Starting `/` is optional.
@@ -864,7 +895,7 @@ class Tidy3dBaseModel(BaseModel):
         Parameters
         ----------
         fname : PathLike
-            Full path to the file to load the :class:`Tidy3dBaseModel` from.
+            Full path to the file to load the :class:`~tidy3d.Tidy3dBaseModel` from.
         group_path : str, optional
             Path to a group inside the file to use as the base level.
 
@@ -900,12 +931,12 @@ class Tidy3dBaseModel(BaseModel):
         return converter(**kwargs)
 
     def to_file(self, fname: PathLike) -> None:
-        """Exports :class:`Tidy3dBaseModel` instance to .yaml, .json, or .hdf5 file
+        """Exports :class:`~tidy3d.Tidy3dBaseModel` instance to .yaml, .json, or .hdf5 file
 
         Parameters
         ----------
         fname : PathLike
-            Full path to the .yaml or .json file to save the :class:`Tidy3dBaseModel` to.
+            Full path to the .yaml or .json file to save the :class:`~tidy3d.Tidy3dBaseModel` to.
 
         Example
         -------
@@ -922,12 +953,12 @@ class Tidy3dBaseModel(BaseModel):
 
     @classmethod
     def from_json(cls: type[T], fname: PathLike, **model_validate_kwargs: Any) -> Self:
-        """Load a :class:`Tidy3dBaseModel` from .json file.
+        """Load a :class:`~tidy3d.Tidy3dBaseModel` from .json file.
 
         Parameters
         ----------
         fname : PathLike
-            Full path to the .json file to load the :class:`Tidy3dBaseModel` from.
+            Full path to the .json file to load the :class:`~tidy3d.Tidy3dBaseModel` from.
 
         Returns
         -------
@@ -950,7 +981,7 @@ class Tidy3dBaseModel(BaseModel):
         Parameters
         ----------
         fname : PathLike
-            Full path to the .json file to load the :class:`Tidy3dBaseModel` from.
+            Full path to the .json file to load the :class:`~tidy3d.Tidy3dBaseModel` from.
 
         Returns
         -------
@@ -966,12 +997,12 @@ class Tidy3dBaseModel(BaseModel):
         return model_dict
 
     def to_json(self, fname: PathLike) -> None:
-        """Exports :class:`Tidy3dBaseModel` instance to .json file
+        """Exports :class:`~tidy3d.Tidy3dBaseModel` instance to .json file
 
         Parameters
         ----------
         fname : PathLike
-            Full path to the .json file to save the :class:`Tidy3dBaseModel` to.
+            Full path to the .json file to save the :class:`~tidy3d.Tidy3dBaseModel` to.
 
         Example
         -------
@@ -987,12 +1018,12 @@ class Tidy3dBaseModel(BaseModel):
 
     @classmethod
     def from_yaml(cls: type[T], fname: PathLike, **model_validate_kwargs: Any) -> Self:
-        """Loads :class:`Tidy3dBaseModel` from .yaml file.
+        """Loads :class:`~tidy3d.Tidy3dBaseModel` from .yaml file.
 
         Parameters
         ----------
         fname : PathLike
-            Full path to the .yaml file to load the :class:`Tidy3dBaseModel` from.
+            Full path to the .yaml file to load the :class:`~tidy3d.Tidy3dBaseModel` from.
         **model_validate_kwargs
             Keyword arguments passed to pydantic's ``model_validate`` method.
 
@@ -1015,7 +1046,7 @@ class Tidy3dBaseModel(BaseModel):
         Parameters
         ----------
         fname : PathLike
-            Full path to the .yaml file to load the :class:`Tidy3dBaseModel` from.
+            Full path to the .yaml file to load the :class:`~tidy3d.Tidy3dBaseModel` from.
 
         Returns
         -------
@@ -1031,12 +1062,12 @@ class Tidy3dBaseModel(BaseModel):
         return model_dict
 
     def to_yaml(self, fname: PathLike) -> None:
-        """Exports :class:`Tidy3dBaseModel` instance to .yaml file.
+        """Exports :class:`~tidy3d.Tidy3dBaseModel` instance to .yaml file.
 
         Parameters
         ----------
         fname : PathLike
-            Full path to the .yaml file to save the :class:`Tidy3dBaseModel` to.
+            Full path to the .yaml file to save the :class:`~tidy3d.Tidy3dBaseModel` to.
 
         Example
         -------
@@ -1138,7 +1169,7 @@ class Tidy3dBaseModel(BaseModel):
         Parameters
         ----------
         fname : PathLike
-            Full path to the .hdf5 file to load the :class:`Tidy3dBaseModel` from.
+            Full path to the .hdf5 file to load the :class:`~tidy3d.Tidy3dBaseModel` from.
         group_path : str, optional
             Path to a group inside the file to selectively load a sub-element of the model only.
         custom_decoders : List[Callable]
@@ -1217,12 +1248,12 @@ class Tidy3dBaseModel(BaseModel):
         custom_decoders: Optional[list[Callable]] = None,
         **model_validate_kwargs: Any,
     ) -> Self:
-        """Loads :class:`Tidy3dBaseModel` instance to .hdf5 file.
+        """Loads :class:`~tidy3d.Tidy3dBaseModel` instance to .hdf5 file.
 
         Parameters
         ----------
         fname : PathLike
-            Full path to the .hdf5 file to load the :class:`Tidy3dBaseModel` from.
+            Full path to the .hdf5 file to load the :class:`~tidy3d.Tidy3dBaseModel` from.
         group_path : str, optional
             Path to a group inside the file to selectively load a sub-element of the model only.
             Starting `/` is optional.
@@ -1251,12 +1282,12 @@ class Tidy3dBaseModel(BaseModel):
         fname: Union[PathLike, io.BytesIO],
         custom_encoders: Optional[list[Callable]] = None,
     ) -> None:
-        """Exports :class:`Tidy3dBaseModel` instance to .hdf5 file.
+        """Exports :class:`~tidy3d.Tidy3dBaseModel` instance to .hdf5 file.
 
         Parameters
         ----------
         fname : Union[PathLike, BytesIO]
-            Full path to the .hdf5 file or buffer to save the :class:`Tidy3dBaseModel` to.
+            Full path to the .hdf5 file or buffer to save the :class:`~tidy3d.Tidy3dBaseModel` to.
         custom_encoders : List[Callable]
             List of functions accepting (fname: str, group_path: str, value: Any) that take
             the ``value`` supplied and write it to the hdf5 ``fname`` at ``group_path``.
@@ -1322,7 +1353,7 @@ class Tidy3dBaseModel(BaseModel):
         Parameters
         ----------
         fname : PathLike
-            Full path to the .hdf5.gz file to load the :class:`Tidy3dBaseModel` from.
+            Full path to the .hdf5.gz file to load the :class:`~tidy3d.Tidy3dBaseModel` from.
         group_path : str, optional
             Path to a group inside the file to selectively load a sub-element of the model only.
         custom_decoders : List[Callable]
@@ -1363,12 +1394,12 @@ class Tidy3dBaseModel(BaseModel):
         custom_decoders: Optional[list[Callable]] = None,
         **model_validate_kwargs: Any,
     ) -> Self:
-        """Loads :class:`Tidy3dBaseModel` instance to .hdf5.gz file.
+        """Loads :class:`~tidy3d.Tidy3dBaseModel` instance to .hdf5.gz file.
 
         Parameters
         ----------
         fname : PathLike
-            Full path to the .hdf5.gz file to load the :class:`Tidy3dBaseModel` from.
+            Full path to the .hdf5.gz file to load the :class:`~tidy3d.Tidy3dBaseModel` from.
         group_path : str, optional
             Path to a group inside the file to selectively load a sub-element of the model only.
             Starting `/` is optional.
@@ -1397,12 +1428,12 @@ class Tidy3dBaseModel(BaseModel):
         fname: Union[PathLike, io.BytesIO],
         custom_encoders: Optional[list[Callable]] = None,
     ) -> None:
-        """Exports :class:`Tidy3dBaseModel` instance to .hdf5.gz file.
+        """Exports :class:`~tidy3d.Tidy3dBaseModel` instance to .hdf5.gz file.
 
         Parameters
         ----------
         fname : Union[PathLike, BytesIO]
-            Full path to the .hdf5.gz file or buffer to save the :class:`Tidy3dBaseModel` to.
+            Full path to the .hdf5.gz file or buffer to save the :class:`~tidy3d.Tidy3dBaseModel` to.
         custom_encoders : List[Callable]
             List of functions accepting (fname: str, group_path: str, value: Any) that take
             the ``value`` supplied and write it to the hdf5 ``fname`` at ``group_path``.
@@ -1491,12 +1522,12 @@ class Tidy3dBaseModel(BaseModel):
 
     @cached_property_guarded(lambda self: self._attrs_digest())
     def _json_string(self) -> str:
-        """Returns string representation of a :class:`Tidy3dBaseModel`.
+        """Returns string representation of a :class:`~tidy3d.Tidy3dBaseModel`.
 
         Returns
         -------
         str
-            Json-formatted string holding :class:`Tidy3dBaseModel` data.
+            Json-formatted string holding :class:`~tidy3d.Tidy3dBaseModel` data.
         """
         return self.model_dump_json(indent=INDENT, exclude_unset=False)
 
@@ -1637,15 +1668,26 @@ class Tidy3dBaseModel(BaseModel):
         return static_self
 
     @classmethod
-    def generate_docstring(cls) -> str:
+    def generate_docstring(
+        cls,
+        show_default_args: Optional[bool] = None,
+        include_attrs: Optional[bool] = None,
+    ) -> str:
         """Generates a docstring for a Tidy3D model."""
+        if show_default_args is None:
+            show_default_args = cls._DOCSTRING_SHOW_DEFAULT_ARGS
+        if include_attrs is None:
+            include_attrs = cls._DOCSTRING_INCLUDE_ATTRS
 
         doc = ""
 
         # keep any pre-existing class description
         original_docstrings = []
-        if cls.__doc__:
-            original_docstrings = cls.__doc__.split("\n\n")
+        raw_doc = cls.__dict__.get(_DOCSTRING_RAW_ATTR)
+        if raw_doc is None:
+            raw_doc = cls.__doc__ or ""
+        if raw_doc:
+            original_docstrings = raw_doc.split("\n\n")
             doc += original_docstrings.pop(0)
         original_docstrings = "\n\n".join(original_docstrings)
 
@@ -1654,23 +1696,30 @@ class Tidy3dBaseModel(BaseModel):
         for field_name, field in cls.model_fields.items():  # v2
             if field_name == TYPE_TAG_STR:
                 continue
+            if field_name == "attrs" and not include_attrs:
+                continue
 
             # type
             ann = getattr(field, "annotation", None)
-            data_type = _fmt_ann_literal(ann)
+            field_metadata = getattr(field, "metadata", None)
+            data_type = _fmt_ann_literal(ann, field_metadata=field_metadata)
 
             # default / default_factory
-            default_val = (
-                f"{field.default_factory.__name__}()"
-                if field.default_factory is not None
-                else field.get_default(call_default_factory=False)
-            )
+            if field.default_factory is not None:
+                try:
+                    default_val = field.default_factory()
+                except Exception:
+                    default_val = f"{field.default_factory.__name__}()"
+            else:
+                default_val = field.get_default(call_default_factory=False)
 
-            if isinstance(default_val, BaseModel) or (
-                "=" in str(default_val) if default_val is not None else False
-            ):
-                default_val = ", ".join(
-                    str(f"{default_val.__class__.__name__}({default_val})").split(" ")
+            if isinstance(default_val, BaseModel):
+                default_val = _format_model_default(
+                    default_val, show_default_args=show_default_args
+                )
+            elif "=" in str(default_val) if default_val is not None else False:
+                default_val = _clean_default_repr(
+                    str(f"{default_val.__class__.__name__}({default_val})")
                 )
 
             default_str = "" if field.is_required() else f" = {default_val}"
@@ -1792,6 +1841,13 @@ class Tidy3dBaseModel(BaseModel):
                 continue
 
             yield name, value
+
+    def __repr__(self) -> str:
+        """Return a concise string representation of the model."""
+        try:
+            return _format_model_default(self, show_default_args=False)
+        except Exception:
+            return super().__repr__()
 
     def __str__(self) -> str:
         """Return a pretty-printed string representation of the model."""

--- a/tidy3d/components/base_sim/data/sim_data.py
+++ b/tidy3d/components/base_sim/data/sim_data.py
@@ -29,18 +29,18 @@ if TYPE_CHECKING:
 
 class AbstractSimulationData(Tidy3dBaseModel, ABC):
     """Stores data from a collection of :class:`AbstractMonitor` objects in
-    a :class:`AbstractSimulation`.
+    a :class:`~tidy3d.components.base_sim.simulation.AbstractSimulation`.
     """
 
     simulation: AbstractSimulation = Field(
         title="Simulation",
-        description="Original :class:`AbstractSimulation` associated with the data.",
+        description="Original :class:`~tidy3d.components.base_sim.simulation.AbstractSimulation` associated with the data.",
     )
 
     data: tuple[AbstractMonitorData, ...] = Field(
         title="Monitor Data",
-        description="List of :class:`AbstractMonitorData` instances "
-        "associated with the monitors of the original :class:`AbstractSimulation`.",
+        description="List of :class:`~tidy3d.components.base_sim.data.monitor_data.AbstractMonitorData` instances "
+        "associated with the monitors of the original :class:`~tidy3d.components.base_sim.simulation.AbstractSimulation`.",
     )
 
     log: Optional[str] = Field(
@@ -56,12 +56,12 @@ class AbstractSimulationData(Tidy3dBaseModel, ABC):
 
     @property
     def monitor_data(self) -> dict[str, AbstractMonitorData]:
-        """Dictionary mapping monitor name to its associated :class:`AbstractMonitorData`."""
+        """Dictionary mapping monitor name to its associated :class:`~tidy3d.components.base_sim.data.monitor_data.AbstractMonitorData`."""
         return {monitor_data.monitor.name: monitor_data for monitor_data in self.data}
 
     @model_validator(mode="after")
     def data_monitors_match_sim(self) -> Self:
-        """Ensure each :class:`AbstractMonitorData` in ``.data`` corresponds to a monitor in
+        """Ensure each :class:`~tidy3d.components.base_sim.data.monitor_data.AbstractMonitorData` in ``.data`` corresponds to a monitor in
         ``.simulation``.
         """
         sim = self.simulation
@@ -82,7 +82,7 @@ class AbstractSimulationData(Tidy3dBaseModel, ABC):
     def validate_no_ambiguity(
         cls, val: tuple[AbstractMonitorData, ...]
     ) -> tuple[AbstractMonitorData, ...]:
-        """Ensure all :class:`AbstractMonitorData` entries in ``.data`` correspond to different
+        """Ensure all :class:`~tidy3d.components.base_sim.data.monitor_data.AbstractMonitorData` entries in ``.data`` correspond to different
         monitors in ``.simulation``.
         """
         names = [mnt_data.monitor.name for mnt_data in val]

--- a/tidy3d/components/base_sim/monitor.py
+++ b/tidy3d/components/base_sim/monitor.py
@@ -37,12 +37,12 @@ class AbstractMonitor(Box, ABC):
 
     @cached_property
     def geometry(self) -> Box:
-        """:class:`Box` representation of monitor.
+        """:class:`~tidy3d.Box` representation of monitor.
 
         Returns
         -------
-        :class:`Box`
-            Representation of the monitor geometry as a :class:`Box`.
+        :class:`~tidy3d.Box`
+            Representation of the monitor geometry as a :class:`~tidy3d.Box`.
         """
         return Box(center=self.center, size=self.size)
 

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -745,12 +745,12 @@ class AbstractSimulation(Box, ABC):
 
     @classmethod
     def from_scene(cls, scene: Scene, **kwargs: Any) -> AbstractSimulation:
-        """Create a simulation from a :class:`.Scene` instance. Must provide additional parameters
+        """Create a simulation from a :class:`~tidy3d.Scene` instance. Must provide additional parameters
         to define a valid simulation (for example, ``size``, ``run_time``, ``grid_spec``, etc).
 
         Parameters
         ----------
-        scene : :class:`.Scene`
+        scene : :class:`~tidy3d.Scene`
             Scene containing structures information.
         **kwargs
             Other arguments

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -316,7 +316,7 @@ class ModeABCBoundary(AbstractABCBoundary):
 
         Parameters
         ----------
-        source : :class:`ModeSource`
+        source : :class:`~tidy3d.ModeSource`
             Mode source.
         freq_spec : Optional[Union[PositiveFloat, BroadbandModeABCSpec]] = None
             Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.
@@ -519,7 +519,7 @@ class BlochBoundary(BoundaryEdge):
 
         Parameters
         ----------
-        source : Union[:class:`GaussianBeam`, :class:`ModeSource`, :class:`PlaneWave`]
+        source : Union[:class:`~tidy3d.GaussianBeam`, :class:`~tidy3d.ModeSource`, :class:`~tidy3d.PlaneWave`]
             Angled source.
         domain_size: float
             Size of the domain (micron) in the direction normal to the Bloch boundary.
@@ -602,7 +602,10 @@ class AbsorberParams(Tidy3dBaseModel):
     sigma_order: NonNegativeInt = Field(
         3,
         title="Sigma Order",
-        description="Order of the polynomial describing the absorber profile (~dist^sigma_order).",
+        description=(
+            "Order of the polynomial describing the absorber profile "
+            "(:math:`\\mathrm{dist}^{\\text{sigma\\_order}}`)."
+        ),
     )
 
     sigma_min: NonNegativeFloat = Field(
@@ -631,8 +634,10 @@ class PMLParams(AbsorberParams):
     kappa_order: NonNegativeInt = Field(
         3,
         title="Kappa Order",
-        description="Order of the polynomial describing the PML kappa profile "
-        "(kappa~dist^kappa_order).",
+        description=(
+            "Order of the polynomial describing the PML kappa profile "
+            "(:math:`\\kappa\\sim\\mathrm{dist}^{\\text{kappa\\_order}}`)."
+        ),
     )
 
     kappa_min: NonNegativeFloat = Field(0.0, title="Kappa Minimum")
@@ -642,8 +647,10 @@ class PMLParams(AbsorberParams):
     alpha_order: NonNegativeInt = Field(
         3,
         title="Alpha Order",
-        description="Order of the polynomial describing the PML alpha profile "
-        "(alpha~dist^alpha_order).",
+        description=(
+            "Order of the polynomial describing the PML alpha profile "
+            "(:math:`\\alpha\\sim\\mathrm{dist}^{\\text{alpha\\_order}}`)."
+        ),
     )
 
     alpha_min: NonNegativeFloat = Field(
@@ -1110,13 +1117,13 @@ class Boundary(Tidy3dBaseModel):
 
         Parameters
         ----------
-        source : Union[:class:`GaussianBeam`, :class:`ModeSource`, :class:`PlaneWave`]
+        source : Union[:class:`~tidy3d.GaussianBeam`, :class:`~tidy3d.ModeSource`, :class:`~tidy3d.PlaneWave`]
             Angled source.
-        domain_size: float
+        domain_size : float
             Size of the domain in the direction normal to the Bloch boundary
-        axis: int
+        axis : int
             Axis normal to the Bloch boundary
-        medium : :class:`.Medium`
+        medium : :class:`~tidy3d.Medium`
             Background medium associated with the Bloch vector.
             Default: free space.
 
@@ -1234,7 +1241,7 @@ class Boundary(Tidy3dBaseModel):
 
         Parameters
         ----------
-        source : :class:`ModeSource`
+        source : :class:`~tidy3d.ModeSource`
             Mode source.
         freq_spec : Optional[Union[PositiveFloat, BroadbandModeABCSpec]] = None
             Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.
@@ -1287,7 +1294,7 @@ class Boundary(Tidy3dBaseModel):
         ----------
         num_layers : int = 12
             Number of layers of standard PML to add to + and - boundaries.
-        parameters : :class:`PMLParams`
+        parameters : :class:`~tidy3d.PMLParams`
             Parameters of the complex frequency-shifted absorption poles.
 
         Example
@@ -1310,7 +1317,7 @@ class Boundary(Tidy3dBaseModel):
         ----------
         num_layers : int = 40
             Number of layers of 'stable' PML to add to + and - boundaries.
-        parameters : :class:`PMLParams`
+        parameters : :class:`~tidy3d.PMLParams`
             'Stable' parameters of the complex frequency-shifted absorption poles.
 
         Example
@@ -1333,7 +1340,7 @@ class Boundary(Tidy3dBaseModel):
         ----------
         num_layers : int = 40
             Number of layers of absorber to add to + and - boundaries.
-        parameters : :class:`PMLParams`
+        parameters : :class:`~tidy3d.PMLParams`
             Adiabatic absorber parameters.
 
         Example

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -370,7 +370,7 @@ class ElectromagneticFieldDataset(AbstractFieldDataset, ABC):
 
 
 class FieldDataset(ElectromagneticFieldDataset):
-    """Dataset storing a collection of the scalar components of E and H fields in the freq. domain
+    """Dataset storing a collection of the scalar components of E and H fields in the freq. domain.
 
     Example
     -------

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -815,7 +815,7 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
 
     @cached_property
     def fill_fraction_box(self) -> FreqModeDataArray:
-        """Convenience accessor using the :class:`Box` defined on ``sort_spec``.
+        """Convenience accessor using the :class:`~tidy3d.Box` defined on ``sort_spec``.
 
         The component of the box along the propagation axis does not influence the fill fraction,
         but the box must intersect the monitor plane.
@@ -3291,7 +3291,7 @@ class AbstractFieldProjectionData(MonitorData):
     def fields_spherical(self) -> xr.Dataset:
         """Get all field components in spherical coordinates relative to the monitor's
         local origin for all projection grid points and frequencies specified in the
-        :class:`AbstractFieldProjectionMonitor`.
+        :class:`~tidy3d.components.monitor.AbstractFieldProjectionMonitor`.
 
         Returns
         -------
@@ -3308,7 +3308,7 @@ class AbstractFieldProjectionData(MonitorData):
     def fields_cartesian(self) -> xr.Dataset:
         """Get all field components in Cartesian coordinates relative to the monitor's
         local origin for all projection grid points and frequencies specified in the
-        :class:`AbstractFieldProjectionMonitor`.
+        :class:`~tidy3d.components.monitor.AbstractFieldProjectionMonitor`.
 
         Returns
         -------

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -692,7 +692,8 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
         Parameters
         ----------
         field_monitor_name : str
-            Name of :class:`.FieldMonitor`, :class:`.FieldTimeData`, or :class:`.ModeSolverData`
+            Name of :class:`.FieldMonitor`, :class:`.FieldTimeData`, or
+            :class:`~tidy3d.ModeSolverData`
             to plot.
         field_name : str
             Name of ``field`` component to plot (eg. `'Ex'`).

--- a/tidy3d/components/docstrings.py
+++ b/tidy3d/components/docstrings.py
@@ -1,0 +1,295 @@
+"""Helpers for rendering concise docstrings for Tidy3D models."""
+
+from __future__ import annotations
+
+import re
+import types as _types
+from types import UnionType
+from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
+
+import numpy as np
+from pydantic import BaseModel, TypeAdapter
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+_TYPING_PREFIXES = ("typing_extensions.", "typing.")
+_AUTOGRAD_BOX_TYPE = "autograd.tracer.Box"
+_DEFAULT_SENTINEL = object()
+_DOCSTRING_RAW_ATTR = "__tidy3d_raw_doc__"
+
+
+def _strip_typing_prefixes(type_str: str) -> str:
+    """Remove verbose typing prefixes from rendered annotations."""
+    for prefix in _TYPING_PREFIXES:
+        type_str = type_str.replace(prefix, "")
+    return type_str
+
+
+def _split_annotated(ann: Any) -> tuple[Any, list[Any]]:
+    """Return (base, metadata) for Annotated types, otherwise (ann, [])."""
+    origin = get_origin(ann)
+    if origin is not None and getattr(origin, "__name__", None) == "Annotated":
+        args = get_args(ann)
+        if not args:
+            return ann, []
+        return args[0], list(args[1:])
+    return ann, []
+
+
+def _strip_annotated(ann: Any) -> Any:
+    """Remove typing.Annotated wrappers while keeping the base annotation."""
+    while True:
+        base, metadata = _split_annotated(ann)
+        if not metadata:
+            return base
+        ann = base
+
+
+def _format_type_name(ann: Any) -> str:
+    """Return a concise, human-readable name for a type-like object."""
+    if ann is type(None):
+        return "None"
+    if ann is object:
+        return "Any"
+    try:
+        from tidy3d.components.base import Tidy3dBaseModel
+
+        if isinstance(ann, type) and issubclass(ann, Tidy3dBaseModel):
+            return f":class:`~{ann.__module__}.{ann.__name__}`"
+    except Exception:
+        pass
+    forward_arg = getattr(ann, "__forward_arg__", None)
+    if forward_arg:
+        if forward_arg.startswith("tidy3d."):
+            return f":class:`~{forward_arg}`"
+        return forward_arg
+    if isinstance(ann, str) and ann.startswith("tidy3d."):
+        return f":class:`~{ann}`"
+    if hasattr(ann, "__name__"):
+        return ann.__name__
+    return _strip_typing_prefixes(str(ann))
+
+
+def _clean_default_repr(value: str) -> str:
+    """Remove noisy fields from default BaseModel repr strings."""
+    cleaned = value.replace("attrs={}, ", "")
+    cleaned = cleaned.replace("attrs={}", "")
+    # Remove only the discriminator field named exactly `type=...` without touching
+    # other fields like `simulation_type=...`.
+    cleaned = re.sub(r"(?<=\()\s*type=(?:'[^']*'|\"[^\"]*\")\s*,\s*", "", cleaned)
+    cleaned = re.sub(r"(?<=,)\s*type=(?:'[^']*'|\"[^\"]*\")\s*,\s*", "", cleaned)
+    cleaned = re.sub(r",\s*type=(?:'[^']*'|\"[^\"]*\")\s*\)", ")", cleaned)
+    cleaned = re.sub(r"\(\s*type=(?:'[^']*'|\"[^\"]*\")\s*\)", "()", cleaned)
+    cleaned = re.sub(r"\(\s*,\s*", "(", cleaned)
+    cleaned = re.sub(r",\s*\)", ")", cleaned)
+    cleaned = re.sub(r",\s*,", ",", cleaned)
+    return " ".join(cleaned.split())
+
+
+def _format_default_value(value: Any, *, show_default_args: bool) -> str:
+    """Format default values for docstrings, handling nested models."""
+    if isinstance(value, BaseModel):
+        return _format_model_default(value, show_default_args=show_default_args)
+    return _clean_default_repr(str(value))
+
+
+def _format_model_default(model: BaseModel, *, show_default_args: bool) -> str:
+    """Render a model default, optionally collapsing to only non-default fields."""
+
+    # IMPORTANT: never call `repr(model)` here. Tidy3dBaseModel overrides __repr__ to
+    # call `_format_model_default(..., show_default_args=False)`, so `repr(model)`
+    # would recurse for any model class that can't be instantiated with no args.
+    def base_repr(m: BaseModel) -> str:
+        return BaseModel.__repr__(m)
+
+    if show_default_args:
+        return _clean_default_repr(" ".join(base_repr(model).split()))
+
+    model_cls = model.__class__
+    try:
+        default_model = model_cls()
+        current_dump = model.model_dump()
+        default_dump = default_model.model_dump()
+    except Exception:
+        return _clean_default_repr(" ".join(base_repr(model).split()))
+
+    diff_keys: set[str] = set()
+    for key, val in current_dump.items():
+        if default_dump.get(key, _DEFAULT_SENTINEL) != val:
+            diff_keys.add(key)
+
+    if not diff_keys:
+        return f"{model_cls.__name__}()"
+
+    ordered_fields = list(getattr(model_cls, "model_fields", {}).keys())
+    parts: list[str] = []
+    for key in ordered_fields:
+        if key in diff_keys:
+            try:
+                value = getattr(model, key)
+            except Exception:
+                value = current_dump.get(key)
+            parts.append(
+                f"{key}={_format_default_value(value, show_default_args=show_default_args)}"
+            )
+
+    for key in diff_keys:
+        if key not in ordered_fields:
+            parts.append(
+                f"{key}={_format_default_value(current_dump[key], show_default_args=show_default_args)}"
+            )
+
+    return _clean_default_repr(f"{model_cls.__name__}({', '.join(parts)})")
+
+
+def _array_schema_from_metadata(metadata: list[Any]) -> Optional[dict[str, Any]]:
+    """Extract an ArrayLike schema dict from annotation metadata if present."""
+    for meta in metadata:
+        schema = getattr(meta, "json_schema", None)
+        if isinstance(schema, dict) and schema.get("type") == "ArrayLike":
+            return schema
+    return None
+
+
+def _format_array_like(schema: dict[str, Any]) -> str:
+    """Format ArrayLike metadata into a concise dtype/ndim/shape string."""
+    dtype = schema.get("x-array-dtype")
+    ndim = schema.get("x-array-ndim")
+    shape = schema.get("x-array-shape")
+
+    dtype_str = None
+    if dtype is not None:
+        try:
+            np_dtype = np.dtype(dtype)
+            kind = np_dtype.kind
+            dtype_str = {
+                "f": "float",
+                "c": "complex",
+                "i": "int",
+                "u": "int",
+                "b": "bool",
+            }.get(kind, np_dtype.name)
+        except Exception:
+            dtype_str = str(dtype)
+
+    parts: list[str] = []
+    if dtype_str is not None:
+        parts.append(f"dtype={dtype_str}")
+    if ndim is not None:
+        parts.append(f"ndim={ndim}")
+    if shape is not None:
+        parts.append(f"shape={shape}")
+
+    if not parts:
+        return "ArrayLike"
+    return f"ArrayLike[{', '.join(parts)}]"
+
+
+def _is_annotation_candidate(val: Any) -> bool:
+    """Return True for values that look like a typing annotation."""
+    if isinstance(val, type):
+        return True
+    try:
+        return get_origin(val) is not None or bool(get_args(val))
+    except Exception:
+        return False
+
+
+def _extract_traced_alias_base(metadata: list[Any]) -> Any | None:
+    """Extract a base annotation from validator closures used by traced aliases."""
+    for meta in metadata:
+        func = getattr(meta, "func", None)
+        if func is None or getattr(func, "__name__", "") != "_validate_box_or_container":
+            continue
+        if not func.__closure__:
+            continue
+        for cell in func.__closure__:
+            val = cell.cell_contents
+            if isinstance(val, TypeAdapter):
+                continue
+            if isinstance(val, (_types.FunctionType, _types.MethodType)):
+                continue
+            if _is_annotation_candidate(val):
+                return val
+    return None
+
+
+def _constraint_alias(base: Any, metadata: list[Any]) -> str | None:
+    """Map constrained Annotated metadata to concise alias names when possible."""
+    if len(metadata) != 1:
+        return None
+    meta = metadata[0]
+    meta_name = meta.__class__.__name__
+    if base is int:
+        if meta_name == "Gt" and getattr(meta, "gt", None) == 0:
+            return "PositiveInt"
+        if meta_name == "Ge" and getattr(meta, "ge", None) == 0:
+            return "NonNegativeInt"
+    if base is float:
+        if meta_name == "Gt" and getattr(meta, "gt", None) == 0:
+            return "PositiveFloat"
+        if meta_name == "Ge" and getattr(meta, "ge", None) == 0:
+            return "NonNegativeFloat"
+    return None
+
+
+def _format_annotation(ann: Any, field_metadata: list[Any] | None = None) -> str:
+    """Format annotations for docstrings, stripping Annotated metadata."""
+    base, metadata = _split_annotated(ann)
+    combined_metadata = list(metadata)
+    if field_metadata:
+        combined_metadata.extend(field_metadata)
+    if combined_metadata:
+        array_schema = _array_schema_from_metadata(combined_metadata)
+        if array_schema is not None and base is np.ndarray:
+            return _format_array_like(array_schema)
+
+        traced_base = _extract_traced_alias_base(combined_metadata)
+        if traced_base is not None:
+            traced_fmt = _format_annotation(traced_base)
+            return f"Union[{traced_fmt}, {_AUTOGRAD_BOX_TYPE}]"
+        alias = _constraint_alias(base, combined_metadata)
+        if alias is not None:
+            return alias
+        ann = base
+    else:
+        ann = base
+    origin = get_origin(ann)
+
+    if origin in (Union, UnionType):
+        raw_args = list(get_args(ann))
+        non_none = [arg for arg in raw_args if _strip_annotated(arg) is not type(None)]
+        has_none = len(non_none) != len(raw_args)
+        if has_none:
+            if len(non_none) == 1:
+                return f"Optional[{_format_annotation(non_none[0])}]"
+            inner = ", ".join(_format_annotation(arg) for arg in non_none)
+            return f"Optional[Union[{inner}]]"
+        return f"Union[{', '.join(_format_annotation(arg) for arg in raw_args)}]"
+
+    if origin is not None:
+        if getattr(origin, "__name__", None) == "Literal":
+            literal_args = ", ".join(repr(arg) for arg in get_args(ann))
+            return f"Literal[{literal_args}]"
+
+        origin_name = _format_type_name(origin)
+        args = get_args(ann)
+        if args:
+            arg_strs = []
+            for arg in args:
+                if arg is Ellipsis:
+                    arg_strs.append("...")
+                else:
+                    arg_strs.append(_format_annotation(arg))
+            return f"{origin_name}[{', '.join(arg_strs)}]"
+        return origin_name
+
+    return _format_type_name(ann)
+
+
+def _fmt_ann_literal(ann: Any, field_metadata: list[Any] | None = None) -> str:
+    """Render a concise annotation string for docstrings."""
+    if ann is None:
+        return "Any"
+    return _format_annotation(ann, field_metadata=field_metadata)

--- a/tidy3d/components/field_projection.py
+++ b/tidy3d/components/field_projection.py
@@ -697,8 +697,9 @@ class FieldProjector(Tidy3dBaseModel):
 
         Parameters
         ----------
-        proj_monitor : :class:`.AbstractFieldProjectionMonitor`
-            Instance of :class:`.AbstractFieldProjectionMonitor` defining the projection
+        proj_monitor : :class:`~tidy3d.components.monitor.AbstractFieldProjectionMonitor`
+            Instance of :class:`~tidy3d.components.monitor.AbstractFieldProjectionMonitor` defining
+            the projection
             observation grid.
 
         Returns

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -146,7 +146,7 @@ class Geometry(Tidy3dBaseModel, ABC):
     def inside(self, x: NDArray[float], y: NDArray[float], z: NDArray[float]) -> NDArray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
-        volume of the :class:`Geometry`, and ``False`` otherwise.
+        volume of the :class:`~tidy3d.Geometry`, and ``False`` otherwise.
 
         Parameters
         ----------
@@ -359,11 +359,11 @@ class Geometry(Tidy3dBaseModel, ABC):
     def intersects(
         self, other: Geometry, strict_inequality: tuple[bool, bool, bool] = [False, False, False]
     ) -> bool:
-        """Returns ``True`` if two :class:`Geometry` have intersecting `.bounds`.
+        """Returns ``True`` if two :class:`~tidy3d.Geometry` have intersecting `.bounds`.
 
         Parameters
         ----------
-        other : :class:`Geometry`
+        other : :class:`~tidy3d.Geometry`
             Geometry to check intersection with.
         strict_inequality : tuple[bool, bool, bool] = [False, False, False]
             For each dimension, defines whether to include equality in the boundaries comparison.
@@ -402,7 +402,7 @@ class Geometry(Tidy3dBaseModel, ABC):
 
         Parameters
         ----------
-        other : :class:`Geometry`
+        other : :class:`~tidy3d.Geometry`
             Geometry to check containment with.
         strict_inequality : tuple[bool, bool, bool] = [False, False, False]
             For each dimension, defines whether to include equality in the boundaries comparison.
@@ -496,18 +496,18 @@ class Geometry(Tidy3dBaseModel, ABC):
 
     @cached_property
     def bounding_box(self) -> Box:
-        """Returns :class:`Box` representation of the bounding box of a :class:`Geometry`.
+        """Returns :class:`~tidy3d.Box` representation of the bounding box of a :class:`~tidy3d.Geometry`.
 
         Returns
         -------
-        :class:`Box`
+        :class:`~tidy3d.Box`
             Geometric object representing bounding box.
         """
         return Box.from_bounds(*self.bounds)
 
     @cached_property
     def zero_dims(self) -> list[Axis]:
-        """A list of axes along which the :class:`Geometry` is zero-sized based on its bounds."""
+        """A list of axes along which the :class:`~tidy3d.Geometry` is zero-sized based on its bounds."""
         zero_dims = []
         for dim in range(3):
             if self.bounds[1][dim] == self.bounds[0][dim]:
@@ -1010,7 +1010,7 @@ class Geometry(Tidy3dBaseModel, ABC):
 
         Returns
         -------
-        :class:`Geometry`
+        :class:`~tidy3d.Geometry`
             Translated copy of this geometry.
         """
         return Transformed(geometry=self, transform=Transformed.translation(x, y, z))
@@ -1029,7 +1029,7 @@ class Geometry(Tidy3dBaseModel, ABC):
 
         Returns
         -------
-        :class:`Geometry`
+        :class:`~tidy3d.Geometry`
             Scaled copy of this geometry.
         """
         return Transformed(geometry=self, transform=Transformed.scaling(x, y, z))
@@ -1046,7 +1046,7 @@ class Geometry(Tidy3dBaseModel, ABC):
 
         Returns
         -------
-        :class:`Geometry`
+        :class:`~tidy3d.Geometry`
             Rotated copy of this geometry.
         """
         return Transformed(geometry=self, transform=Transformed.rotation(angle, axis))
@@ -1062,7 +1062,7 @@ class Geometry(Tidy3dBaseModel, ABC):
 
         Returns
         -------
-        :class:`Geometry`
+        :class:`~tidy3d.Geometry`
             Reflected copy of this geometry.
         """
         return Transformed(geometry=self, transform=Transformed.reflection(normal))
@@ -1372,7 +1372,7 @@ class Geometry(Tidy3dBaseModel, ABC):
 
         Returns
         -------
-        :class:`Geometry`
+        :class:`~tidy3d.Geometry`
             Geometries created from the 2D data.
         """
         import gdstk
@@ -1438,7 +1438,7 @@ class Geometry(Tidy3dBaseModel, ABC):
 
         Returns
         -------
-        :class:`Geometry`
+        :class:`~tidy3d.Geometry`
             Geometry extruded from the 2D data.
         """
         return from_shapely(shape, axis, slab_bounds, dilation, sidewall_angle, reference_plane)
@@ -1548,7 +1548,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         Parameters
         ----------
         fname : PathLike
-            Full path to the .gds file to save the :class:`Geometry` slice to.
+            Full path to the .gds file to save the :class:`~tidy3d.Geometry` slice to.
         x : float = None
             Position of plane in x direction, only one of x,y,z can be specified to define plane.
         y : float = None
@@ -2034,7 +2034,7 @@ class Box(SimplePlaneIntersection, Centered):
 
     @classmethod
     def from_bounds(cls, rmin: Coordinate, rmax: Coordinate, **kwargs: Any) -> Self:
-        """Constructs a :class:`Box` from minimum and maximum coordinate bounds
+        """Constructs a :class:`~tidy3d.Box` from minimum and maximum coordinate bounds
 
         Parameters
         ----------
@@ -2063,7 +2063,7 @@ class Box(SimplePlaneIntersection, Centered):
 
     @classmethod
     def surfaces(cls, size: Size, center: Coordinate, **kwargs: Any) -> list[Self]:
-        """Returns a list of 6 :class:`Box` instances corresponding to each surface of a 3D volume.
+        """Returns a list of 6 :class:`~tidy3d.Box` instances corresponding to each surface of a 3D volume.
         The output surfaces are stored in the order [x-, x+, y-, y+, z-, z+], where x, y, and z
         denote which axis is perpendicular to that surface, while "-" and "+" denote the direction
         of the normal vector of that surface. If a name is provided, each output surface's name
@@ -2151,7 +2151,7 @@ class Box(SimplePlaneIntersection, Centered):
 
     @classmethod
     def surfaces_with_exclusion(cls, size: Size, center: Coordinate, **kwargs: Any) -> list[Self]:
-        """Returns a list of 6 :class:`Box` instances corresponding to each surface of a 3D volume.
+        """Returns a list of 6 :class:`~tidy3d.Box` instances corresponding to each surface of a 3D volume.
         The output surfaces are stored in the order [x-, x+, y-, y+, z-, z+], where x, y, and z
         denote which axis is perpendicular to that surface, while "-" and "+" denote the direction
         of the normal vector of that surface. If a name is provided, each output surface's name
@@ -2289,7 +2289,7 @@ class Box(SimplePlaneIntersection, Centered):
     def inside(self, x: NDArray[float], y: NDArray[float], z: NDArray[float]) -> NDArray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
-        volume of the :class:`Geometry`, and ``False`` otherwise.
+        volume of the :class:`~tidy3d.Geometry`, and ``False`` otherwise.
 
         Parameters
         ----------
@@ -2372,7 +2372,7 @@ class Box(SimplePlaneIntersection, Centered):
         y: Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None,
         z: Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None,
     ) -> Box:
-        """Created a padded copy of a :class:`Box` instance.
+        """Created a padded copy of a :class:`~tidy3d.Box` instance.
 
         Parameters
         ----------
@@ -2386,7 +2386,7 @@ class Box(SimplePlaneIntersection, Centered):
         Returns
         -------
         Box
-            Padded instance of :class:`Box`.
+            Padded instance of :class:`~tidy3d.Box`.
         """
 
         # Validate that padding values are non-negative
@@ -2430,18 +2430,18 @@ class Box(SimplePlaneIntersection, Centered):
 
     @cached_property
     def geometry(self) -> Box:
-        """:class:`Box` representation of self (used for subclasses of Box).
+        """:class:`~tidy3d.Box` representation of self (used for subclasses of Box).
 
         Returns
         -------
-        :class:`Box`
-            Instance of :class:`Box` representing self's geometry.
+        :class:`~tidy3d.Box`
+            Instance of :class:`~tidy3d.Box` representing self's geometry.
         """
         return Box(center=self.center, size=self.size)
 
     @cached_property
     def zero_dims(self) -> list[Axis]:
-        """A list of axes along which the :class:`Box` is zero-sized."""
+        """A list of axes along which the :class:`~tidy3d.Box` is zero-sized."""
         return [dim for dim, size in enumerate(self.size) if size == 0]
 
     @cached_property
@@ -2989,7 +2989,7 @@ class Transformed(Geometry):
     def inside(self, x: NDArray[float], y: NDArray[float], z: NDArray[float]) -> NDArray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
-        volume of the :class:`Geometry`, and ``False`` otherwise.
+        volume of the :class:`~tidy3d.Geometry`, and ``False`` otherwise.
 
         Parameters
         ----------
@@ -3392,7 +3392,7 @@ class ClipOperation(Geometry):
     def inside(self, x: NDArray[float], y: NDArray[float], z: NDArray[float]) -> NDArray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
-        volume of the :class:`Geometry`, and ``False`` otherwise.
+        volume of the :class:`~tidy3d.Geometry`, and ``False`` otherwise.
 
         Parameters
         ----------
@@ -3613,7 +3613,7 @@ class GeometryGroup(Geometry):
     def inside(self, x: NDArray[float], y: NDArray[float], z: NDArray[float]) -> NDArray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
-        volume of the :class:`Geometry`, and ``False`` otherwise.
+        volume of the :class:`~tidy3d.Geometry`, and ``False`` otherwise.
 
         Parameters
         ----------

--- a/tidy3d/components/geometry/mesh.py
+++ b/tidy3d/components/geometry/mesh.py
@@ -687,7 +687,7 @@ class TriangleMesh(base.Geometry, ABC):
     def inside(self, x: NDArray, y: NDArray, z: NDArray) -> np.ndarray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
-        volume of the :class:`Geometry`, and ``False`` otherwise.
+        volume of the :class:`~tidy3d.Geometry`, and ``False`` otherwise.
 
         Parameters
         ----------

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -504,7 +504,7 @@ class PolySlab(base.Planar):
     def inside(self, x: NDArray[float], y: NDArray[float], z: NDArray[float]) -> NDArray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
-        volume of the :class:`Geometry`, and ``False`` otherwise.
+        volume of the :class:`~tidy3d.Geometry`, and ``False`` otherwise.
 
         Note
         ----
@@ -2467,7 +2467,7 @@ class PolySlab(base.Planar):
 
         Returns
         -------
-        :class:`Geometry`
+        :class:`~tidy3d.Geometry`
             Scaled copy of this geometry.
         """
         scale_normal, scale_in_plane = self.pop_axis((x, y, z), axis=self.axis)

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -163,7 +163,7 @@ class Sphere(base.Centered, base.Circular):
     ) -> np.ndarray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
-        volume of the :class:`Geometry`, and ``False`` otherwise.
+        volume of the :class:`~tidy3d.Geometry`, and ``False`` otherwise.
 
         Parameters
         ----------
@@ -1123,7 +1123,7 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
     ) -> np.ndarray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
-        volume of the :class:`Geometry`, and ``False`` otherwise.
+        volume of the :class:`~tidy3d.Geometry`, and ``False`` otherwise.
 
         Parameters
         ----------

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -278,7 +278,7 @@ def traverse_geometries(geometry: GeometryType) -> GeometryType:
 
     Returns
     -------
-    :class:`Geometry`
+    :class:`~tidy3d.Geometry`
         Geometries within the base geometry.
     """
     if isinstance(geometry, base.GeometryGroup):
@@ -325,7 +325,7 @@ def from_shapely(
 
     Returns
     -------
-    :class:`Geometry`
+    :class:`~tidy3d.Geometry`
         Geometry extruded from the 2D data.
     """
     if shape.geom_type == "LinearRing":

--- a/tidy3d/components/grid/grid.py
+++ b/tidy3d/components/grid/grid.py
@@ -683,11 +683,11 @@ class Grid(Tidy3dBaseModel):
     def discretize_inds(
         self, box: Box, extend: bool = False, relax_precision: bool = False
     ) -> list[tuple[int, int]]:
-        """Start and stopping indexes for the cells that intersect with a :class:`Box`.
+        """Start and stopping indexes for the cells that intersect with a :class:`~tidy3d.Box`.
 
         Parameters
         ----------
-        box : :class:`Box`
+        box : :class:`~tidy3d.Box`
             Rectangular geometry within simulation to discretize.
         extend : bool = False
             If ``True``, ensure that the returned indexes extend sufficiently in every direction to
@@ -826,7 +826,7 @@ class Grid(Tidy3dBaseModel):
 
         Parameters
         ----------
-        box : :class:`Box`
+        box : :class:`~tidy3d.Box`
             Box to use for the zero dim check.
 
         Returns

--- a/tidy3d/components/lumped_element.py
+++ b/tidy3d/components/lumped_element.py
@@ -96,7 +96,8 @@ class LumpedElement(MicrowaveBaseModel, ABC):
 
     @abstractmethod
     def to_geometry(self) -> Geometry:
-        """Converts the :class:`.LumpedElement` object to a :class:`.Geometry`."""
+        """Converts the :class:`.LumpedElement` object to a
+        :class:`~tidy3d.Geometry`."""
 
     @abstractmethod
     def to_structure(self, grid: Optional[Grid] = None) -> Structure:
@@ -441,7 +442,8 @@ class CoaxialLumpedResistor(LumpedElement):
         )
 
     def to_geometry(self, grid: Optional[Grid] = None) -> ClipOperation:
-        """Converts the :class:`CoaxialLumpedResistor` object to a :class:`Geometry`."""
+        """Converts the :class:`CoaxialLumpedResistor` object to a
+        :class:`~tidy3d.Geometry`."""
         rout = self.outer_diameter / 2
         rin = self.inner_diameter / 2
         disk_out = Cylinder(axis=self.normal_axis, radius=rout, length=0, center=self.center)

--- a/tidy3d/components/material/tcad/charge.py
+++ b/tidy3d/components/material/tcad/charge.py
@@ -41,7 +41,7 @@ class AbstractChargeMedium(AbstractMedium):
     def charge(self) -> Self:
         """
         This means that a charge medium has been defined inherently within this solver medium.
-        This provides interconnection with the :class:`MultiPhysicsMedium` higher-dimensional classes.
+        This provides interconnection with the :class:`~tidy3d.MultiPhysicsMedium` higher-dimensional classes.
         """
         return self
 

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -225,10 +225,10 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
     heat_spec: Optional[ThermalSpecType] = Field(
         None,
         title="Heat Specification",
-        description="DEPRECATED: Use :class:`MultiPhysicsMedium`. Specification of the medium heat properties. They are "
-        "used for solving the heat equation via the :class:`HeatSimulation` interface. Such simulations can be"
+        description="DEPRECATED: Use :class:`~tidy3d.MultiPhysicsMedium`. Specification of the medium heat properties. They are "
+        "used for solving the heat equation via the :class:`~tidy3d.HeatSimulation` interface. Such simulations can be"
         "used for investigating the influence of heat propagation on the properties of optical systems. "
-        "Once the temperature distribution in the system is found using :class:`HeatSimulation` object, "
+        "Once the temperature distribution in the system is found using :class:`~tidy3d.HeatSimulation` object, "
         "``Simulation.perturbed_mediums_copy()`` can be used to convert mediums with perturbation "
         "models defined into spatially dependent custom mediums. "
         "Otherwise, the ``heat_spec`` does not directly affect the running of an optical "
@@ -6989,8 +6989,8 @@ class AbstractPerturbationMedium(ABC, Tidy3dBaseModel):
 class PerturbationMedium(Medium, AbstractPerturbationMedium):
     """Dispersionless medium with perturbations. Perturbation model can be defined either directly
     through providing ``permittivity_perturbation`` and ``conductivity_perturbation`` or via
-    providing a specific perturbation model (:class:`PermittivityPerturbation`,
-    :class:`IndexPerturbation`) as ``perturbaiton_spec``.
+    providing a specific perturbation model (:class:`~tidy3d.PermittivityPerturbation`,
+    :class:`~tidy3d.IndexPerturbation`) as ``perturbaiton_spec``.
 
     Example
     -------
@@ -7158,8 +7158,8 @@ class PerturbationPoleResidue(PoleResidue, AbstractPerturbationMedium):
     """A dispersive medium described by the pole-residue pair model with perturbations.
     Perturbation model can be defined either directly
     through providing ``eps_inf_perturbation`` and ``poles_perturbation`` or via
-    providing a specific perturbation model (:class:`PermittivityPerturbation`,
-    :class:`IndexPerturbation`) as ``perturbaiton_spec``.
+    providing a specific perturbation model (:class:`~tidy3d.PermittivityPerturbation`,
+    :class:`~tidy3d.IndexPerturbation`) as ``perturbaiton_spec``.
 
     Notes
     -----

--- a/tidy3d/components/microwave/data/dataset.py
+++ b/tidy3d/components/microwave/data/dataset.py
@@ -18,7 +18,7 @@ class TransmissionLineDataset(ModeFreqDataset):
 
     Notes
     -----
-        The data in this class is only calculated when a :class:`MicrowaveModeSpec`
+        The data in this class is only calculated when a :class:`~tidy3d.rf.MicrowaveModeSpec`
         is provided to the :class:`ModeMonitor`, :class:`ModeSolverMonitor`, :class:`ModeSolver`,
         or :class:`ModeSimulation`.
     """

--- a/tidy3d/components/microwave/data/monitor_data.py
+++ b/tidy3d/components/microwave/data/monitor_data.py
@@ -237,7 +237,8 @@ class MicrowaveModeDataBase(MicrowaveBaseModel):
     Notes
     -----
     This is a mixin class that must be combined with mode data classes (:class:`.ModeData` or
-    :class:`.ModeSolverData`). It uses ``super()`` to call methods on the mixed-in class, extending
+    :class:`~tidy3d.ModeSolverData`). It uses ``super()`` to call
+    methods on the mixed-in class, extending
     their functionality rather than replacing it.
 
     The mixin should be placed first in the inheritance list to ensure its method overrides
@@ -248,7 +249,7 @@ class MicrowaveModeDataBase(MicrowaveBaseModel):
         None,
         title="Transmission Line Data",
         description="Additional data relevant to transmission lines in RF and microwave applications, "
-        "like characteristic impedance. This field is populated when a :class:`MicrowaveModeSpec` has "
+        "like characteristic impedance. This field is populated when a :class:`~tidy3d.rf.MicrowaveModeSpec` has "
         "been used to set up the monitor or mode solver.",
     )
 
@@ -484,7 +485,7 @@ class MicrowaveModeData(MicrowaveModeDataBase, ModeData):
 
         The microwave mode data contains all the information from :class:`.ModeData` plus additional
         microwave dataset with impedance calculations performed using voltage and current line integrals
-        as specified in the :class:`.MicrowaveModeSpec`.
+        as specified in the :class:`~tidy3d.rf.MicrowaveModeSpec`.
 
     Example
     -------
@@ -541,14 +542,16 @@ class MicrowaveModeSolverData(MicrowaveModeDataBase, ModeSolverData):
     Notes
     -----
 
-        This class extends :class:`.ModeSolverData` with additional microwave-specific data including
+        This class extends :class:`~tidy3d.ModeSolverData` with
+        additional microwave-specific data including
         characteristic impedance, voltage coefficients, and current coefficients. The data is
         stored as `DataArray <https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html>`_
         objects using the `xarray <https://docs.xarray.dev/en/stable/index.html>`_ package.
 
         The microwave mode solver data contains all field components (Ex, Ey, Ez, Hx, Hy, Hz) and
-        effective indices from :class:`.ModeSolverData`, plus impedance calculations performed using
-        voltage and current line integrals as specified in the :class:`.MicrowaveModeSpec`.
+        effective indices from :class:`~tidy3d.ModeSolverData`, plus
+        impedance calculations performed using
+        voltage and current line integrals as specified in the :class:`~tidy3d.rf.MicrowaveModeSpec`.
 
     Example
     -------
@@ -642,8 +645,9 @@ class MicrowaveModeSolverData(MicrowaveModeDataBase, ModeSolverData):
 
         Returns
         -------
-        ModeSolverData
-            New :class:`ModeSolverData` object with data interpolated to the requested frequencies.
+        :class:`~tidy3d.ModeSolverData`
+            New :class:`~tidy3d.ModeSolverData` object with data
+            interpolated to the requested frequencies.
 
         Raises
         ------

--- a/tidy3d/components/microwave/impedance_calculator.py
+++ b/tidy3d/components/microwave/impedance_calculator.py
@@ -96,16 +96,16 @@ class ImpedanceCalculator(MicrowaveBaseModel):
 
         Parameters
         ----------
-        em_field : :class:`.IntegrableMonitorDataType`
+        em_field : ``IntegrableMonitorDataType``
             The electromagnetic field data that will be used for computing the characteristic
             impedance.
         return_voltage_and_current: bool = False
-            When ``True``, returns additional :class:`.IntegralResultType` that represent the voltage
+            When ``True``, returns additional ``IntegralResultType`` that represent the voltage
             and current associated with the supplied fields.
 
         Returns
         -------
-        :class:`.IntegralResultType` or tuple[VoltageIntegralResultType, CurrentIntegralResultType, ImpedanceResultType]
+        ``IntegralResultType`` or tuple[VoltageIntegralResultType, CurrentIntegralResultType, ImpedanceResultType]
             If ``return_voltage_and_current=False``, single result of impedance computation
             over remaining dimensions (frequency, time, mode indices). If ``return_voltage_and_current=True``,
             tuple of (impedance, voltage, current).

--- a/tidy3d/components/microwave/mode_spec.py
+++ b/tidy3d/components/microwave/mode_spec.py
@@ -35,7 +35,7 @@ class MicrowaveModeSpec(AbstractModeSpec, MicrowaveBaseModel):
 
     Notes
     -----
-        The :class:`.MicrowaveModeSpec` class specifies how quantities related to transmission line
+        The :class:`~tidy3d.rf.MicrowaveModeSpec` class specifies how quantities related to transmission line
         modes and microwave waveguides are computed. For example, it defines the paths for line integrals, which are used to
         compute voltage, current, and characteristic impedance of the transmission line.
 

--- a/tidy3d/components/microwave/monitor.py
+++ b/tidy3d/components/microwave/monitor.py
@@ -10,14 +10,14 @@ from tidy3d.components.monitor import ModeMonitor, ModeSolverMonitor
 
 
 class MicrowaveModeMonitorBase(MicrowaveBaseModel):
-    """Base class for microwave mode monitors that use :class:`.MicrowaveModeSpec`.
+    """Base class for microwave mode monitors that use :class:`~tidy3d.rf.MicrowaveModeSpec`.
 
     This mixin provides the ``mode_spec`` field configured for RF and microwave applications,
     including characteristic impedance calculations and transmission line analysis.
 
     Notes
     -----
-    This is a mixin class that provides the :class:`.MicrowaveModeSpec` field for mode monitors.
+    This is a mixin class that provides the :class:`~tidy3d.rf.MicrowaveModeSpec` field for mode monitors.
     It must be placed first in the inheritance list to ensure its ``mode_spec`` field takes
     precedence over the base :class:`.ModeSpec` field from :class:`.AbstractModeMonitor`.
     """

--- a/tidy3d/components/microwave/path_integrals/integrals/base.py
+++ b/tidy3d/components/microwave/path_integrals/integrals/base.py
@@ -162,12 +162,12 @@ class Custom2DPathIntegral(Custom2DPathIntegralSpec):
         field : :class:`.FieldParameter`
             Can take the value of ``"E"`` or ``"H"``. Determines whether to perform the integral
             over electric or magnetic field.
-        em_field : :class:`.IntegrableMonitorDataType`
+        em_field : ``IntegrableMonitorDataType``
             The electromagnetic field data that will be used for integrating.
 
         Returns
         -------
-        :class:`.IntegralResultType`
+        ``IntegralResultType``
             Result of integral over remaining dimensions (frequency, time, mode indices).
         """
 

--- a/tidy3d/components/microwave/path_integrals/integrals/current.py
+++ b/tidy3d/components/microwave/path_integrals/integrals/current.py
@@ -113,12 +113,12 @@ class Custom2DCurrentIntegral(Custom2DPathIntegral, Custom2DCurrentIntegralSpec)
 
         Parameters
         ----------
-        em_field : :class:`.IntegrableMonitorDataType`
+        em_field : ``IntegrableMonitorDataType``
             The electromagnetic field data that will be used for integrating.
 
         Returns
         -------
-        :class:`.CurrentIntegralResultType`
+        ``CurrentIntegralResultType``
             Result of current computation over remaining dimensions (frequency, time, mode indices).
         """
 

--- a/tidy3d/components/microwave/path_integrals/integrals/voltage.py
+++ b/tidy3d/components/microwave/path_integrals/integrals/voltage.py
@@ -79,12 +79,12 @@ class Custom2DVoltageIntegral(Custom2DPathIntegral, Custom2DVoltageIntegralSpec)
 
         Parameters
         ----------
-        em_field : :class:`.IntegrableMonitorDataType`
+        em_field : ``IntegrableMonitorDataType``
             The electromagnetic field data that will be used for integrating.
 
         Returns
         -------
-        :class:`.VoltageIntegralResultType`
+        ``VoltageIntegralResultType``
             Result of voltage computation over remaining dimensions (frequency, time, mode indices).
         """
 

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -489,7 +489,7 @@ class ModeSolver(Tidy3dBaseModel):
 
     @property
     def _has_microwave_mode_spec(self) -> bool:
-        """Check if the mode solver is using a :class:`.MicrowaveModeSpec`.,
+        """Check if the mode solver is using a :class:`~tidy3d.rf.MicrowaveModeSpec`.,
         and will thus be creating :class:`.MicrowaveModeSolverData`."""
         return isinstance(self.mode_spec, MicrowaveModeSpec)
 

--- a/tidy3d/components/mode_spec.py
+++ b/tidy3d/components/mode_spec.py
@@ -116,7 +116,7 @@ class ModeSortSpec(Tidy3dBaseModel):
         None,
         title="Bounding box",
         description=(
-            "Regular 3D tidy3d :class:`Box` used by metrics such as ``'fill_fraction_box'``. "
+            "Regular 3D tidy3d :class:`~tidy3d.Box` used by metrics such as ``'fill_fraction_box'``. "
             "The extent along the propagation axis is ignored for the metric, but the box must "
             "still intersect the monitor plane. Required when filtering or sorting with that key."
         ),

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -97,7 +97,7 @@ class Monitor(AbstractMonitor):
 
 
 class FreqMonitor(Monitor, ABC):
-    """:class:`Monitor` that records data in the frequency-domain."""
+    """:class:`~tidy3d.Monitor` that records data in the frequency-domain."""
 
     freqs: FreqArray = Field(
         title="Frequencies",
@@ -147,7 +147,7 @@ class FreqMonitor(Monitor, ABC):
 
 
 class TimeMonitor(Monitor, ABC):
-    """:class:`Monitor` that records data in the time-domain."""
+    """:class:`~tidy3d.Monitor` that records data in the time-domain."""
 
     start: NonNegativeFloat = Field(
         0.0,
@@ -246,7 +246,7 @@ class TimeMonitor(Monitor, ABC):
 
 
 class AbstractFieldMonitor(Monitor, ABC):
-    """:class:`Monitor` that records electromagnetic field data as a function of x,y,z."""
+    """:class:`~tidy3d.Monitor` that records electromagnetic field data as a function of x,y,z."""
 
     fields: tuple[EMField, ...] = Field(
         ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"],
@@ -334,7 +334,7 @@ class AbstractAuxFieldMonitor(Monitor, ABC):
 
 
 class PlanarMonitor(Monitor, ABC):
-    """:class:`Monitor` that has a planar geometry."""
+    """:class:`~tidy3d.Monitor` that has a planar geometry."""
 
     _plane_validator = assert_plane()
 
@@ -345,7 +345,7 @@ class PlanarMonitor(Monitor, ABC):
 
 
 class AbstractOverlapMonitor(PlanarMonitor, FreqMonitor):
-    """:class:`Monitor` that projects fields onto a specified basis and stores overlap amplitudes.
+    """:class:`~tidy3d.Monitor` that projects fields onto a specified basis and stores overlap amplitudes.
 
     This base is shared by ModeMonitor and Gaussian-overlap monitors.
     """
@@ -423,7 +423,7 @@ class AbstractOverlapMonitor(PlanarMonitor, FreqMonitor):
 
 
 class AbstractModeMonitor(AbstractOverlapMonitor):
-    """:class:`Monitor` that records mode-related data."""
+    """:class:`~tidy3d.Monitor` that records mode-related data."""
 
     _draw_overlap_arrows: bool = False  # AbstractModeMonitor.plot() draws its own arrows
 
@@ -534,7 +534,7 @@ class AbstractModeMonitor(AbstractOverlapMonitor):
 
 
 class AbstractGaussianOverlapMonitor(AbstractOverlapMonitor):
-    """:class:`Monitor` that records amplitudes from decomposition onto a Gaussian-like beam.
+    """:class:`~tidy3d.Monitor` that records amplitudes from decomposition onto a Gaussian-like beam.
 
     Common fields and behavior shared by GaussianOverlapMonitor and
     AstigmaticGaussianOverlapMonitor.
@@ -580,7 +580,7 @@ class AbstractGaussianOverlapMonitor(AbstractOverlapMonitor):
 
 
 class GaussianOverlapMonitor(AbstractGaussianOverlapMonitor):
-    """:class:`Monitor` that records amplitudes from decomposition onto a Gaussian beam.
+    """:class:`~tidy3d.Monitor` that records amplitudes from decomposition onto a Gaussian beam.
 
     Example
     -------
@@ -617,7 +617,7 @@ class GaussianOverlapMonitor(AbstractGaussianOverlapMonitor):
 
 
 class AstigmaticGaussianOverlapMonitor(AbstractGaussianOverlapMonitor):
-    """:class:`Monitor` that records amplitudes from decomposition onto an astigmatic Gaussian beam.
+    """:class:`~tidy3d.Monitor` that records amplitudes from decomposition onto an astigmatic Gaussian beam.
 
     The simple astigmatic Gaussian distribution allows
     both an elliptical intensity profile and different waist locations for the two principal axes
@@ -664,7 +664,7 @@ class AstigmaticGaussianOverlapMonitor(AbstractGaussianOverlapMonitor):
 
 
 class FieldMonitor(AbstractFieldMonitor, FreqMonitor):
-    """:class:`Monitor` that records electromagnetic fields in the frequency domain.
+    """:class:`~tidy3d.Monitor` that records electromagnetic fields in the frequency domain.
 
     Notes
     -----
@@ -704,7 +704,7 @@ class FieldMonitor(AbstractFieldMonitor, FreqMonitor):
 
 
 class FieldTimeMonitor(AbstractFieldMonitor, TimeMonitor):
-    """:class:`Monitor` that records electromagnetic fields in the time domain.
+    """:class:`~tidy3d.Monitor` that records electromagnetic fields in the time domain.
 
     Notes
     -----
@@ -777,7 +777,7 @@ class AuxFieldTimeMonitor(AbstractAuxFieldMonitor, TimeMonitor):
 
 
 class AbstractMediumPropertyMonitor(FreqMonitor, ABC):
-    """:class:`Monitor` that records material properties in the frequency domain."""
+    """:class:`~tidy3d.Monitor` that records material properties in the frequency domain."""
 
     colocate: Literal[False] = Field(
         False,
@@ -802,7 +802,7 @@ class AbstractMediumPropertyMonitor(FreqMonitor, ABC):
 
 
 class MediumMonitor(AbstractMediumPropertyMonitor):
-    """:class:`Monitor` that records the diagonal components of the complex-valued relative
+    """:class:`~tidy3d.Monitor` that records the diagonal components of the complex-valued relative
     permittivity and permeability tensor in the frequency domain. The recorded data has the same shape as a
     :class:`.FieldMonitor` of the same geometry: the permittivity and permeability values are saved at the
     Yee grid locations, and can be interpolated to any point inside the monitor.
@@ -831,7 +831,7 @@ class MediumMonitor(AbstractMediumPropertyMonitor):
 
 
 class PermittivityMonitor(AbstractMediumPropertyMonitor):
-    """:class:`Monitor` that records the diagonal components of the complex-valued relative
+    """:class:`~tidy3d.Monitor` that records the diagonal components of the complex-valued relative
     permittivity tensor in the frequency domain. The recorded data has the same shape as a
     :class:`.FieldMonitor` of the same geometry: the permittivity values are saved at the
     Yee grid locations, and can be interpolated to any point inside the monitor.
@@ -923,11 +923,11 @@ class SurfaceIntegrationMonitor(Monitor, ABC):
 
 
 class AbstractFluxMonitor(SurfaceIntegrationMonitor, ABC):
-    """:class:`Monitor` that records flux during the solver run."""
+    """:class:`~tidy3d.Monitor` that records flux during the solver run."""
 
 
 class FluxMonitor(AbstractFluxMonitor, FreqMonitor):
-    """:class:`Monitor` that records power flux in the frequency domain.
+    """:class:`~tidy3d.Monitor` that records power flux in the frequency domain.
 
     Notes
     -----
@@ -960,7 +960,7 @@ class FluxMonitor(AbstractFluxMonitor, FreqMonitor):
 
 
 class FluxTimeMonitor(AbstractFluxMonitor, TimeMonitor):
-    """:class:`Monitor` that records power flux in the time domain.
+    """:class:`~tidy3d.Monitor` that records power flux in the time domain.
 
     Notes
     -----
@@ -989,7 +989,7 @@ class FluxTimeMonitor(AbstractFluxMonitor, TimeMonitor):
 
 
 class ModeMonitor(AbstractModeMonitor):
-    """:class:`Monitor` that records amplitudes from modal decomposition of fields on plane.
+    """:class:`~tidy3d.Monitor` that records amplitudes from modal decomposition of fields on plane.
 
     Notes
     ------
@@ -1052,7 +1052,7 @@ class ModeMonitor(AbstractModeMonitor):
 
 
 class ModeSolverMonitor(AbstractModeMonitor):
-    """:class:`Monitor` that stores the mode field profiles returned by the mode solver in the
+    """:class:`~tidy3d.Monitor` that stores the mode field profiles returned by the mode solver in the
     monitor plane.
 
     Example
@@ -1151,7 +1151,7 @@ class FieldProjectionSurface(Tidy3dBaseModel):
 
 
 class AbstractFieldProjectionMonitor(SurfaceIntegrationMonitor, FreqMonitor):
-    """:class:`Monitor` that samples electromagnetic near fields in the frequency domain
+    """:class:`~tidy3d.Monitor` that samples electromagnetic near fields in the frequency domain
     and projects them to a given set of observation points.
     """
 
@@ -1326,7 +1326,7 @@ class AbstractFieldProjectionMonitor(SurfaceIntegrationMonitor, FreqMonitor):
 
 
 class FieldProjectionAngleMonitor(AbstractFieldProjectionMonitor):
-    """:class:`Monitor` that samples electromagnetic near fields in the frequency domain
+    """:class:`~tidy3d.Monitor` that samples electromagnetic near fields in the frequency domain
     and projects them at given observation angles.
 
     Notes
@@ -1460,7 +1460,7 @@ class FieldProjectionAngleMonitor(AbstractFieldProjectionMonitor):
 
 class DirectivityMonitor(MicrowaveBaseModel, FieldProjectionAngleMonitor, FluxMonitor):
     """
-    :class:`Monitor` that records the radiation characteristics of antennas in the frequency domain
+    :class:`~tidy3d.Monitor` that records the radiation characteristics of antennas in the frequency domain
     at specified observation angles.
 
     Note
@@ -1508,7 +1508,7 @@ class DirectivityMonitor(MicrowaveBaseModel, FieldProjectionAngleMonitor, FluxMo
 
 
 class FieldProjectionCartesianMonitor(AbstractFieldProjectionMonitor):
-    """:class:`Monitor` that samples electromagnetic near fields in the frequency domain
+    """:class:`~tidy3d.Monitor` that samples electromagnetic near fields in the frequency domain
     and projects them on a Cartesian observation plane.
 
     Notes
@@ -1650,7 +1650,7 @@ class FieldProjectionCartesianMonitor(AbstractFieldProjectionMonitor):
 
 
 class FieldProjectionKSpaceMonitor(AbstractFieldProjectionMonitor):
-    """:class:`Monitor` that samples electromagnetic near fields in the frequency domain
+    """:class:`~tidy3d.Monitor` that samples electromagnetic near fields in the frequency domain
     and projects them on an observation plane defined in k-space.
 
      Notes
@@ -1765,7 +1765,7 @@ class FieldProjectionKSpaceMonitor(AbstractFieldProjectionMonitor):
 
 
 class DiffractionMonitor(PlanarMonitor, FreqMonitor):
-    """:class:`Monitor` that uses a 2D Fourier transform to compute the
+    """:class:`~tidy3d.Monitor` that uses a 2D Fourier transform to compute the
     diffraction amplitudes and efficiency for allowed diffraction orders.
 
     Note

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1613,7 +1613,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         return grid.snap_to_box_zero_dim(Box(center=self.center, size=size_snapped))
 
     def _discretize_grid(self, box: Box, grid: Grid, extend: bool = False) -> Grid:
-        """Grid containing only cells that intersect with a :class:`Box`.
+        """Grid containing only cells that intersect with a :class:`~tidy3d.Box`.
 
         As opposed to ``Simulation.discretize``, this function operates on a ``grid``
         which may not be the grid of the simulation.
@@ -3005,22 +3005,24 @@ class Simulation(AbstractYeeGridSimulation):
         description="Tuple of integers defining reflection symmetry across a plane "
         "bisecting the simulation domain normal to the x-, y-, and z-axis "
         "at the simulation center of each axis, respectively. "
-        "Each element can be ``0`` (no symmetry), ``1`` (even, i.e. 'PMC' symmetry) or "
-        "``-1`` (odd, i.e. 'PEC' symmetry). "
+        "Each element can be ``0`` (no symmetry), ``1`` (even, i.e. "
+        ":class:`~tidy3d.PMCBoundary` symmetry) or ``-1`` (odd, i.e. "
+        ":class:`~tidy3d.PECBoundary` symmetry). "
         "Note that the vectorial nature of the fields must be taken into account to correctly "
         "determine the symmetry value.",
     )
     """
     You should set the ``symmetry`` parameter in your :class:`.Simulation` object using a tuple of integers
     defining reflection symmetry across a plane bisecting the simulation domain normal to the x-, y-, and z-axis.
-    Each element can be 0 (no symmetry), 1 (even, i.e. :class:`PMC` symmetry) or -1 (odd, i.e. :class:`PEC`
+    Each element can be 0 (no symmetry), 1 (even, i.e. :class:`~tidy3d.PMCBoundary` symmetry) or -1 (odd, i.e. :class:`~tidy3d.PECBoundary`
     symmetry). Note that the vectorial nature of the fields must be considered to determine the symmetry value
     correctly.
 
-    The figure below illustrates how the electric and magnetic field components transform under :class:`PEC`- and
-    :class:`PMC`-like symmetry planes. You can refer to this figure when considering whether a source field conforms
-    to a :class:`PEC`- or :class:`PMC`-like symmetry axis. This would be helpful, especially when dealing with
-    optical waveguide modes.
+    The figure below illustrates how the electric and magnetic field components transform under
+    :class:`~tidy3d.PECBoundary`- and :class:`~tidy3d.PMCBoundary`-like symmetry planes. You can refer to this figure
+    when considering whether a source field conforms to a :class:`~tidy3d.PECBoundary`- or
+    :class:`~tidy3d.PMCBoundary`-like symmetry axis. This would be helpful, especially when dealing with optical
+    waveguide modes.
 
     .. image:: ../../notebooks/img/pec_pmc.png
 

--- a/tidy3d/components/source/base.py
+++ b/tidy3d/components/source/base.py
@@ -44,7 +44,7 @@ class Source(Box, AbstractSource, ABC):
 
     @cached_property
     def geometry(self) -> Box:
-        """:class:`Box` representation of source."""
+        """:class:`~tidy3d.Box` representation of source."""
 
         return Box(center=self.center, size=self.size)
 

--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -66,7 +66,7 @@ class PlanarSource(Source, ABC):
 
 
 class VolumeSource(Source, ABC):
-    """A source defined in a 3D :class:`Box`."""
+    """A source defined in a 3D :class:`~tidy3d.Box`."""
 
     _volume_validator = assert_volumetric()
 

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -194,7 +194,7 @@ class AbstractStructure(Tidy3dBaseModel):
 class Structure(AbstractStructure):
     """Defines a physical object that interacts with the electromagnetic fields.
     A :class:`.Structure` is a combination of a material property (:class:`AbstractMedium`)
-    and a :class:`Geometry`.
+    and a :class:`~tidy3d.Geometry`.
 
     Notes
     ------
@@ -798,7 +798,7 @@ class MeshOverrideStructure(AbstractStructure):
     Notes
     -----
 
-        A :class:`.MeshOverrideStructure` is a combination of geometry :class:`Geometry`,
+        A :class:`.MeshOverrideStructure` is a combination of geometry :class:`~tidy3d.Geometry`,
         grid size along ``x``, ``y``, ``z`` directions, and a boolean on whether the override
         will be enforced.
 

--- a/tidy3d/components/tcad/data/monitor_data/abstract.py
+++ b/tidy3d/components/tcad/data/monitor_data/abstract.py
@@ -25,7 +25,7 @@ UnstructuredFieldType = Union[TriangularGridDataset, TetrahedralGridDataset]
 
 
 class HeatChargeMonitorData(AbstractMonitorData, ABC):
-    """Abstract base class of objects that store data pertaining to a single :class:`HeatChargeMonitor`."""
+    """Abstract base class of objects that store data pertaining to a single :class:`~tidy3d.components.tcad.monitors.abstract.HeatChargeMonitor`."""
 
     monitor: HeatChargeMonitorType = Field(
         title="Monitor",

--- a/tidy3d/components/tcad/data/sim_data.py
+++ b/tidy3d/components/tcad/data/sim_data.py
@@ -148,7 +148,7 @@ class AbstractHeatChargeSimulationData(AbstractSimulationData, ABC):
         Parameters
         ----------
         monitor_name : str
-            Name of :class:`.HeatChargeMonitor` to plot. Must be a monitor with the `unstructured=True` setting.
+            Name of :class:`~tidy3d.components.tcad.monitors.abstract.HeatChargeMonitor` to plot. Must be a monitor with the `unstructured=True` setting.
         field_name : Optional[str] = "mesh"
             Name of ``field`` component whose associated grid to plot. Not required if monitor data contains only one field.
         structures_fill : bool = True
@@ -299,7 +299,7 @@ class HeatChargeSimulationData(AbstractHeatChargeSimulationData):
         Parameters
         ----------
         monitor_name : str
-            Name of :class:`.HeatChargeMonitor` to plot.
+            Name of :class:`~tidy3d.components.tcad.monitors.abstract.HeatChargeMonitor` to plot.
         field_name : Optional[Literal["temperature", "potential"]] = None
             Name of ``field`` component to plot (eg. `'temperature'`). Not required if monitor data contains only one field.
         val : Literal['real', 'abs', 'abs^2'] = 'real'
@@ -492,7 +492,7 @@ class HeatSimulationData(HeatChargeSimulationData):
 
     simulation: HeatSimulation = Field(
         title="Heat Simulation",
-        description="Original :class:`HeatSimulation` associated with the data.",
+        description="Original :class:`~tidy3d.HeatSimulation` associated with the data.",
     )
 
     @model_validator(mode="before")
@@ -583,7 +583,7 @@ class VolumeMesherData(AbstractHeatChargeSimulationData):
 
     @model_validator(mode="after")
     def data_monitors_match_sim(self) -> Self:
-        """Ensure each :class:`AbstractMonitorData` in ``.data`` corresponds to a monitor in
+        """Ensure each :class:`~tidy3d.components.base_sim.data.monitor_data.AbstractMonitorData` in ``.data`` corresponds to a monitor in
         ``.simulation``.
         """
         mnt_names = {mnt.name for mnt in self.monitors}

--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -141,7 +141,7 @@ PERMITTIVITY = "None (relative permittivity)"
 Relative permittivity.
 """
 
-PML_SIGMA = "2*EPSILON_0/dt"
+PML_SIGMA = r":math:`2\epsilon_0/\Delta t`"
 """
 2 times vacuum permittivity over time differential step.
 """

--- a/tidy3d/plugins/expressions/__init__.py
+++ b/tidy3d/plugins/expressions/__init__.py
@@ -65,4 +65,4 @@ for module_name in _module_names:
             _local_vars[name] = obj
 
 for cls in _model_classes:
-    cls.model_rebuild(force=True)
+    cls.model_rebuild(force=True, _types_namespace=_local_vars)

--- a/tidy3d/plugins/klayout/drc/drc.py
+++ b/tidy3d/plugins/klayout/drc/drc.py
@@ -170,12 +170,15 @@ class DRCRunner(Tidy3dBaseModel):
         max_results: Optional[int] = None,
         **to_gds_file_kwargs: Any,
     ) -> DRCResults:
-        """Runs KLayout's DRC on a GDS file or a Tidy3D object. The Tidy3D object can be a :class:`.Geometry`, :class:`.Structure`, or :class:`.Simulation`.
+        """Runs KLayout's DRC on a GDS file or a Tidy3D object. The Tidy3D object can be a
+        :class:`~tidy3d.Geometry`, :class:`~tidy3d.Structure`, or
+        :class:`~tidy3d.Simulation`.
 
         Parameters
         ----------
-        source : Union[:class:`.Geometry`, :class:`.Structure`, :class:`.Simulation`, Path]
-            The :class:`.Geometry`, :class:`.Structure`, :class:`.Simulation`, or GDS file to run DRC on.
+        source : Union[:class:`~tidy3d.Geometry`, :class:`~tidy3d.Structure`, :class:`~tidy3d.Simulation`, Path]
+            The :class:`~tidy3d.Geometry`, :class:`~tidy3d.Structure`,
+            :class:`~tidy3d.Simulation`, or GDS file to run DRC on.
         td_object_gds_savefile : Path
             The path to save the Tidy3D object to. Defaults to ``"layout.gds"``.
         resultsfile : Path

--- a/tidy3d/plugins/microwave/array_factor.py
+++ b/tidy3d/plugins/microwave/array_factor.py
@@ -514,14 +514,14 @@ class AbstractAntennaArrayCalculator(MicrowaveBaseModel, ABC):
 
         Parameters
         ----------
-        monitor_data : AbstractFieldProjectionData
+        monitor_data : :class:`~tidy3d.components.data.monitor_data.AbstractFieldProjectionData`
             The monitor data of a single antenna.
-        new_monitor : AbstractFieldProjectionMonitor = None
+        new_monitor : :class:`~tidy3d.components.monitor.AbstractFieldProjectionMonitor` = None
             The new monitor to be used in the resulting data.
 
         Returns
         -------
-        AbstractFieldProjectionData
+        :class:`~tidy3d.components.data.monitor_data.AbstractFieldProjectionData`
             The monitor data of the antenna array.
         """
 

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -98,13 +98,13 @@ class WebContainer(Tidy3dBaseModel, ABC):
 
 class Job(WebContainer):
     """
-    Interface for managing the running of a :class:`.Simulation` on server.
+    Interface for managing the running of a :class:`~tidy3d.Simulation` on server.
 
     Notes
     -----
 
         This class provides a more convenient way to manage single simulations, mainly because it eliminates the need
-        for keeping track of the ``task_id`` and original :class:`.Simulation`.
+        for keeping track of the ``task_id`` and original :class:`~tidy3d.Simulation`.
 
         We can get the cost estimate of running the task before actually running it. This prevents us from
         accidentally running large jobs that we set up by mistake. The estimated cost is the maximum cost
@@ -161,11 +161,11 @@ class Job(WebContainer):
     --------
 
     :meth:`tidy3d.web.api.webapi.run_async`
-        Submits a set of :class:`.Simulation` objects to server, starts running, monitors progress,
+        Submits a set of :class:`~tidy3d.Simulation` objects to server, starts running, monitors progress,
         downloads, and loads results as a :class:`.BatchData` object.
 
     :class:`Batch`
-         Interface for submitting several :class:`.Simulation` objects to sever.
+         Interface for submitting several :class:`~tidy3d.Simulation` objects to sever.
 
     **Notebooks**
         *  `Running simulations through the cloud <../../notebooks/WebAPI.html>`_
@@ -442,7 +442,7 @@ class Job(WebContainer):
 
         Note
         ----
-        To load the output of completed simulation into :class:`.SimulationData` objects,
+        To load the output of completed simulation into :class:`~tidy3d.SimulationData` objects,
         call :meth:`Job.load`.
         """
         if self.load_if_cached:
@@ -477,7 +477,8 @@ class Job(WebContainer):
 
         Returns
         -------
-        Union[:class:`.SimulationData`, :class:`.HeatSimulationData`, :class:`.EMESimulationData`]
+        Union[:class:`~tidy3d.SimulationData`, :class:`~tidy3d.HeatSimulationData`,
+        :class:`~tidy3d.EMESimulationData`]
             Object containing simulation results.
         """
         self._check_path_dir(path=path)
@@ -575,23 +576,25 @@ class Job(WebContainer):
 
 class BatchData(Tidy3dBaseModel, Mapping):
     """
-    Holds a collection of :class:`.SimulationData` returned by :class:`Batch`.
+    Holds a collection of :class:`~tidy3d.SimulationData` returned by :class:`Batch`.
 
     Notes
     -----
 
-        When the batch is completed, the output is not a :class:`.SimulationData` but rather a :class:`BatchData`. The
-        data within this :class:`BatchData` object can either be indexed directly ``batch_results[task_name]`` or can be looped
-        through ``batch_results.items()`` to get the :class:`.SimulationData` for each task.
+        When the batch is completed, the output is not a :class:`~tidy3d.SimulationData` but rather a
+        :class:`BatchData`. The data within this :class:`BatchData` object can either be indexed
+        directly ``batch_results[task_name]`` or can be looped through ``batch_results.items()`` to
+        get the :class:`~tidy3d.SimulationData` for each task.
 
     See Also
     --------
 
     :class:`Batch`:
-         Interface for submitting several :class:`.Simulation` objects to sever.
+         Interface for submitting several :class:`~tidy3d.Simulation` objects to sever.
 
-    :class:`.SimulationData`:
-         Stores data from a collection of :class:`.Monitor` objects in a :class:`.Simulation`.
+    :class:`~tidy3d.SimulationData`:
+         Stores data from a collection of :class:`~tidy3d.Monitor` objects in a
+         :class:`~tidy3d.Simulation`.
 
     **Notebooks**
         * `Running simulations through the cloud <../../notebooks/WebAPI.html>`_
@@ -730,8 +733,9 @@ class BatchData(Tidy3dBaseModel, Mapping):
         Returns
         ------
         :class:`BatchData`
-            Contains Union[:class:`.SimulationData`, :class:`.HeatSimulationData`, :class:`.EMESimulationData`]
-            for each Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`] in :class:`Batch`.
+            Contains Union[:class:`~tidy3d.SimulationData`, :class:`~tidy3d.HeatSimulationData`,
+            :class:`~tidy3d.EMESimulationData`] for each Union[:class:`~tidy3d.Simulation`,
+            :class:`~tidy3d.HeatSimulation`, :class:`~tidy3d.EMESimulation`] in :class:`Batch`.
         """
         base_dir = Path(path_dir)
         batch_file = Batch._batch_path(path_dir=base_dir)
@@ -741,20 +745,21 @@ class BatchData(Tidy3dBaseModel, Mapping):
 
 class Batch(WebContainer):
     """
-    Interface for submitting several :class:`.Simulation` objects to sever.
+    Interface for submitting several :class:`~tidy3d.Simulation` objects to sever.
 
     Notes
     -----
 
-        Commonly one needs to submit a batch of :class:`.Simulation`. The built-in :class:`Batch` object is the best way to upload,
-        start, monitor, and load a series of tasks. The batch object is like a :class:`Job`, but stores task metadata
-        for a series of simulations.
+        Commonly one needs to submit a batch of :class:`~tidy3d.Simulation`. The built-in
+        :class:`Batch` object is the best way to upload, start, monitor, and load a series of
+        tasks. The batch object is like a :class:`Job`, but stores task metadata for a series of
+        simulations.
 
     See Also
     --------
 
     :meth:`tidy3d.web.api.webapi.run_async`
-        Submits a set of :class:`.Simulation` objects to server, starts running, monitors progress,
+        Submits a set of :class:`~tidy3d.Simulation` objects to server, starts running, monitors progress,
         downloads, and loads results as a :class:`.BatchData` object.
 
     :class:`Job`:
@@ -872,8 +877,9 @@ class Batch(WebContainer):
         Returns
         ------
         :class:`BatchData`
-            Contains Union[:class:`.SimulationData`, :class:`.HeatSimulationData`, :class:`.EMESimulationData] for
-            each Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`] in :class:`Batch`.
+            Contains Union[:class:`~tidy3d.SimulationData`, :class:`~tidy3d.HeatSimulationData`,
+            :class:`~tidy3d.EMESimulationData`] for each Union[:class:`~tidy3d.Simulation`,
+            :class:`~tidy3d.HeatSimulation`, :class:`~tidy3d.EMESimulation`] in :class:`Batch`.
 
         Note
         ----
@@ -1403,8 +1409,9 @@ class Batch(WebContainer):
         Returns
         ------
         :class:`BatchData`
-            Contains Union[:class:`.SimulationData`, :class:`.HeatSimulationData`, :class:`.EMESimulationData`] for each
-            Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`] in :class:`Batch`.
+            Contains Union[:class:`~tidy3d.SimulationData`, :class:`~tidy3d.HeatSimulationData`,
+            :class:`~tidy3d.EMESimulationData`] for each Union[:class:`~tidy3d.Simulation`,
+            :class:`~tidy3d.HeatSimulation`, :class:`~tidy3d.EMESimulation`] in :class:`Batch`.
 
         The :class:`Batch` hdf5 file will be automatically saved as ``{path_dir}/batch.hdf5``,
         allowing one to load this :class:`Batch` later using ``batch = Batch.from_file()``.

--- a/tidy3d/web/api/run.py
+++ b/tidy3d/web/api/run.py
@@ -108,7 +108,7 @@ def run(
     Submit one or many simulations and return results in the same container shape.
 
     This is a convenience wrapper around the autograd runners that accepts a single
-    :class:`WorkflowType` **or** an arbitrarily nested container of simulations
+    simulation **or** an arbitrarily nested container of simulations
     (`list`, `tuple`, or `dict` values). Internally, all simulations are collected,
     deduplicated by object hash, executed either synchronously (single) or
     asynchronously (batch), and the returned data objects are reassembled to mirror
@@ -129,7 +129,7 @@ def run(
         A simulation or a container whose leaves are simulations.
         Supported containers are ``list``, ``tuple``, and ``dict`` (values only).
         Dict **keys must not** be simulations.
-    task_name : Optional[str], default None
+    task_name : Optional[str] = None
         Optional name for a single run. Prefixed for multiple runs.
     folder_name : str = "default"
         Folder shown on the web UI.
@@ -197,25 +197,25 @@ def run(
 
     Examples
     --------
-        Single run (eager by default)::
+    Single run (eager by default)
 
-        .. code-block:: python
+    .. code-block:: python
 
-            sim_data = run(sim, task_name="wg_bend", path="out/bend")
-            # writes: "out/bend.hdf5"
+        sim_data = run(sim, task_name="wg_bend", path="out/bend")
+        # writes: "out/bend.hdf5"
 
-        Batch run with nested structure (lazy by default)::
+    Batch run with nested structure (lazy by default)
 
-        .. code-block:: python
+    .. code-block:: python
 
-            sims = {
-                "coarse": [sim_a, sim_b],
-                "fine": sim_c,
-            }
-            data = run(sims, path="out/batch_dir", max_workers=4)
+        sims = {
+            "coarse": [sim_a, sim_b],
+            "fine": sim_c,
+        }
+        data = run(sims, path="out/batch_dir", max_workers=4)
 
-            # 'data' mirrors 'sims' structure:
-            # data["coarse"][0] -> data for sim_a, etc.
+        # 'data' mirrors 'sims' structure:
+        # data["coarse"][0] -> data for sim_a, etc.
 
     See Also
     --------

--- a/tidy3d/web/cli/develop/documentation.py
+++ b/tidy3d/web/cli/develop/documentation.py
@@ -178,9 +178,9 @@ def build_documentation(args: Any = None) -> None:
     args : optional
         Additional arguments for the documentation build process.
     """
-    # Runs the documentation build from the poetry environment
+    # Runs a clean doc build to avoid stale doctrees after refactors.
     echo_and_check_subprocess(
-        ["poetry", "run", "python", "-m", "sphinx", "-j", "auto", "docs/", "_docs/"]
+        ["poetry", "run", "python", "-m", "sphinx", "-E", "-a", "-j", "auto", "docs/", "_docs/"]
     )
     return 0
 


### PR DESCRIPTION
This PR overhauls docstring generation for **Pydantic v2** and cleans up Sphinx docs to reduce noise and ambiguity.

---

## Changes

### Docstring generation refactor + cleanup
- Extracted docstring formatting utilities into a new module (`docstrings.py`) and wired `Tidy3dBaseModel` to use them.
- Docstrings now:
  - Strip `Annotated` metadata and verbose `typing_extensions.*` prefixes.
  - Preserve constrained types (`PositiveFloat`, `NonNegativeInt`, etc.).
  - Render `ArrayLike[...]` with `dtype` / `ndim` / `shape` metadata.
  - Remove noisy defaults like `attrs={}` and `type=...` from reprs.
  - Collapse default model args unless non-default values are present.
  - Avoid stale/duplicated “Parameters” sections by caching raw docstrings.
- Added options to hide `attrs` by default and toggle default-arg verbosity.

### Docstring regression tests
- Added `test_docstrings.py` to assert:
  - readable types,
  - absence of `Annotated` / `discriminated_union`,
  - correct default formatting.

### Docs fixes and cleanup
- Exclude `attrs` from autodoc and autosummary (no more `attrs` subpages).
- Updated stale autosummary references and invalid API targets.
- Fixed invalid GDS docs (`to_gdspy` removal; clarified `gdstk` only).
- Corrected plugin autosummary paths (KLayout DRC results, S-matrix data).
- Disambiguated Sphinx cross-references (e.g., `Scene`, `Geometry`, `ModeSolverData`) by using `~tidy3d.*` aliases.
- Added missing abstract/medium class references and removed nonexistent ones.

See as reference example images (before -> after)
---

## Tests
- `pytest -k docstrings` (new docstring regression coverage via `test_docstrings.py`)

---

## Notes
- Primary goal: make generated API docs **cleaner**, **more stable**, and **less noisy** under Pydantic v2 while preventing docstring regressions.
<img width="936" height="1001" alt="image" src="https://github.com/user-attachments/assets/67c9819d-dc8c-44b0-b9ca-f2d041d16aae" />
<img width="936" height="1001" alt="image" src="https://github.com/user-attachments/assets/4a6a6daf-584c-4bb6-b786-7d0c54bfb96e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `Tidy3dBaseModel` docstring/repr and Sphinx build hooks; while mostly documentation-facing, it can subtly affect generated docs and any downstream code relying on `__repr__`/docstring contents.
> 
> **Overview**
> **Overhauls docstring/repr generation for Pydantic v2 models** to produce shorter, more stable API output: docstrings now cache the raw class doc, render cleaner type annotations (strip `Annotated`/typing prefixes, preserve constrained aliases, surface `ArrayLike` metadata), optionally hide `attrs`, and format default values/models more concisely; `Tidy3dBaseModel` now regenerates docs on `model_rebuild` and uses a new concise `__repr__`.
> 
> **Cleans up Sphinx API generation and references** by filtering autosummary/autodoc output (skip private/dunder members, drop noisy Pydantic `model_*` docs, rewrite/avoid dead `:class:` links), excluding internal fields (`attrs`, discriminator `type`, `model_config`/`model_post_init`) from templates, and fixing/expanding API pages and cross-references (including `tidy3d.rf` moves, gds `gdstk`-only wording, and new monitor/abstract entries). Adds regression tests for docstring formatting and repr cleanliness, and tightens the script that strips only the `type=` discriminator from generated scripts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaae22197cb6f56b252f847fedb92e346b8939fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->