### PR TITLE
FXC-4546: add baseband source time classes for transient simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added in-memory caching for downloaded batch results, configurable via ``config.batch_data_cache``.
 - Added `DesignSpace` support for sweeping `WorkflowType` objects, including mode/EME simulations and component modelers.
 - Added `current_amplitude_definition` parameter to `UniformCurrentSource` for size-independent total current injection. Set to `"total"` to interpret the source amplitude as total current rather than current density.
+- Added baseband source time classes (`BasebandStep`, `BasebandGaussianPulse`, `BasebandRectangularPulse`, `BasebandCustomSourceTime`) for transient RF simulations with real-valued time signals.
 
 ### Breaking Changes
 - Added optional automatic extrusion of structures at the simulation boundaries into/through PML/Absorber layers via `extrude_structures` field in class `AbsorberSpec`.

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -955,6 +955,158 @@
       ],
       "type": "object"
     },
+    "BasebandCustomSourceTime": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "phase": {
+          "const": 0,
+          "default": 0,
+          "type": "integer"
+        },
+        "source_time_dataset": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TimeDataset"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "BasebandCustomSourceTime",
+          "default": "BasebandCustomSourceTime",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "BasebandGaussianPulse": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "offset": {
+          "default": 5.0,
+          "minimum": 2.5,
+          "type": "number"
+        },
+        "phase": {
+          "const": 0,
+          "default": 0,
+          "type": "integer"
+        },
+        "twidth": {
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "type": {
+          "const": "BasebandGaussianPulse",
+          "default": "BasebandGaussianPulse",
+          "type": "string"
+        }
+      },
+      "required": [
+        "twidth"
+      ],
+      "type": "object"
+    },
+    "BasebandRectangularPulse": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "offset": {
+          "default": 5.0,
+          "minimum": 2.5,
+          "type": "number"
+        },
+        "phase": {
+          "const": 0,
+          "default": 0,
+          "type": "integer"
+        },
+        "rise_time": {
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "twidth": {
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "type": {
+          "const": "BasebandRectangularPulse",
+          "default": "BasebandRectangularPulse",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rise_time",
+        "twidth"
+      ],
+      "type": "object"
+    },
+    "BasebandStep": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "offset": {
+          "default": 5.0,
+          "minimum": 2.5,
+          "type": "number"
+        },
+        "phase": {
+          "const": 0,
+          "default": 0,
+          "type": "integer"
+        },
+        "rise_time": {
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "type": {
+          "const": "BasebandStep",
+          "default": "BasebandStep",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rise_time"
+      ],
+      "type": "object"
+    },
     "BlochBoundary": {
       "additionalProperties": false,
       "properties": {
@@ -8095,6 +8247,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -8103,6 +8259,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -817,6 +817,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -825,6 +829,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -1376,6 +1392,158 @@
       "required": [
         "sign",
         "size"
+      ],
+      "type": "object"
+    },
+    "BasebandCustomSourceTime": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "phase": {
+          "const": 0,
+          "default": 0,
+          "type": "integer"
+        },
+        "source_time_dataset": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TimeDataset"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "BasebandCustomSourceTime",
+          "default": "BasebandCustomSourceTime",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "BasebandGaussianPulse": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "offset": {
+          "default": 5.0,
+          "minimum": 2.5,
+          "type": "number"
+        },
+        "phase": {
+          "const": 0,
+          "default": 0,
+          "type": "integer"
+        },
+        "twidth": {
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "type": {
+          "const": "BasebandGaussianPulse",
+          "default": "BasebandGaussianPulse",
+          "type": "string"
+        }
+      },
+      "required": [
+        "twidth"
+      ],
+      "type": "object"
+    },
+    "BasebandRectangularPulse": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "offset": {
+          "default": 5.0,
+          "minimum": 2.5,
+          "type": "number"
+        },
+        "phase": {
+          "const": 0,
+          "default": 0,
+          "type": "integer"
+        },
+        "rise_time": {
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "twidth": {
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "type": {
+          "const": "BasebandRectangularPulse",
+          "default": "BasebandRectangularPulse",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rise_time",
+        "twidth"
+      ],
+      "type": "object"
+    },
+    "BasebandStep": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "offset": {
+          "default": 5.0,
+          "minimum": 2.5,
+          "type": "number"
+        },
+        "phase": {
+          "const": 0,
+          "default": 0,
+          "type": "integer"
+        },
+        "rise_time": {
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "type": {
+          "const": "BasebandStep",
+          "default": "BasebandStep",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rise_time"
       ],
       "type": "object"
     },
@@ -3093,6 +3261,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -3101,6 +3273,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -3706,6 +3890,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -3714,6 +3902,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -7607,6 +7807,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -7615,6 +7819,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -11202,6 +11418,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -11210,6 +11430,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -12903,6 +13135,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -12911,6 +13147,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -13020,6 +13268,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -13028,6 +13280,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -14848,6 +15112,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -14856,6 +15124,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -15280,6 +15560,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -15288,6 +15572,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -817,6 +817,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -825,6 +829,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -1376,6 +1392,158 @@
       "required": [
         "sign",
         "size"
+      ],
+      "type": "object"
+    },
+    "BasebandCustomSourceTime": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "phase": {
+          "const": 0,
+          "default": 0,
+          "type": "integer"
+        },
+        "source_time_dataset": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TimeDataset"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "BasebandCustomSourceTime",
+          "default": "BasebandCustomSourceTime",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "BasebandGaussianPulse": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "offset": {
+          "default": 5.0,
+          "minimum": 2.5,
+          "type": "number"
+        },
+        "phase": {
+          "const": 0,
+          "default": 0,
+          "type": "integer"
+        },
+        "twidth": {
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "type": {
+          "const": "BasebandGaussianPulse",
+          "default": "BasebandGaussianPulse",
+          "type": "string"
+        }
+      },
+      "required": [
+        "twidth"
+      ],
+      "type": "object"
+    },
+    "BasebandRectangularPulse": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "offset": {
+          "default": 5.0,
+          "minimum": 2.5,
+          "type": "number"
+        },
+        "phase": {
+          "const": 0,
+          "default": 0,
+          "type": "integer"
+        },
+        "rise_time": {
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "twidth": {
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "type": {
+          "const": "BasebandRectangularPulse",
+          "default": "BasebandRectangularPulse",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rise_time",
+        "twidth"
+      ],
+      "type": "object"
+    },
+    "BasebandStep": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "offset": {
+          "default": 5.0,
+          "minimum": 2.5,
+          "type": "number"
+        },
+        "phase": {
+          "const": 0,
+          "default": 0,
+          "type": "integer"
+        },
+        "rise_time": {
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "type": {
+          "const": "BasebandStep",
+          "default": "BasebandStep",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rise_time"
       ],
       "type": "object"
     },
@@ -3183,6 +3351,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -3191,6 +3363,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -3796,6 +3980,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -3804,6 +3992,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -7781,6 +7981,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -7789,6 +7993,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -11469,6 +11685,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -11477,6 +11697,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -13213,6 +13445,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -13221,6 +13457,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -13330,6 +13578,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -13338,6 +13590,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -15632,6 +15896,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -15640,6 +15908,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -16064,6 +16344,10 @@
         "source_time": {
           "discriminator": {
             "mapping": {
+              "BasebandCustomSourceTime": "#/$defs/BasebandCustomSourceTime",
+              "BasebandGaussianPulse": "#/$defs/BasebandGaussianPulse",
+              "BasebandRectangularPulse": "#/$defs/BasebandRectangularPulse",
+              "BasebandStep": "#/$defs/BasebandStep",
               "BroadbandPulse": "#/$defs/BroadbandPulse",
               "ContinuousWave": "#/$defs/ContinuousWave",
               "CustomSourceTime": "#/$defs/CustomSourceTime",
@@ -16072,6 +16356,18 @@
             "propertyName": "type"
           },
           "oneOf": [
+            {
+              "$ref": "#/$defs/BasebandCustomSourceTime"
+            },
+            {
+              "$ref": "#/$defs/BasebandGaussianPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandRectangularPulse"
+            },
+            {
+              "$ref": "#/$defs/BasebandStep"
+            },
             {
               "$ref": "#/$defs/BroadbandPulse"
             },
@@ -16373,6 +16669,18 @@
     },
     "custom_source_time": {
       "anyOf": [
+        {
+          "$ref": "#/$defs/BasebandCustomSourceTime"
+        },
+        {
+          "$ref": "#/$defs/BasebandGaussianPulse"
+        },
+        {
+          "$ref": "#/$defs/BasebandRectangularPulse"
+        },
+        {
+          "$ref": "#/$defs/BasebandStep"
+        },
         {
           "$ref": "#/$defs/BroadbandPulse"
         },

--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -13,7 +13,8 @@ import xarray as xr
 from shapely import LineString
 
 import tidy3d as td
-from tidy3d.components.data.data_array import FreqModeDataArray
+from tidy3d.components.data.data_array import FreqModeDataArray, TimeDataArray
+from tidy3d.components.data.dataset import TimeDataset
 from tidy3d.components.data.monitor_data import FreqDataArray
 from tidy3d.components.microwave.formulas.circuit_parameters import (
     capacitance_colinear_cylindrical_wire_segments,
@@ -2378,3 +2379,233 @@ def test_microwave_mode_data_interpolation():
     assert np.allclose(Z0_at_end_mode1, expected_Z0_end_mode1, rtol=1e-6), (
         f"Z0 at endpoint should match original: expected {expected_Z0_end_mode1}, got {Z0_at_end_mode1}"
     )
+
+
+# --- Baseband source time tests ---
+def _make_sim_with_source_time(source_time):
+    """Helper to create a Simulation with a PointDipole using the given source_time."""
+    freq_range = source_time.frequency_range()
+    fmid = 0.5 * (freq_range[0] + freq_range[1])
+    return td.Simulation(
+        size=(2, 1, 1),
+        grid_spec=td.GridSpec.uniform(dl=0.04),
+        monitors=[
+            td.FieldMonitor(
+                center=(0, 0, 0),
+                size=(1, 1, 0),
+                freqs=[fmid],
+                name="field",
+            ),
+        ],
+        sources=[
+            td.PointDipole(
+                center=(0, 0, 0),
+                polarization="Ex",
+                source_time=source_time,
+            )
+        ],
+        run_time=source_time.end_time() or 50e-9,
+    )
+
+
+def test_baseband_phase_locked():
+    """Phase must be 0 for all baseband sources."""
+    with pytest.raises(pd.ValidationError):
+        td.BasebandStep(rise_time=1e-9, phase=1.0)
+    with pytest.raises(pd.ValidationError):
+        td.BasebandGaussianPulse(twidth=1e-9, phase=0.5)
+    with pytest.raises(pd.ValidationError):
+        td.BasebandRectangularPulse(rise_time=1e-10, twidth=1e-9, phase=np.pi)
+
+
+def test_baseband_step_source_time():
+    """Construction, amp_time shape, end_time for step source."""
+    step = td.BasebandStep(rise_time=1e-9)
+    assert step.rise_time == 1e-9
+    assert step.offset == 5.0
+    assert step.phase == 0
+    assert step.end_time() is None
+
+    times = np.linspace(0, 20e-9, 1000)
+    amp = step.amp_time(times)
+
+    # near 0 well before step center
+    assert np.abs(amp[0]) < 0.01
+    # ~0.5 at step center
+    t_center_idx = np.argmin(np.abs(times - step.t_center))
+    assert np.abs(amp[t_center_idx] - 0.5) < 0.01
+    # ~1.0 well after step center
+    assert np.abs(amp[-1] - 1.0) < 0.01
+
+    fmin, fmax = step.frequency_range()
+    assert fmin == 0.0
+    sigma = 1e-9 / 2.5631031310892006
+    assert np.isclose(fmax, 4.0 / (2 * np.pi * sigma), rtol=1e-6)
+
+
+def test_baseband_gaussian_source_time():
+    """Construction, amp_time shape, end_time, frequency_range for Gaussian."""
+    gauss = td.BasebandGaussianPulse(twidth=1e-9)
+    assert gauss.twidth == 1e-9
+    assert gauss.offset == 5.0
+
+    times = np.linspace(0, 20e-9, 1000)
+    amp = gauss.amp_time(times)
+
+    # peak amplitude at t_center
+    t_center_idx = np.argmin(np.abs(times - gauss.t_center))
+    assert np.isclose(np.abs(amp[t_center_idx]), gauss.amplitude, rtol=0.01)
+    # ~0 far from center
+    assert np.abs(amp[0]) < 0.01
+    assert np.abs(amp[-1]) < 0.01
+
+    assert np.isclose(gauss.end_time(), gauss.t_center + 10 * gauss.twidth, atol=1e-15)
+
+    fmin, fmax = gauss.frequency_range()
+    assert fmin == 0.0
+    assert np.isclose(fmax, 4.0 / (2 * np.pi * 1e-9), rtol=1e-6)
+
+
+def test_baseband_pulse_source_time():
+    """Construction, amp_time shape, end_time, frequency_range for pulse."""
+    pulse = td.BasebandRectangularPulse(rise_time=1e-10, twidth=1e-9)
+    assert pulse.rise_time == 1e-10
+    assert pulse.twidth == 1e-9
+
+    times = np.linspace(0, 5e-9, 5000)
+    amp = pulse.amp_time(times)
+
+    # ~0 before pulse
+    assert np.abs(amp[0]) < 0.01
+    # ~1.0 in flat-top region
+    flat_top_time = 0.5 * (pulse.t_start + pulse.t_stop)
+    flat_idx = np.argmin(np.abs(times - flat_top_time))
+    assert np.isclose(np.abs(amp[flat_idx]), pulse.amplitude, rtol=0.01)
+    # ~0 after falling edge
+    assert np.abs(amp[-1]) < 0.01
+
+    sigma = pulse.rise_time / 2.5631031310892006
+    assert np.isclose(pulse.end_time(), pulse.t_stop + 10 * sigma, atol=1e-15)
+
+    fmin, fmax = pulse.frequency_range()
+    assert fmin == 0.0
+    assert np.isclose(fmax, 4.0 / (2 * np.pi * sigma), rtol=1e-6)
+
+
+def test_baseband_custom_source_time():
+    """Construction, interpolation, end_time for custom source."""
+    # from_values constructor
+    values = np.array([0.0, 0.5, 1.0, 0.5, 0.0])
+    dt = 1e-9
+    cst = td.BasebandCustomSourceTime.from_values(values=values, dt=dt)
+    assert cst.source_time_dataset is not None
+
+    # interpolation matches at data points
+    amp = cst.amp_time(np.array([0.0, 1e-9, 2e-9, 3e-9, 4e-9]))
+    assert np.allclose(np.real(amp), values, atol=1e-10)
+    # linear interpolation at midpoint (scalar input returns 0-d array)
+    amp_mid = cst.amp_time(0.5e-9)
+    assert np.isclose(np.real(amp_mid), 0.25, atol=0.01)
+
+    # end_time is last non-zero sample
+    assert np.isclose(cst.end_time(), 3e-9, atol=1e-15)
+
+    # None dataset raises SetupError
+    with pytest.raises(td.exceptions.SetupError):
+        td.BasebandCustomSourceTime().end_time()
+
+
+def test_baseband_custom_source_time_edge_cases():
+    """Edge cases for BasebandCustomSourceTime: single-point, None dataset, all-zeros."""
+    # single-point dataset must raise
+    with pytest.raises(pd.ValidationError):
+        td.BasebandCustomSourceTime.from_values(values=np.array([1.0]), dt=1e-9)
+
+    # None dataset: data_times, amp_time, frequency_range, end_time
+    empty = td.BasebandCustomSourceTime()
+    assert len(empty.data_times) == 0
+    with pytest.raises(td.exceptions.SetupError):
+        empty.amp_time(0.0)
+    with pytest.raises(td.exceptions.SetupError):
+        empty.frequency_range()
+    with pytest.raises(td.exceptions.SetupError):
+        empty.end_time()
+
+    # unsorted time coordinates must raise
+    unsorted_da = TimeDataArray([1.0, 2.0, 3.0], coords={"t": [0.0, 2e-9, 1e-9]})
+    with pytest.raises(pd.ValidationError):
+        td.BasebandCustomSourceTime(source_time_dataset=TimeDataset(values=unsorted_da))
+
+    # all-zero dataset returns None end_time
+    zeros = td.BasebandCustomSourceTime.from_values(values=np.zeros(5), dt=1e-9)
+    assert zeros.end_time() is None
+
+    # dt <= 0 must raise
+    with pytest.raises(ValidationError):
+        td.BasebandCustomSourceTime.from_values(values=np.array([0.0, 1.0]), dt=0)
+    with pytest.raises(ValidationError):
+        td.BasebandCustomSourceTime.from_values(values=np.array([0.0, 1.0]), dt=-1)
+
+    # Non-uniform time dataset produces valid frequency_range
+    times_nonuniform = np.array([0.0, 0.5e-9, 2e-9, 3e-9, 4e-9])
+    vals = np.array([0.0, 0.5, 1.0, 0.5, 0.0])
+    dataarray = TimeDataArray(vals, coords={"t": times_nonuniform})
+    dataset = TimeDataset(values=dataarray)
+    cst = td.BasebandCustomSourceTime(source_time_dataset=dataset)
+    fmin, fmax = cst.frequency_range()
+    assert fmin >= 0
+    assert fmax > fmin
+
+
+def test_baseband_custom_frequency_range():
+    """FFT-based frequency_range for custom source matches analytical Gaussian result."""
+    sigma = 1e-9
+    gauss = td.BasebandGaussianPulse(twidth=sigma)
+
+    # Sample the Gaussian envelope; use a long window (8x sigma*offset) for sufficient zero-padding
+    times = np.linspace(0, 40e-9, 4096)
+    dt = times[1] - times[0]
+    values = gauss.amp_time(times)
+
+    cst = td.BasebandCustomSourceTime.from_values(values=values, dt=dt)
+
+    _, fmax_analytical = gauss.frequency_range()
+    _, fmax_fft = cst.frequency_range()
+
+    assert fmax_fft == pytest.approx(fmax_analytical, rel=0.05)
+
+
+def test_baseband_source_in_simulation():
+    """Each baseband source type works inside a Simulation (full validation)."""
+    _make_sim_with_source_time(td.BasebandStep(rise_time=1e-9))
+    _make_sim_with_source_time(td.BasebandGaussianPulse(twidth=1e-9))
+    _make_sim_with_source_time(td.BasebandRectangularPulse(rise_time=1e-10, twidth=1e-9))
+
+    times = np.linspace(0, 10e-9, 1000)
+    values = np.exp(-((times - 5e-9) ** 2) / (2 * (1e-9) ** 2))
+    dt = times[1] - times[0]
+    _make_sim_with_source_time(td.BasebandCustomSourceTime.from_values(values=values, dt=dt))
+
+
+def test_baseband_source_plot():
+    """plot() and plot_spectrum() work for each baseband source type."""
+    sources = [
+        (td.BasebandStep(rise_time=1e-9), 20e-9),
+        (td.BasebandGaussianPulse(twidth=1e-9), 20e-9),
+        (td.BasebandRectangularPulse(rise_time=1e-10, twidth=1e-9), 5e-9),
+    ]
+    for src, t_end in sources:
+        times = np.linspace(0, t_end, 2000)
+        _, ax = plt.subplots()
+        src.plot(times, ax=ax)
+        plt.close()
+        _, ax = plt.subplots()
+        src.plot_spectrum(times, ax=ax)
+        plt.close()
+
+    # custom source plot
+    cst = td.BasebandCustomSourceTime.from_values(values=np.linspace(0, 1, 100), dt=1e-10)
+    times = np.linspace(0, 10e-9, 1000)
+    _, ax = plt.subplots()
+    cst.plot(times, ax=ax)
+    plt.close()

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -594,6 +594,12 @@ def test_custom_source_time():
     _ = cst.amp_time(-1)
     assert np.allclose(cst.amp_time([2]), np.exp(-1j * 2 * np.pi * 2 * freq0), rtol=0, atol=ATOL)
 
+    # unsorted time coordinates must raise
+    unsorted_vals = td.components.data.data_array.TimeDataArray([1, 2, 3], coords={"t": [0, 2, 1]})
+    unsorted_dataset = td.components.data.dataset.TimeDataset(values=unsorted_vals)
+    with pytest.raises(ValidationError):
+        td.CustomSourceTime(source_time_dataset=unsorted_dataset, freq0=freq0, fwidth=0.1e12)
+
     vals = td.components.data.data_array.TimeDataArray([1, 2], coords={"t": [-1, -0.5]})
     dataset = td.components.data.dataset.TimeDataset(values=vals)
     cst = td.CustomSourceTime(source_time_dataset=dataset, freq0=freq0, fwidth=0.1e12)
@@ -615,6 +621,18 @@ def test_custom_source_time():
         dataset = td.components.data.dataset.TimeDataset(values=vals)
         cst = td.CustomSourceTime(source_time_dataset=dataset, freq0=freq0, fwidth=0.1e12)
         assert np.allclose(cst.amp_time([0]), [1], rtol=0, atol=ATOL)
+
+    # dt <= 0 must raise
+    with pytest.raises(td.exceptions.ValidationError):
+        td.CustomSourceTime.from_values(freq0=1e12, fwidth=1e11, values=np.array([0, 1]), dt=0)
+    with pytest.raises(td.exceptions.ValidationError):
+        td.CustomSourceTime.from_values(freq0=1e12, fwidth=1e11, values=np.array([0, 1]), dt=-1)
+
+    # all-zero dataset: end_time returns None instead of crashing
+    cst_zeros = td.CustomSourceTime.from_values(
+        freq0=1e12, fwidth=1e11, values=np.zeros(5), dt=1e-12
+    )
+    assert cst_zeros.end_time() is None
 
 
 def test_custom_field_source():

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -348,6 +348,14 @@ from .components.medium import (
     SurfaceImpedanceFitterParam,
     medium_from_nk,
 )
+
+# sources
+from .components.microwave.time import (
+    BasebandCustomSourceTime,
+    BasebandGaussianPulse,
+    BasebandRectangularPulse,
+    BasebandStep,
+)
 from .components.mode.data.sim_data import ModeSimulationData
 
 # Mode
@@ -431,8 +439,6 @@ from .components.source.field import (
 from .components.source.frame import (
     PECFrame,
 )
-
-# sources
 from .components.source.time import (
     BroadbandPulse,
     ContinuousWave,
@@ -540,6 +546,10 @@ __all__ = [
     "AxisAlignedCurrentIntegralSpec",
     "AxisAlignedVoltageIntegral",
     "AxisAlignedVoltageIntegralSpec",
+    "BasebandCustomSourceTime",
+    "BasebandGaussianPulse",
+    "BasebandRectangularPulse",
+    "BasebandStep",
     "BlochBoundary",
     "Boundary",
     "BoundaryEdge",

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -96,7 +96,6 @@ if TYPE_CHECKING:
     from tidy3d.components.mode_spec import ModeSortSpec, ModeSpec
     from tidy3d.components.source.base import Source
     from tidy3d.components.source.current import PointDipole
-    from tidy3d.components.source.time import SourceTimeType
     from tidy3d.components.types import (
         ArrayFloat2D,
         Direction,
@@ -106,6 +105,7 @@ if TYPE_CHECKING:
         Size,
         TrackFreq,
     )
+    from tidy3d.components.types.time import SourceTimeType
 
     from .data_array import MixedModeDataArray, ModeIndexDataArray, ScalarFieldTimeDataArray
     from .dataset import Dataset

--- a/tidy3d/components/microwave/time.py
+++ b/tidy3d/components/microwave/time.py
@@ -1,0 +1,350 @@
+"""Baseband (unmodulated) source time classes for transient RF simulations."""
+
+from __future__ import annotations
+
+from abc import ABC
+from typing import TYPE_CHECKING, Any, Literal, Optional
+
+import numpy as np
+from pydantic import Field, PositiveFloat, field_validator
+
+from tidy3d.components.base import cached_property
+from tidy3d.components.data.data_array import TimeDataArray
+from tidy3d.components.data.dataset import TimeDataset
+from tidy3d.components.data.validators import validate_no_nans
+from tidy3d.components.source.time import DEFAULT_SIGMA, END_TIME_FACTOR_GAUSSIAN, SourceTime
+from tidy3d.components.validators import warn_if_dataset_none
+from tidy3d.exceptions import SetupError, ValidationError
+
+if TYPE_CHECKING:
+    from typing import Union
+
+    from tidy3d.components.types import ArrayFloat1D, FreqBound
+
+# Factor converting 10%-to-90% rise time to Gaussian sigma (standard deviation).
+# rise_time = RISE_TIME_10_90_FACTOR * sigma
+# Derived from: 2 * sqrt(2) * erfinv(0.8) ≈ 2.5631
+RISE_TIME_10_90_FACTOR = 2.5631031310892006
+
+
+class BasebandSourceTime(SourceTime, ABC):
+    """Abstract base class for baseband (unmodulated) source time profiles.
+
+    These source times have no carrier frequency and are intended for transient
+    RF simulations (TDR, step excitations, arbitrary time-domain profiles).
+    The ``phase`` parameter is locked to 0 since baseband signals have no carrier.
+    """
+
+    phase: Literal[0] = Field(
+        0,
+        frozen=True,
+        title="Phase",
+        description="Phase is locked to 0 for baseband source times (no carrier frequency).",
+    )
+
+
+class BasebandStep(BasebandSourceTime):
+    """Step function source time profile using an error function (erf).
+
+    The signal ramps from 0 to ``amplitude`` with ``rise_time`` specifying the
+    10%-to-90% rise time.
+
+    Example
+    -------
+    >>> step = BasebandStep(rise_time=1e-9)
+    """
+
+    rise_time: PositiveFloat = Field(
+        title="Rise Time",
+        description="The 10%-to-90% rise time in seconds. "
+        "Related to the Gaussian standard deviation (sigma) by ``rise_time ≈ 2.563 * sigma``.",
+    )
+
+    offset: float = Field(
+        5.0,
+        title="Offset",
+        description="Delay of the step center in units of ``rise_time``.",
+        ge=2.5,
+    )
+
+    @cached_property
+    def _sigma(self) -> float:
+        """Gaussian standard deviation derived from the 10-90% rise time."""
+        return self.rise_time / RISE_TIME_10_90_FACTOR
+
+    @cached_property
+    def t_center(self) -> float:
+        """Time of the step center in seconds."""
+        return self.offset * self.rise_time
+
+    @cached_property
+    def fwidth_equiv(self) -> float:
+        """Equivalent frequency-domain standard deviation (sigma_f) in Hz.
+
+        Defined as the frequency where the Gaussian spectral envelope drops
+        to ``exp(-1/2)`` of its peak value."""
+        return 1.0 / (2 * np.pi * self._sigma)
+
+    def amp_time(self, time: Union[float, ArrayFloat1D]) -> ArrayFloat1D:
+        """Real-valued source amplitude as a function of time."""
+        from scipy.special import erf
+
+        time = np.atleast_1d(np.asarray(time, dtype=float))
+        return (
+            self.amplitude * 0.5 * (1.0 + erf((time - self.t_center) / (np.sqrt(2) * self._sigma)))
+        )
+
+    def frequency_range(self, num_fwidth: float = DEFAULT_SIGMA) -> FreqBound:
+        """Frequency range based on equivalent bandwidth."""
+        return (0.0, num_fwidth * self.fwidth_equiv)
+
+    def end_time(self) -> Optional[float]:
+        """Step never decays, so no end time."""
+        return None
+
+
+class BasebandGaussianPulse(BasebandSourceTime):
+    """Unmodulated Gaussian pulse source time profile.
+
+    The signal is a Gaussian envelope centered at ``offset * twidth`` with
+    temporal width ``twidth``.
+
+    Example
+    -------
+    >>> gauss = BasebandGaussianPulse(twidth=1e-9)
+    """
+
+    twidth: PositiveFloat = Field(
+        title="Temporal Width",
+        description="Temporal width (standard deviation) of the Gaussian pulse in seconds.",
+    )
+
+    offset: float = Field(
+        5.0,
+        title="Offset",
+        description="Delay of the pulse peak in units of ``twidth``.",
+        ge=2.5,
+    )
+
+    @cached_property
+    def t_center(self) -> float:
+        """Time of the pulse peak in seconds."""
+        return self.offset * self.twidth
+
+    @cached_property
+    def fwidth(self) -> float:
+        """Standard deviation of the frequency content of the Gaussian pulse."""
+        return 1.0 / (2 * np.pi * self.twidth)
+
+    def amp_time(self, time: Union[float, ArrayFloat1D]) -> ArrayFloat1D:
+        """Real-valued source amplitude as a function of time."""
+        time = np.atleast_1d(np.asarray(time, dtype=float))
+        return self.amplitude * np.exp(-((time - self.t_center) ** 2) / (2 * self.twidth**2))
+
+    def frequency_range(self, num_fwidth: float = DEFAULT_SIGMA) -> FreqBound:
+        """Frequency range based on equivalent bandwidth."""
+        return (0.0, num_fwidth * self.fwidth)
+
+    def end_time(self) -> Optional[float]:
+        """Time after which the source is effectively zero."""
+        return self.t_center + END_TIME_FACTOR_GAUSSIAN * self.twidth
+
+
+class BasebandRectangularPulse(BasebandSourceTime):
+    """Smoothed rectangular pulse source time profile.
+
+    The signal is a flat-top pulse constructed from two error functions,
+    producing a smooth rise and fall. The ``rise_time`` parameter specifies
+    the 10%-to-90% rise/fall time.
+
+    Example
+    -------
+    >>> pulse = BasebandRectangularPulse(rise_time=1e-10, twidth=1e-9)
+    """
+
+    rise_time: PositiveFloat = Field(
+        title="Rise Time",
+        description="The 10%-to-90% rise/fall time in seconds. "
+        "Related to the Gaussian standard deviation (sigma) by ``rise_time ≈ 2.563 * sigma``.",
+    )
+
+    twidth: PositiveFloat = Field(
+        title="Temporal Width",
+        description="Duration of the flat-top region in seconds.",
+    )
+
+    offset: float = Field(
+        5.0,
+        title="Offset",
+        description="Delay of the pulse start (rising edge center) in units of ``rise_time``.",
+        ge=2.5,
+    )
+
+    @cached_property
+    def _sigma(self) -> float:
+        """Gaussian standard deviation derived from the 10-90% rise time."""
+        return self.rise_time / RISE_TIME_10_90_FACTOR
+
+    @cached_property
+    def t_start(self) -> float:
+        """Center of the rising edge in seconds."""
+        return self.offset * self.rise_time
+
+    @cached_property
+    def t_stop(self) -> float:
+        """Center of the falling edge in seconds."""
+        return self.t_start + self.twidth
+
+    @cached_property
+    def fwidth_equiv(self) -> float:
+        """Equivalent frequency-domain standard deviation (sigma_f) in Hz.
+
+        Defined as the frequency where the Gaussian spectral envelope drops
+        to ``exp(-1/2)`` of its peak value."""
+        return 1.0 / (2 * np.pi * self._sigma)
+
+    def amp_time(self, time: Union[float, ArrayFloat1D]) -> ArrayFloat1D:
+        """Real-valued source amplitude as a function of time."""
+        from scipy.special import erf
+
+        time = np.atleast_1d(np.asarray(time, dtype=float))
+        rise = erf((time - self.t_start) / (np.sqrt(2) * self._sigma))
+        fall = erf((time - self.t_stop) / (np.sqrt(2) * self._sigma))
+        return self.amplitude * 0.5 * (rise - fall)
+
+    def frequency_range(self, num_fwidth: float = DEFAULT_SIGMA) -> FreqBound:
+        """Frequency range based on equivalent bandwidth (determined by rise time)."""
+        return (0.0, num_fwidth * self.fwidth_equiv)
+
+    def end_time(self) -> Optional[float]:
+        """Time after which the source is effectively zero."""
+        return self.t_stop + END_TIME_FACTOR_GAUSSIAN * self._sigma
+
+
+class BasebandCustomSourceTime(BasebandSourceTime):
+    """Custom baseband source time profile from a user-provided time-domain dataset.
+
+    The signal is defined by a ``source_time_dataset`` containing the time-domain
+    envelope.
+
+    Example
+    -------
+    >>> cst = BasebandCustomSourceTime.from_values(values=np.linspace(0, 1, 100), dt=1e-10)
+    """
+
+    source_time_dataset: Optional[TimeDataset] = Field(
+        None,
+        title="Source time dataset",
+        description="Dataset for storing the baseband source time envelope. "
+        "If ``None``, the source produces no signal and must be populated before use.",
+    )
+
+    _no_nans_dataset = validate_no_nans("source_time_dataset")
+    _source_time_dataset_none_warning = warn_if_dataset_none("source_time_dataset")
+
+    @field_validator("source_time_dataset")
+    @classmethod
+    def _validate_time_coords(cls, val: Optional[TimeDataset]) -> Optional[TimeDataset]:
+        """Time coordinates must have more than one point and be strictly increasing."""
+        if val is None:
+            return val
+        if val.values.size <= 1:
+            raise ValidationError(
+                "'BasebandCustomSourceTime' must have more than one time coordinate."
+            )
+        times = val.values.coords["t"].values
+        if not np.all(np.diff(times) > 0):
+            raise ValidationError(
+                "'BasebandCustomSourceTime' time coordinates must be strictly monotonically"
+                " increasing."
+            )
+        return val
+
+    @classmethod
+    def from_values(
+        cls, values: ArrayFloat1D, dt: float, **kwargs: Any
+    ) -> BasebandCustomSourceTime:
+        """Create a :class:`.BasebandCustomSourceTime` from a numpy array.
+
+        Parameters
+        ----------
+        values : ArrayFloat1D
+            Real-valued source envelope samples.
+        dt : float
+            Time step for the ``values`` array.
+        **kwargs
+            Additional keyword arguments passed to the constructor.
+
+        Returns
+        -------
+        BasebandCustomSourceTime
+            Source time with envelope given by ``values``.
+        """
+        if dt <= 0:
+            raise ValidationError("'dt' must be positive.")
+        times = np.arange(len(values)) * dt
+        source_time_dataarray = TimeDataArray(values, coords={"t": times})
+        source_time_dataset = TimeDataset(values=source_time_dataarray)
+        return cls(source_time_dataset=source_time_dataset, **kwargs)
+
+    @property
+    def data_times(self) -> ArrayFloat1D:
+        """Times of envelope definition."""
+        if self.source_time_dataset is None:
+            return np.array([], dtype=float)
+        return self.source_time_dataset.values.coords["t"].values.squeeze()
+
+    def amp_time(self, time: Union[float, ArrayFloat1D]) -> ArrayFloat1D:
+        """Real-valued source amplitude as a function of time."""
+        if self.source_time_dataset is None:
+            raise SetupError("'source_time_dataset' must be provided to use this method.")
+
+        times = np.atleast_1d(np.asarray(time, dtype=float))
+        data_times = self.data_times
+
+        # Mask for times outside dataset range; these use endpoint clamping
+        mask = (times < min(data_times)) | (times > max(data_times))
+
+        # Interpolate envelope
+        envelope = np.zeros(len(times), dtype=float)
+        values = self.source_time_dataset.values
+        envelope[mask] = values.sel(t=times[mask], method="nearest").to_numpy()
+        if not all(mask):
+            envelope[~mask] = values.interp(t=times[~mask]).to_numpy()
+
+        return self.amplitude * envelope
+
+    def frequency_range(self, num_fwidth: float = DEFAULT_SIGMA) -> FreqBound:
+        """Frequency range computed from FFT of the source envelope.
+
+        Note: only the real part of the envelope is used for frequency estimation.
+        """
+        if self.source_time_dataset is None:
+            raise SetupError("'source_time_dataset' must be provided to use this method.")
+
+        data_times = self.data_times
+        values = np.real(self.source_time_dataset.values.to_numpy().squeeze())
+        dts = np.diff(data_times)
+        dt = float(np.min(dts))
+
+        # Resample to uniform grid if times are non-uniform
+        if not np.allclose(dts, dt):
+            uniform_times = np.arange(data_times[0], data_times[-1] + dt * 0.5, dt)
+            values = np.interp(uniform_times, data_times, values)
+
+        return self._frequency_range_from_fft(dt, values, num_fwidth)
+
+    def end_time(self) -> Optional[float]:
+        """Time of the last non-zero value in the dataset."""
+        if self.source_time_dataset is None:
+            raise SetupError("'source_time_dataset' must be provided to use this method.")
+
+        data_array = self.source_time_dataset.values
+        t_coords = data_array.coords["t"]
+        source_is_non_zero = ~np.isclose(abs(data_array), 0)
+        t_non_zero = t_coords[source_is_non_zero]
+
+        if len(t_non_zero) == 0:
+            return None
+
+        return float(np.max(t_non_zero))

--- a/tidy3d/components/source/base.py
+++ b/tidy3d/components/source/base.py
@@ -11,6 +11,7 @@ from tidy3d.components.base import cached_property
 from tidy3d.components.base_sim.source import AbstractSource
 from tidy3d.components.geometry.base import Box
 from tidy3d.components.types import TYPE_TAG_STR
+from tidy3d.components.types.time import SourceTimeType
 from tidy3d.components.validators import _assert_min_freq, _warn_unsupported_traced_argument
 from tidy3d.components.viz import (
     ARROW_ALPHA,
@@ -18,8 +19,6 @@ from tidy3d.components.viz import (
     ARROW_COLOR_SOURCE,
     plot_params_source,
 )
-
-from .time import SourceTimeType
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -70,7 +69,7 @@ class Source(Box, AbstractSource, ABC):
     @classmethod
     def _freqs_lower_bound(cls, val: SourceTimeType) -> SourceTimeType:
         """Raise validation error if central frequency is too low."""
-        _assert_min_freq(val._freq0_sigma_centroid, msg_start="'source_time.freq0'")
+        _assert_min_freq(val._freq0_sigma_centroid, msg_start="'source_time' central frequency")
         return val
 
     def plot(

--- a/tidy3d/components/source/current.py
+++ b/tidy3d/components/source/current.py
@@ -20,7 +20,7 @@ from .base import Source
 
 if TYPE_CHECKING:
     from tidy3d.compat import Self
-    from tidy3d.components.source import SourceTimeType
+    from tidy3d.components.types.time import SourceTimeType
 
 
 class CurrentSource(Source, ABC):

--- a/tidy3d/components/source/time.py
+++ b/tidy3d/components/source/time.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 from pydantic import Field, PositiveFloat, field_validator, model_validator
@@ -19,11 +19,13 @@ from tidy3d.components.types import FreqBound
 from tidy3d.components.validators import warn_if_dataset_none
 from tidy3d.components.viz import add_ax_if_none
 from tidy3d.constants import HERTZ
-from tidy3d.exceptions import ValidationError
+from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 from tidy3d.packaging import check_tidy3d_extras_licensed_feature, tidy3d_extras
 
 if TYPE_CHECKING:
+    from typing import Union
+
     from tidy3d.components.types import ArrayComplex1D, ArrayFloat1D, Ax, PlotVal
 
 # how many units of ``twidth`` from the ``offset`` until a gaussian pulse is considered "off"
@@ -75,6 +77,49 @@ class SourceTime(AbstractTimeDependence):
         return self.plot_spectrum_in_frequency_range(
             times, fmin, fmax, num_freqs=num_freqs, val=val, ax=ax
         )
+
+    @staticmethod
+    def _frequency_range_from_fft(dt: float, values: ArrayFloat1D, num_fwidth: float) -> FreqBound:
+        """Compute frequency range from FFT of a time-domain signal.
+
+        Returns ``(fmin, fmax)`` bounding all FFT bins whose amplitude exceeds
+        ``exp(-num_fwidth**2 / 2)`` of the peak value.  The lower bound is
+        nonzero when the signal has no DC content (e.g. a modulated carrier).
+
+        Parameters
+        ----------
+        dt : float
+            Uniform time step between samples.
+        values : np.ndarray
+            Real-valued signal samples.
+        num_fwidth : float
+            Number of equivalent bandwidths for the cutoff threshold.
+            Bins are kept where ``amplitude >= exp(-num_fwidth**2 / 2) * peak``.
+
+        Returns
+        -------
+        Tuple[float, float]
+            ``(fmin, fmax)`` frequency range.
+        """
+        if len(values) < 2:
+            raise SetupError("'values' must be an array with more than one element.")
+        if np.allclose(values, 0):
+            raise SetupError("'values' signal is all zeros; frequency range is undefined.")
+        spectrum = np.abs(np.fft.rfft(np.real(values)))
+        freqs = np.fft.rfftfreq(len(values), d=dt)
+        df = freqs[1] - freqs[0]
+
+        peak = np.max(spectrum)
+
+        cutoff = np.exp(-(num_fwidth**2) / 2)
+        above_cutoff = spectrum >= cutoff * peak
+
+        indices = np.where(above_cutoff)[0]
+        fmin = float(freqs[indices[0]])
+        fmax = float(freqs[indices[-1]])
+        # Ensure at least one frequency bin of bandwidth
+        fmax = max(fmax, fmin + df)
+        return (fmin, fmax)
 
     @abstractmethod
     def frequency_range(self, num_fwidth: float = DEFAULT_SIGMA) -> FreqBound:
@@ -200,7 +245,7 @@ class GaussianPulse(Pulse):
         """Offset time in seconds. Note that in the case of DC removal, the maximal value of pulse can be shifted."""
         return self.peak_time + self._peak_time_shift
 
-    def amp_time(self, time: float) -> complex:
+    def amp_time(self, time: Union[float, ArrayFloat1D]) -> ArrayComplex1D:
         """Complex-valued source amplitude as a function of time."""
 
         omega0 = 2 * np.pi * self.freq0
@@ -221,7 +266,7 @@ class GaussianPulse(Pulse):
             # 1j to make it agree in large omega0 limit
             pulse_amp = pulse_amp * 1j
 
-        return pulse_amp
+        return np.atleast_1d(pulse_amp)
 
     def end_time(self) -> Optional[float]:
         """Time after which the source is effectively turned off / close to zero amplitude."""
@@ -413,7 +458,7 @@ class ContinuousWave(Pulse):
     >>> cw = ContinuousWave(freq0=200e12, fwidth=20e12)
     """
 
-    def amp_time(self, time: float) -> complex:
+    def amp_time(self, time: Union[float, ArrayFloat1D]) -> ArrayComplex1D:
         """Complex-valued source amplitude as a function of time."""
 
         twidth = 1.0 / (2 * np.pi * self.fwidth)
@@ -425,7 +470,7 @@ class ContinuousWave(Pulse):
         oscillation = np.exp(-1j * omega0 * time)
         amp = 1 / (1 + np.exp(-time_shifted / twidth)) * self.amplitude
 
-        return const * offset * oscillation * amp
+        return np.atleast_1d(const * offset * oscillation * amp)
 
     def end_time(self) -> Optional[float]:
         """Time after which the source is effectively turned off / close to zero amplitude."""
@@ -484,12 +529,17 @@ class CustomSourceTime(Pulse):
 
     @field_validator("source_time_dataset")
     @classmethod
-    def _more_than_one_time(cls, val: Optional[TimeDataset]) -> Optional[TimeDataset]:
-        """Must have more than one time to interpolate."""
+    def _validate_time_coords(cls, val: Optional[TimeDataset]) -> Optional[TimeDataset]:
+        """Time coordinates must have more than one point and be strictly increasing."""
         if val is None:
             return val
         if val.values.size <= 1:
             raise ValidationError("'CustomSourceTime' must have more than one time coordinate.")
+        times = val.values.coords["t"].values
+        if not np.all(np.diff(times) > 0):
+            raise ValidationError(
+                "'CustomSourceTime' time coordinates must be strictly monotonically increasing."
+            )
         return val
 
     @classmethod
@@ -519,6 +569,8 @@ class CustomSourceTime(Pulse):
             between ``0`` and ``dt * (N-1)`` with a step size of ``dt``, where ``N`` is the length of
             the values array.
         """
+        if dt <= 0:
+            raise ValidationError("'dt' must be positive.")
 
         times = np.arange(len(values)) * dt
         source_time_dataarray = TimeDataArray(values, coords={"t": times})
@@ -553,25 +605,25 @@ class CustomSourceTime(Pulse):
 
         return (max_time_shifted < min(data_times)) | (min_time_shifted > max(data_times))
 
-    def amp_time(self, time: float) -> complex:
+    def amp_time(self, time: Union[float, ArrayFloat1D]) -> ArrayComplex1D:
         """Complex-valued source amplitude as a function of time.
 
         Parameters
         ----------
-        time : float
-            Time in seconds.
+        time : Union[float, ArrayFloat1D]
+            Time in seconds, either a single value or an array.
 
         Returns
         -------
-        complex
-            Complex-valued source amplitude at that time.
+        ArrayComplex1D
+            Complex-valued source amplitude at the given time(s).
         """
 
         if self.source_time_dataset is None:
-            return None
+            raise SetupError("'source_time_dataset' must be provided to use this method.")
 
         # make time a numpy array for uniform handling
-        times = np.array([time] if isinstance(time, (int, float)) else time)
+        times = np.atleast_1d(np.asarray(time))
         data_times = self.data_times
 
         # shift time
@@ -600,7 +652,7 @@ class CustomSourceTime(Pulse):
         """Time after which the source is effectively turned off / close to zero amplitude."""
 
         if self.source_time_dataset is None:
-            return None
+            raise SetupError("'source_time_dataset' must be provided to use this method.")
 
         data_array = self.source_time_dataset.values
 
@@ -608,7 +660,10 @@ class CustomSourceTime(Pulse):
         source_is_non_zero = ~np.isclose(abs(data_array), 0)
         t_non_zero = t_coords[source_is_non_zero]
 
-        return np.max(t_non_zero)
+        if len(t_non_zero) == 0:
+            return None
+
+        return float(np.max(t_non_zero))
 
 
 class BroadbandPulse(SourceTime):
@@ -669,7 +724,7 @@ class BroadbandPulse(SourceTime):
         """Time after which the source is effectively turned off / close to zero amplitude."""
         return self._source.end_time(END_TIME_FACTOR_GAUSSIAN)
 
-    def amp_time(self, time: float) -> complex:
+    def amp_time(self, time: Union[float, ArrayFloat1D]) -> ArrayComplex1D:
         """Complex-valued source amplitude as a function of time."""
         return self._source.amp_time(time)
 
@@ -686,6 +741,3 @@ class BroadbandPulse(SourceTime):
         is within ``exp(-num_fwidth**2/2)`` of the peak amplitude.
         """
         return self.frequency_range_sigma(num_fwidth)
-
-
-SourceTimeType = Union[GaussianPulse, ContinuousWave, CustomSourceTime, BroadbandPulse]

--- a/tidy3d/components/time.py
+++ b/tidy3d/components/time.py
@@ -15,7 +15,9 @@ from .base import Tidy3dBaseModel
 from .viz import add_ax_if_none
 
 if TYPE_CHECKING:
-    from .types import ArrayFloat1D, Ax, PlotVal
+    from typing import Union
+
+    from .types import ArrayComplex1D, ArrayFloat1D, Ax, PlotVal
 
 # in spectrum computation, discard amplitudes with relative magnitude smaller than cutoff
 DFT_CUTOFF = 1e-8
@@ -36,18 +38,18 @@ class AbstractTimeDependence(ABC, Tidy3dBaseModel):
     )
 
     @abstractmethod
-    def amp_time(self, time: float) -> complex:
+    def amp_time(self, time: Union[float, ArrayFloat1D]) -> ArrayComplex1D:
         """Complex-valued amplitude as a function of time.
 
         Parameters
         ----------
-        time : float
-            Time in seconds.
+        time : Union[float, ArrayFloat1D]
+            Time in seconds, either a single value or an array.
 
         Returns
         -------
-        complex
-            Complex-valued amplitude at that time.
+        ArrayComplex1D
+            Complex-valued amplitude at the given time(s).
         """
 
     def spectrum(

--- a/tidy3d/components/time_modulation.py
+++ b/tidy3d/components/time_modulation.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
     from tidy3d.compat import Self
 
-    from .types import Bound
+    from .types import ArrayComplex1D, ArrayFloat1D, Bound
 
 
 class AbstractTimeModulation(AbstractTimeDependence, ABC):
@@ -76,7 +76,7 @@ class ContinuousWaveTimeModulation(AbstractTimeDependence):
         json_schema_extra={"units": HERTZ},
     )
 
-    def amp_time(self, time: float) -> complex:
+    def amp_time(self, time: Union[float, ArrayFloat1D]) -> Union[complex, ArrayComplex1D]:
         """Complex-valued source amplitude as a function of time."""
 
         omega = 2 * np.pi * self.freq0

--- a/tidy3d/components/types/time.py
+++ b/tidy3d/components/types/time.py
@@ -1,0 +1,29 @@
+"""Union type for all source time profiles."""
+
+from __future__ import annotations
+
+from typing import Union
+
+from tidy3d.components.microwave.time import (
+    BasebandCustomSourceTime,
+    BasebandGaussianPulse,
+    BasebandRectangularPulse,
+    BasebandStep,
+)
+from tidy3d.components.source.time import (
+    BroadbandPulse,
+    ContinuousWave,
+    CustomSourceTime,
+    GaussianPulse,
+)
+
+SourceTimeType = Union[
+    GaussianPulse,
+    ContinuousWave,
+    CustomSourceTime,
+    BroadbandPulse,
+    BasebandStep,
+    BasebandGaussianPulse,
+    BasebandRectangularPulse,
+    BasebandCustomSourceTime,
+]

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -10,8 +10,8 @@ from pydantic import Field, field_validator, model_validator
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.geometry.utils import _shift_value_signed
 from tidy3d.components.simulation import Simulation
-from tidy3d.components.source.time import SourceTimeType
 from tidy3d.components.types import Complex, FreqArray
+from tidy3d.components.types.time import SourceTimeType
 from tidy3d.components.validators import (
     assert_unique_names,
     validate_freqs_min,

--- a/tidy3d/plugins/smatrix/ports/modal.py
+++ b/tidy3d/plugins/smatrix/ports/modal.py
@@ -24,7 +24,7 @@ from tidy3d.plugins.smatrix.ports.base import AbstractBasePort
 if TYPE_CHECKING:
     from typing import Optional
 
-    from tidy3d.components.source.time import SourceTimeType
+    from tidy3d.components.types.time import SourceTimeType
 
 
 class ModalPortDataArray(DataArray):

--- a/tidy3d/rf.py
+++ b/tidy3d/rf.py
@@ -84,6 +84,14 @@ from tidy3d.components.microwave.path_integrals.specs.voltage import (
     AxisAlignedVoltageIntegralSpec,
     Custom2DVoltageIntegralSpec,
 )
+
+# Baseband source times
+from tidy3d.components.microwave.time import (
+    BasebandCustomSourceTime,
+    BasebandGaussianPulse,
+    BasebandRectangularPulse,
+    BasebandStep,
+)
 from tidy3d.components.monitor import DirectivityMonitor
 
 # Source frame
@@ -149,6 +157,10 @@ __all__ = [
     "AxisAlignedPathIntegral",
     "AxisAlignedVoltageIntegral",
     "AxisAlignedVoltageIntegralSpec",
+    "BasebandCustomSourceTime",
+    "BasebandGaussianPulse",
+    "BasebandRectangularPulse",
+    "BasebandStep",
     "BlackmanHarrisWindow",
     "BlackmanWindow",
     "ChebWindow",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core source-time typing and behavior (including `amp_time` return types and validation semantics) which could affect downstream code expecting previous scalar/None behaviors. New baseband types also expand schema unions, so compatibility depends on consumers handling the updated discriminator options.
> 
> **Overview**
> Adds **baseband (unmodulated) `SourceTime` profiles** for transient RF workflows: `BasebandStep`, `BasebandGaussianPulse`, `BasebandRectangularPulse`, and `BasebandCustomSourceTime`, including dataset-based interpolation, FFT-derived `frequency_range`, and phase locked to `0`.
> 
> Wires these new types into JSON schemas (`Simulation`, `ModeSimulation`, `TerminalComponentModeler`) and exports them via `tidy3d.__init__` and `tidy3d.rf`, while centralizing `SourceTimeType` into a new `components/types/time.py` and updating imports accordingly.
> 
> Tightens and standardizes source-time behavior: `amp_time` now accepts scalar or array inputs and returns arrays, `CustomSourceTime` validates strictly increasing time coordinates, rejects non-positive `dt`, raises `SetupError` when datasets are missing, and returns `None` for `end_time` on all-zero data; extensive new tests cover baseband sources and these edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7d872572408e83dc61e0e177a5f5afcb125b911. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->