### PR TITLE
chore: Improve local subpixel warnings and docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed redundant server lookups when loading simulation results.
 - Updated docstrings for `DerivativeInfo` to more accurately reflect dataclass fields.
 - Fixed local cache race conditions causing `FileNotFoundError`.
+- Improved `ModeSolver.solve()` to suppress the accuracy warning when local subpixel averaging is enabled via `tidy3d-extras`, and expanded docstrings for `ModeSolver.solve()`, `ModeSimulation.run_local()`, `Simulation.epsilon()`, and `Simulation.epsilon_on_grid()` to document the `config.simulation.use_local_subpixel` option.
 
 ## [2.10.2] - 2026-01-21
 

--- a/docs/configuration/reference.rst
+++ b/docs/configuration/reference.rst
@@ -64,7 +64,13 @@ Optional overrides that tweak solver behavior at runtime.
    * - ``use_local_subpixel``
      - ``None``
      - No
-     - Set to ``True`` to force local subpixel averaging, ``False`` to disable it, or leave ``None`` to keep the solver default.
+     - Controls whether local subpixel averaging is used in ``Simulation.epsilon``,
+       ``ModeSimulation.run_local``, and ``ModeSolver.solve``. Requires the ``tidy3d-extras``
+       package (``pip install "tidy3d[extras]"``). Set to ``True`` to force local subpixel
+       averaging (raises an error if ``tidy3d-extras`` is not installed), ``False`` to disable
+       it and use permittivity staircasing, or leave ``None`` to use subpixel averaging when
+       available and silently fall back to staircasing otherwise.
+       See :doc:`../extras/index` for more details.
 
 
 Microwave (``config.microwave``)

--- a/docs/extras/index.rst
+++ b/docs/extras/index.rst
@@ -51,9 +51,13 @@ Currently, ``tidy3d-extras`` provides the following features:
 - More accurate local mode solver with subpixel averaging.
 
 By default, these features are automatically enabled if the ``tidy3d-extras``
-package is installed. Thus to obtain subpixel-averaged permittivity, you can
-use functions like ``Simulation.epsilon``. And the more accurate mode solver
-with subpixel averaging is used whenever the mode solver is run locally.
+package is installed. The following functions benefit from local subpixel
+averaging:
+
+- ``Simulation.epsilon`` — returns subpixel-averaged permittivity.
+- ``ModeSimulation.run_local`` — runs the mode simulation locally with
+  subpixel averaging for improved accuracy.
+- ``ModeSolver.solve`` — runs the local mode solver with subpixel averaging.
 
 Sometimes, you may want to change this behavior, for example to speed up
 permittivity computation. In this case, you can temporarily disable these

--- a/tests/test_components/test_packaging.py
+++ b/tests/test_components/test_packaging.py
@@ -194,5 +194,95 @@ def test_supports_local_subpixel_no_error_logged_when_optional(monkeypatch, capl
         reload_config(profile="default")
 
 
+def test_solve_warning_suppressed_when_subpixel_enabled():
+    """The accuracy warning in ModeSolver.solve() should not fire when local subpixel is active."""
+    from types import SimpleNamespace
+
+    from tidy3d.log import log
+
+    reload_config(profile="default")
+
+    # Build a mock module that satisfies _check_tidy3d_extras_available (mod is not
+    # None ⇒ early return) and check_tidy3d_extras_licensed_feature (needs
+    # mod.extension._features() containing "local_subpixel").
+    mock_extension = SimpleNamespace(_features=lambda: {"local_subpixel"})
+    mock_mod = SimpleNamespace(extension=mock_extension)
+
+    tidy3d_extras["mod"] = mock_mod
+    tidy3d_extras["use_local_subpixel"] = None
+
+    _LogCapture = type(
+        "_LogCapture", (), {"records": [], "handle": lambda s, *a: s.records.append(a)}
+    )
+    handler = _LogCapture()
+    log.handlers["_test_capture"] = handler
+
+    try:
+        config.update_section("simulation", use_local_subpixel=True)
+
+        @supports_local_subpixel
+        def _guarded():
+            from tidy3d.packaging import tidy3d_extras as _te
+
+            # Mimics the warning guard in ModeSolver.solve()
+            if not _te["use_local_subpixel"]:
+                log.warning("remote mode solver", log_once=True)
+
+        _guarded()
+        assert not any("remote mode solver" in str(r) for r in handler.records), (
+            "Accuracy warning should be suppressed when local subpixel is enabled"
+        )
+    finally:
+        tidy3d_extras["mod"] = None
+        tidy3d_extras["use_local_subpixel"] = None
+        del log.handlers["_test_capture"]
+        reload_config(profile="default")
+
+
+def test_solve_warning_emitted_when_subpixel_disabled(monkeypatch):
+    """The accuracy warning in ModeSolver.solve() should fire when local subpixel is off."""
+    from tidy3d.log import log
+
+    reload_config(profile="default")
+    tidy3d_extras["mod"] = None
+    tidy3d_extras["use_local_subpixel"] = None
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tidy3d_extras":
+            raise ImportError("forced failure")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    _LogCapture = type(
+        "_LogCapture", (), {"records": [], "handle": lambda s, *a: s.records.append(a)}
+    )
+    handler = _LogCapture()
+    log.handlers["_test_capture"] = handler
+
+    try:
+        config.update_section("simulation", use_local_subpixel=None)
+
+        @supports_local_subpixel
+        def _guarded():
+            from tidy3d.packaging import tidy3d_extras as _te
+
+            # Mimics the warning guard in ModeSolver.solve()
+            if not _te["use_local_subpixel"]:
+                log.warning("remote mode solver", log_once=True)
+
+        _guarded()
+        assert any("remote mode solver" in str(r) for r in handler.records), (
+            "Accuracy warning should be emitted when local subpixel is unavailable"
+        )
+    finally:
+        tidy3d_extras["mod"] = None
+        tidy3d_extras["use_local_subpixel"] = None
+        del log.handlers["_test_capture"]
+        reload_config(profile="default")
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -493,6 +493,7 @@ class ModeSolver(Tidy3dBaseModel):
         and will thus be creating :class:`.MicrowaveModeSolverData`."""
         return isinstance(self.mode_spec, MicrowaveModeSpec)
 
+    @supports_local_subpixel
     def solve(self) -> ModeSolverData:
         """:class:`.ModeSolverData` containing the field and effective index data.
 
@@ -500,12 +501,26 @@ class ModeSolver(Tidy3dBaseModel):
         -------
         ModeSolverData
             :class:`.ModeSolverData` object containing the effective index and mode fields.
+
+        Note
+        ----
+        By default, this method does not use subpixel averaging, which may reduce accuracy.
+        For better accuracy, either use the remote mode solver via ``tidy3d.web.run(...)``
+        or install ``tidy3d-extras`` (``pip install "tidy3d[extras]"``) and set
+        ``config.simulation.use_local_subpixel = True``. See
+        :attr:`SimulationConfig.use_local_subpixel \
+<tidy3d.config.sections.SimulationConfig.use_local_subpixel>`
+        for details.
         """
-        log.warning(
-            "Use the remote mode solver with subpixel averaging for better accuracy through "
-            "'tidy3d.web.run(...)' or the deprecated 'tidy3d.plugins.mode.web.run(...)'.",
-            log_once=True,
-        )
+        # only warn if tidy3d-extras local subpixel is not enabled
+        if not tidy3d_extras["use_local_subpixel"]:
+            log.warning(
+                "Use the remote mode solver with subpixel averaging for better accuracy through "
+                "'tidy3d.web.run(...)' or the deprecated 'tidy3d.plugins.mode.web.run(...)'. "
+                "Alternatively, you can install the package 'tidy3d-extras' using "
+                "'pip install \"tidy3d[extras]\"' and set 'config.simulation.use_local_subpixel=True'.",
+                log_once=True,
+            )
         return self.data
 
     def _freqs_for_group_index(self, freqs: FreqArray) -> FreqArray:

--- a/tidy3d/components/mode/simulation.py
+++ b/tidy3d/components/mode/simulation.py
@@ -269,7 +269,20 @@ class ModeSimulation(AbstractYeeGridSimulation):
 
     @supports_local_subpixel
     def run_local(self) -> ModeSimulationData:
-        """Run locally."""
+        """Run the mode simulation locally and return the results.
+
+        If the ``tidy3d-extras`` package is installed and
+        ``config.simulation.use_local_subpixel`` is not ``False``, subpixel
+        averaging will be used for improved accuracy. See
+        :attr:`SimulationConfig.use_local_subpixel \
+<tidy3d.config.sections.SimulationConfig.use_local_subpixel>`
+        for details.
+
+        Returns
+        -------
+        ModeSimulationData
+            :class:`.ModeSimulationData` containing the mode solver results.
+        """
 
         if tidy3d_extras["use_local_subpixel"]:
             subpixel_sim = tidy3d_extras["mod"].SubpixelModeSimulation.from_mode_simulation(self)
@@ -281,8 +294,8 @@ class ModeSimulation(AbstractYeeGridSimulation):
                     "The package 'tidy3d-extras' is required "
                     "for accurate local 'PermittivityMonitor' and 'MediumMonitor' handling. "
                     "Please install this package using, for example, "
-                    "'pip install tidy3d[extras]', and ensure "
-                    "'config.use_local_subpixel' is not 'False'. "
+                    "'pip install \"tidy3d[extras]\"', and ensure "
+                    "'config.simulation.use_local_subpixel' is not 'False'. "
                     "Alternatively, 'ModeSimulation.epsilon' may be "
                     "used to obtain the non-subpixel-averaged "
                     "permittivity."

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1709,6 +1709,15 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             For details on xarray DataArray objects,
             refer to `xarray's Documentation <https://tinyurl.com/2zrzsp7b>`_.
 
+        Note
+        ----
+        This method supports local subpixel averaging when the ``tidy3d-extras``
+        package is installed. The behavior is controlled by
+        ``config.simulation.use_local_subpixel``. See
+        :attr:`SimulationConfig.use_local_subpixel \
+<tidy3d.config.sections.SimulationConfig.use_local_subpixel>`
+        for details.
+
         See Also
         --------
 
@@ -1743,12 +1752,22 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         freq : float = None
             The frequency to evaluate the mediums at.
             If not specified, evaluates at infinite frequency.
+
         Returns
         -------
         xarray.DataArray
             Datastructure containing the relative permittivity values and location coordinates.
             For details on xarray DataArray objects,
             refer to `xarray's Documentation <https://tinyurl.com/2zrzsp7b>`_.
+
+        Note
+        ----
+        This method supports local subpixel averaging when the ``tidy3d-extras``
+        package is installed. The behavior is controlled by
+        ``config.simulation.use_local_subpixel``. See
+        :attr:`SimulationConfig.use_local_subpixel \
+<tidy3d.config.sections.SimulationConfig.use_local_subpixel>`
+        for details.
         """
 
         grid_cells = np.prod(grid.num_cells)

--- a/tidy3d/config/sections.py
+++ b/tidy3d/config/sections.py
@@ -103,7 +103,18 @@ class SimulationConfig(ConfigSection):
         None,
         title="Use local subpixel",
         description=(
-            "If True, force local subpixel averaging; False disables it; None keeps default behavior."
+            "Controls whether local subpixel averaging is used in "
+            "'Simulation.epsilon', 'ModeSimulation.run_local', and 'ModeSolver.solve'. "
+            "Subpixel averaging improves the accuracy of these computations. "
+            "This feature requires the 'tidy3d-extras' package, which "
+            r"can be installed using 'pip install tidy3d\[extras]'. "
+            "If True, local subpixel averaging is enabled, and these functions will "
+            "raise an error if 'tidy3d-extras' is not installed. "
+            "If False, local subpixel averaging is disabled and these functions "
+            "will use permittivity staircasing instead. "
+            "If None (the default), local subpixel averaging will be used when "
+            "'tidy3d-extras' is installed and will silently fall back "
+            "to permittivity staircasing otherwise."
         ),
     )
 


### PR DESCRIPTION
Fixes unclear warnings / docstrings reported by Tyler.
Related FAQ PR: https://github.com/flexcompute/tidy3d-faq/pull/60


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to warning emission and docstrings, with lightweight test coverage; minimal risk to solver correctness aside from potential warning visibility changes.
> 
> **Overview**
> Updates local mode-solving behavior so `ModeSolver.solve()` is wrapped with `@supports_local_subpixel` and **only emits the accuracy warning when local subpixel averaging is not active**, reducing noise for users running with `tidy3d-extras`.
> 
> Expands/clarifies documentation for `config.simulation.use_local_subpixel` across `Simulation.epsilon*`, `ModeSimulation.run_local()`, `ModeSolver.solve()`, the configuration reference, and the extras docs, including install guidance and the `True`/`False`/`None` semantics. Adds regression tests to verify the warning suppression/emission behavior under different `tidy3d-extras` availability/config settings, and records the change in the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 290e288779cb5217c15ffe3fd170c8abf36f457d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->