### PR TITLE
bug(FXC-5154): add function to compute min radius

### DIFF
--- a/tests/test_components/test_heat_charge.py
+++ b/tests/test_components/test_heat_charge.py
@@ -1310,6 +1310,37 @@ def test_grid_spec_validation(grid_specs):
         distance_grid.updated_copy(distance_interface=2, distance_bulk=1)
 
 
+def test_min_mesh_size(grid_specs):
+    """Tests the min_mesh_size property for unstructured grids."""
+    # UniformUnstructuredGrid: min_mesh_size is simply dl
+    uniform_grid = grid_specs["uniform"]
+    assert uniform_grid.min_mesh_size == uniform_grid.dl
+
+    # DistanceUnstructuredGrid without refinements: min_mesh_size is dl_interface
+    distance_grid = grid_specs["distance"]
+    assert distance_grid.min_mesh_size == distance_grid.dl_interface
+
+    # DistanceUnstructuredGrid with refinement region smaller than dl_interface
+    region = td.GridRefinementRegion(
+        center=(0, 0, 0),
+        size=(1, 1, 1),
+        dl_internal=0.01,
+        transition_thickness=0.5,
+    )
+    grid_with_region = distance_grid.updated_copy(mesh_refinements=[region])
+    assert grid_with_region.min_mesh_size == region.dl_internal
+
+    # DistanceUnstructuredGrid with refinement region larger than dl_interface
+    large_region = td.GridRefinementRegion(
+        center=(0, 0, 0),
+        size=(1, 1, 1),
+        dl_internal=0.5,
+        transition_thickness=0.5,
+    )
+    grid_with_large_region = distance_grid.updated_copy(mesh_refinements=[large_region])
+    assert grid_with_large_region.min_mesh_size == distance_grid.dl_interface
+
+
 def test_device_characteristics():
     C = [0, 1, 4]
     V = [-1, -0.5, 0]

--- a/tidy3d/components/tcad/grid.py
+++ b/tidy3d/components/tcad/grid.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Union
 
 import numpy as np
@@ -34,6 +34,11 @@ class UnstructuredGrid(Tidy3dBaseModel, ABC):
         title="Remove Fragments",
         description="Whether to remove fragments before meshing. This is useful when overlapping structures generate internal boundaries that can lead to very small cell volumes.",
     )
+
+    @property
+    @abstractmethod
+    def min_mesh_size(self) -> float:
+        """Minimum mesh size used by this grid specification."""
 
 
 class UniformUnstructuredGrid(UnstructuredGrid):
@@ -70,6 +75,11 @@ class UniformUnstructuredGrid(UnstructuredGrid):
         description="List of structures for which ``min_edges_per_circumference`` and "
         "``min_edges_per_side`` will not be enforced. The original ``dl`` is used instead.",
     )
+
+    @property
+    def min_mesh_size(self) -> float:
+        """Minimum mesh size used by this grid specification."""
+        return self.dl
 
 
 class GridRefinementRegion(Box):
@@ -220,6 +230,17 @@ class DistanceUnstructuredGrid(UnstructuredGrid):
             raise ValidationError("'distance_bulk' cannot be smaller than 'distance_interface'.")
 
         return self
+
+    @property
+    def min_mesh_size(self) -> float:
+        """Minimum mesh size used by this grid specification."""
+        dl_array = [self.dl_interface]
+        for ref in self.mesh_refinements:
+            if isinstance(ref, GridRefinementRegion):
+                dl_array.append(ref.dl_internal)
+            elif isinstance(ref, GridRefinementLine):
+                dl_array.append(ref.dl_near)
+        return min(dl_array)
 
 
 UnstructuredGridType = Union[UniformUnstructuredGrid, DistanceUnstructuredGrid]

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -125,10 +125,72 @@ AnalysisSpecType = Union[ElectricalAnalysisType, UnsteadyHeatAnalysis]
 # define some limits for transient heat simulations
 TRANSIENT_HEAT_MAX_STEPS = 1000
 
-# OpenCASCADE minimum tolerance for cylinder radii
-OPENCASCADE_CYLINDER_RADIUS_TOL = 1e-6
+# Minimum tolerance for cylinder radii
+CYLINDER_RADIUS_TOL = 1e-6
 # Minimum radius as fraction of the larger radius (for tapered cylinders)
 MIN_CYLINDER_RADIUS_FRACTION = 0.01
+
+
+def _get_cylinder_radii_with_meshing_tol(
+    geometry: Cylinder, min_mesh_size: float = 0
+) -> tuple[float, float]:
+    """Get cylinder radii clamped to the minimum meshing tolerance.
+
+    This function clamps small or negative values to a small positive value to ensure
+    valid geometry that can be meshed. The minimum is set relative to the
+    larger radius to ensure meshability while still creating a reasonably sharp
+    tip for tapered cylinders. If ``min_mesh_size`` is provided, radii are also
+    clamped to that value.
+
+    Parameters
+    ----------
+    geometry : Cylinder
+        The cylinder geometry to get radii from.
+    min_mesh_size : float, optional
+        Minimum mesh size from the grid specification. When positive, radii are
+        additionally clamped to this value.
+
+    Returns
+    -------
+    tuple[float, float]
+        ``(r1, r2)`` -- bottom and top radii, clamped to the minimum allowed radius.
+    """
+    r_bottom = geometry.radius_bottom
+    r_top = geometry.radius_top
+    is_tapered = not np.isclose(r_bottom, r_top)
+
+    min_radius = max(
+        CYLINDER_RADIUS_TOL,
+        MIN_CYLINDER_RADIUS_FRACTION * max(abs(r_bottom), abs(r_top)),
+    )
+    if min_mesh_size > 0:
+        min_radius = max(min_radius, min_mesh_size)
+
+    r1 = max(r_bottom, min_radius)
+    r2 = max(r_top, min_radius)
+
+    if is_tapered:
+        if r1 > r_bottom:
+            log.warning(
+                f"Cylinder 'radius_bottom' ({r_bottom:.3e}) is below the minimum "
+                f"radius for meshing ({r1:.3e}). The sidewall angle may be "
+                f"too steep. Will be clamped to {r1:.3e}."
+            )
+        if r2 > r_top:
+            log.warning(
+                f"Cylinder 'radius_top' ({r_top:.3e}) is below the minimum "
+                f"radius for meshing ({r2:.3e}). The sidewall angle may be "
+                f"too steep. Will be clamped to {r2:.3e}."
+            )
+    else:
+        if r1 > r_bottom:
+            log.warning(
+                f"Cylinder 'radius' ({r_bottom:.3e}) is below the minimum "
+                f"radius for meshing ({r1:.3e}). "
+                f"Will be clamped to {r1:.3e}."
+            )
+
+    return r1, r2
 
 
 class TCADAnalysisTypes(str, Enum):
@@ -372,37 +434,7 @@ class HeatChargeSimulation(AbstractSimulation):
                 # Unwrap Transformed to get the base geometry
                 base_geometry = geometry.geometry if isinstance(geometry, Transformed) else geometry
                 if isinstance(base_geometry, Cylinder):
-                    r_bottom = base_geometry.radius_bottom
-                    r_top = base_geometry.radius_top
-                    is_tapered = not np.isclose(r_bottom, r_top)
-
-                    # Compute minimum allowed radius (matches backend heat_mesh.py logic)
-                    min_radius = max(
-                        OPENCASCADE_CYLINDER_RADIUS_TOL,
-                        MIN_CYLINDER_RADIUS_FRACTION * max(abs(r_bottom), abs(r_top)),
-                    )
-
-                    # Warn if radii are below minimum
-                    if is_tapered:
-                        if r_bottom < min_radius:
-                            log.warning(
-                                f"Cylinder 'radius_bottom' ({r_bottom:.3e}) is below the minimum "
-                                f"radius for meshing ({min_radius:.3e}). The sidewall angle may be "
-                                f"too steep. Will be clamped to minimum radius or mesh size, whichever is larger."
-                            )
-                        if r_top < min_radius:
-                            log.warning(
-                                f"Cylinder 'radius_top' ({r_top:.3e}) is below the minimum "
-                                f"radius for meshing ({min_radius:.3e}). The sidewall angle may be "
-                                f"too steep. Will be clamped to minimum radius or mesh size, whichever is larger."
-                            )
-                    else:
-                        if r_bottom < min_radius:
-                            log.warning(
-                                f"Cylinder 'radius' ({r_bottom:.3e}) is below the minimum "
-                                f"radius for meshing ({min_radius:.3e}). "
-                                f"Will be clamped to minimum radius or mesh size, whichever is larger."
-                            )
+                    _get_cylinder_radii_with_meshing_tol(base_geometry)
         return val
 
     def _check_cross_solids(self, objs: tuple[Box, ...]) -> tuple[int, ...]:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches TCAD meshing-related logic and warning paths; incorrect `min_mesh_size` computation or radius clamping could change geometry/mesh validity or lead to unexpected meshing behavior.
> 
> **Overview**
> Adds a new `UnstructuredGrid.min_mesh_size` contract and implements it for `UniformUnstructuredGrid` and `DistanceUnstructuredGrid` (including mesh refinements) so callers can query the smallest enforced cell size.
> 
> Refactors cylinder small-radius handling in `HeatChargeSimulation` into `_get_cylinder_radii_with_meshing_tol`, which computes/clamps minimum radii (optionally using mesh size) and emits more specific warnings. Adds tests covering `min_mesh_size` behavior for grids with/without refinement regions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a9d8a1dad8301b998ccac6ba9a36c58eff1aa51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->