### PR TITLE
fix: FXC-5462 terminal modeler serialization with custom grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed sliver polygon artifacts in 2D material subdivision by filtering polygons based on grid cell size, preventing numerical issues with large-coordinate geometries.
 - Fixed `CustomMedium` gradient calculation when field coordinates exactly align with boundaries.
 - Fixed adjoint simulation `grid_spec` to align exactly with forward simulation for correct `FieldData` adjoint source power.
+- Fixed `TerminalComponentModeler` serialization failure with `CustomGridBoundaries` by storing JSON-serializable grid metadata in `GridSpec.attrs`.
 - Fixed redundant logging when `Batch.download()` skips existing files, and added `replace_existing` to `Batch.run()` so overwrite behavior can be controlled directly.
 - Fixed redundant server lookups when loading simulation results.
 - Updated docstrings for `DerivativeInfo` to more accurately reflect dataclass fields.

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -347,6 +347,45 @@ def test_make_component_modeler(tmp_path, port_refinement):
             _ = sim.volumetric_structures
 
 
+def test_sim_dict_serialization_with_custom_grid_boundaries(tmp_path):
+    """TerminalComponentModeler sims should remain serializable with custom grid boundaries."""
+    grid_spec = td.GridSpec(
+        grid_x=td.CustomGridBoundaries(coords=np.linspace(-1000, 1000, 50)),
+        grid_y=td.CustomGridBoundaries(coords=np.linspace(-1000, 1000, 50)),
+        grid_z=td.CustomGridBoundaries(coords=np.linspace(-100, 100, 10)),
+        wavelength=td.C_0 / 5e9,
+    )
+    sim = td.Simulation(
+        size=(2000, 2000, 200),
+        structures=[],
+        grid_spec=grid_spec,
+        monitors=[],
+        run_time=1e-9,
+    )
+    port = LumpedPort(
+        center=(0, 0, 0),
+        size=(0.01, 100, 0),
+        voltage_axis=1,
+        name="port1",
+        num_grid_cells=None,
+        enable_snapping_points=False,
+    )
+    modeler = TerminalComponentModeler(
+        simulation=sim,
+        ports=[port],
+        freqs=np.linspace(1e9, 10e9, 11),
+    )
+
+    sim_tcm = modeler.sim_dict["port1"]
+
+    # Regression: this used to raise PydanticSerializationError because attrs contained ndarray.
+    sim_tcm.model_dump_json()
+
+    # Validate both user-facing export paths mentioned in the bug report.
+    sim_tcm.to_file(tmp_path / "sim.json")
+    sim_tcm.to_file(tmp_path / "sim.hdf5")
+
+
 def test_run(monkeypatch, tmp_path):
     modeler = make_component_modeler(planar_pec=True)
     modeler_data = run_component_modeler(monkeypatch, modeler)

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -565,7 +565,7 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         base_sim_tmp = self._base_sim_no_radiation_monitors
         mnts_with_radiation = list(base_sim_tmp.monitors) + list(self._finalized_radiation_monitors)
         grid_spec = GridSpec.from_grid(base_sim_tmp.grid)
-        grid_spec.attrs["from_grid_spec"] = base_sim_tmp.grid_spec
+        grid_spec.attrs["from_grid_spec"] = base_sim_tmp.grid_spec.model_dump(mode="json")
         # We skipped validations up to now, here we finally validate the base sim
         return base_sim_tmp.updated_copy(monitors=mnts_with_radiation, grid_spec=grid_spec)
 


### PR DESCRIPTION
## Summary
- fix `TerminalComponentModeler.base_sim` to store `from_grid_spec` metadata as JSON-serializable data (`model_dump(mode="json")`)
- add regression test covering `CustomGridBoundaries` + `TerminalComponentModeler.sim_dict` serialization and file export
- add changelog entry under `## [Unreleased]`

## Jira
- [FXC-5462](https://flow360.atlassian.net/browse/FXC-5462)

## Validation
- `poetry run pytest -q tests/test_plugins/smatrix/test_terminal_component_modeler.py -k "sim_dict_serialization_with_custom_grid_boundaries"`
- `poetry run pytest -q tests/test_plugins/smatrix/test_terminal_component_modeler.py -k "test_make_component_modeler or sim_dict_serialization_with_custom_grid_boundaries"`
- `poetry run pre-commit run --all-files`


[FXC-5462]: https://flow360.atlassian.net/browse/FXC-5462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to metadata serialization plus a regression test; risk is limited to how `GridSpec.attrs` is stored/used during component-modeler sim construction and export.
> 
> **Overview**
> Fixes `TerminalComponentModeler` simulation serialization when using `CustomGridBoundaries` by storing `from_grid_spec` metadata in `GridSpec.attrs` as JSON-serializable output (`model_dump(mode="json")`) instead of the raw model (which could include ndarrays).
> 
> Adds a regression test that builds a `TerminalComponentModeler` with custom grid boundaries and asserts `sim_dict` entries can be `model_dump_json()`’d and exported via `to_file()` to both JSON and HDF5. Updates the `CHANGELOG` with the corresponding unreleased fix entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4017ed8388543e70937edf8876a9b66a67d9675e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->