### PR TITLE
Improve EME docstrings and change default num_points (FXC-4276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduced computation time of `adaptive_vjp_spacing` for `GeometryGroup` by allowing permittivity based spacing value to be cached.
 - Added warning in `LayerRefinementSpec` when `dl_min_from_gaps` (derived from automatic gap refinement) is very small relative to the lateral grid size for identifying cases where excessive grid refinement may occur due to very small detected gaps.
 - Added `custom_vjp` and new custom run functions that provide hooks into adjoint for custom gradient calculations.
+- Changed default `num_points` in `EMEModeSpec.interp_spec` from 3 to 5 for improved accuracy of frequency interpolation.
 
 ### Fixed
 - Fixed intermittent "API key not found" errors in parallel job launches by making configuration directory detection race-safe.

--- a/docs/api/eme/output_data.rst
+++ b/docs/api/eme/output_data.rst
@@ -23,3 +23,17 @@ Simulation Data
    :template: module.rst
 
    tidy3d.EMESimulationData
+
+
+Datasets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.EMESMatrixDataset
+   tidy3d.EMECoefficientDataset
+   tidy3d.EMEOverlapDataset
+   tidy3d.EMEFieldDataset
+   tidy3d.EMEModeSolverDataset

--- a/docs/api/eme/sweep.rst
+++ b/docs/api/eme/sweep.rst
@@ -9,3 +9,6 @@ Propagation Sweeps
 
    tidy3d.EMELengthSweep
    tidy3d.EMEModeSweep
+   tidy3d.EMEPeriodicitySweep
+   tidy3d.EMEFreqSweep
+

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -5200,7 +5200,7 @@
             "reduce_data": true,
             "sampling_spec": {
               "attrs": {},
-              "num_points": 3,
+              "num_points": 5,
               "type": "ChebSampling"
             },
             "type": "ModeInterpSpec"

--- a/tidy3d/components/eme/data/dataset.py
+++ b/tidy3d/components/eme/data/dataset.py
@@ -22,7 +22,43 @@ from tidy3d.exceptions import ValidationError
 
 
 class EMESMatrixDataset(Dataset):
-    """Dataset storing S matrix."""
+    """Dataset storing the scattering matrix of an EME simulation.
+
+    Notes
+    -----
+        The S matrix relates incoming and outgoing mode amplitudes at the two ports
+        of the EME device. Port 1 is at the beginning and port 2 is at the end of
+        the propagation axis.
+
+        Convention:
+
+        - ``S11``: reflection at port 1 (input at port 1, output at port 1).
+        - ``S21``: transmission from port 1 to port 2.
+        - ``S12``: transmission from port 2 to port 1.
+        - ``S22``: reflection at port 2 (input at port 2, output at port 2).
+
+        Each element is indexed by ``(f, mode_index_out, mode_index_in)`` and
+        optionally ``sweep_index`` when a sweep is used.
+
+    See Also
+    --------
+        :class:`.EMESimulationData` :
+            Simulation data containing the S matrix.
+
+    Example
+    -------
+    >>> from tidy3d import EMESMatrixDataArray
+    >>> f = [2e14]
+    >>> sweep_index = [0]
+    >>> mode_index_in = [0, 1]
+    >>> mode_index_out = [0, 1]
+    >>> coords = dict(
+    ...     f=f, sweep_index=sweep_index,
+    ...     mode_index_out=mode_index_out, mode_index_in=mode_index_in,
+    ... )
+    >>> S = EMESMatrixDataArray((1+1j) * np.random.random((1, 1, 2, 2)), coords=coords)
+    >>> smatrix = EMESMatrixDataset(S11=S, S12=S, S21=S, S22=S)
+    """
 
     S11: EMESMatrixDataArray = Field(
         title="S11 matrix",
@@ -105,6 +141,23 @@ class EMECoefficientDataset(Dataset):
 
         The ``interface_Sij`` fields store the S matrices associated with the interfaces
         between EME cells.
+
+    Example
+    -------
+    >>> from tidy3d import EMECoefficientDataArray
+    >>> f = [2e14]
+    >>> sweep_index = [0]
+    >>> eme_port_index = [0, 1]
+    >>> eme_cell_index = [0, 1, 2]
+    >>> mode_index_out = [0, 1]
+    >>> mode_index_in = [0, 1]
+    >>> coords = dict(
+    ...     f=f, sweep_index=sweep_index, eme_port_index=eme_port_index,
+    ...     eme_cell_index=eme_cell_index,
+    ...     mode_index_out=mode_index_out, mode_index_in=mode_index_in,
+    ... )
+    >>> A = EMECoefficientDataArray((1+1j) * np.random.random((1, 1, 2, 3, 2, 2)), coords=coords)
+    >>> data = EMECoefficientDataset(A=A, B=A)
     """
 
     A: Optional[EMECoefficientDataArray] = Field(
@@ -143,9 +196,20 @@ class EMECoefficientDataset(Dataset):
 
     @cached_property
     def normalized_copy(self) -> EMECoefficientDataset:
-        """Return a copy of the ``EMECoefficientDataset`` where
-        the ``A`` and ``B`` coefficients as well as the ``interface_smatrices``
-        are normalized by flux."""
+        """Return a flux-normalized copy of this dataset.
+
+        The ``A`` and ``B`` coefficients as well as the ``interface_smatrices``
+        are multiplied by the square root of the mode flux, so that the
+        forward and backward power of each mode are given directly by
+        ``|A|^2`` and ``|B|^2``, respectively, without additional
+        normalization by flux.
+
+        Returns
+        -------
+        :class:`.EMECoefficientDataset`
+            A new dataset with flux-normalized coefficients. The ``flux`` field
+            is set to ``None`` to prevent double normalization.
+        """
         if self.flux is None:
             raise ValidationError(
                 "The 'flux' field of the 'EMECoefficientDataset' is 'None', "
@@ -179,7 +243,32 @@ class EMECoefficientDataset(Dataset):
 
 
 class EMEFieldDataset(ElectromagneticFieldDataset):
-    """Dataset storing scalar components of E and H fields as a function of freq, mode_index, and port_index."""
+    """Dataset storing scalar components of E and H fields from EME propagation.
+
+    Notes
+    -----
+        Each field component is an :class:`.EMEScalarFieldDataArray` with coordinates
+        ``(x, y, z, f, sweep_index, eme_port_index, mode_index)``, where
+        ``eme_port_index`` indicates which port is excited and ``mode_index``
+        indicates which mode at that port is excited.
+
+    Example
+    -------
+    >>> from tidy3d import EMEScalarFieldDataArray
+    >>> x = [0, 1]
+    >>> y = [0, 1, 2]
+    >>> z = [0]
+    >>> f = [2e14]
+    >>> sweep_index = [0]
+    >>> eme_port_index = [0, 1]
+    >>> mode_index = [0, 1]
+    >>> coords = dict(
+    ...     x=x, y=y, z=z, f=f, sweep_index=sweep_index,
+    ...     eme_port_index=eme_port_index, mode_index=mode_index,
+    ... )
+    >>> field = EMEScalarFieldDataArray((1+1j) * np.random.random((2,3,1,1,1,2,2)), coords=coords)
+    >>> data = EMEFieldDataset(Ex=field, Hy=field)
+    """
 
     Ex: Optional[EMEScalarFieldDataArray] = Field(
         None,
@@ -214,11 +303,44 @@ class EMEFieldDataset(ElectromagneticFieldDataset):
 
 
 class EMEModeSolverDataset(ElectromagneticFieldDataset):
-    """Dataset storing EME modes as a function of freq, mode_index, and cell_index."""
+    """Dataset storing the eigenmodes computed at each EME cell.
+
+    Notes
+    -----
+        Each field component is an :class:`.EMEScalarModeFieldDataArray` with coordinates
+        ``(x, y, z, f, eme_cell_index, mode_index)`` and optionally ``sweep_index``
+        when a frequency sweep is used. Also stores the complex propagation index
+        ``n_complex`` for each mode.
+
+    Example
+    -------
+    >>> from tidy3d import EMEScalarModeFieldDataArray, EMEModeIndexDataArray
+    >>> x = [0, 1]
+    >>> y = [0, 1, 2]
+    >>> z = [0]
+    >>> f = [2e14]
+    >>> sweep_index = [0]
+    >>> eme_cell_index = [0, 1, 2]
+    >>> mode_index = [0, 1]
+    >>> field_coords = dict(
+    ...     x=x, y=y, z=z, f=f, sweep_index=sweep_index,
+    ...     eme_cell_index=eme_cell_index, mode_index=mode_index,
+    ... )
+    >>> field = EMEScalarModeFieldDataArray(
+    ...     (1+1j) * np.random.random((2,3,1,1,1,3,2)), coords=field_coords
+    ... )
+    >>> index_coords = dict(
+    ...     f=f, sweep_index=sweep_index, eme_cell_index=eme_cell_index, mode_index=mode_index,
+    ... )
+    >>> n_complex = EMEModeIndexDataArray((1+0.01j) * np.ones((1,1,3,2)), coords=index_coords)
+    >>> data = EMEModeSolverDataset(
+    ...     n_complex=n_complex, Ex=field, Ey=field, Ez=field, Hx=field, Hy=field, Hz=field,
+    ... )
+    """
 
     n_complex: EMEModeIndexDataArray = Field(
         title="Propagation Index",
-        description="Complex-valued effective propagation constants associated with the mode.",
+        description="Complex-valued effective propagation indices associated with the mode.",
     )
 
     Ex: EMEScalarModeFieldDataArray = Field(

--- a/tidy3d/components/eme/data/monitor_data.py
+++ b/tidy3d/components/eme/data/monitor_data.py
@@ -23,7 +23,47 @@ from .dataset import EMECoefficientDataset, EMEFieldDataset, EMEModeSolverDatase
 
 
 class EMEModeSolverData(ElectromagneticFieldData, EMEModeSolverDataset):
-    """Data associated with an EME mode solver monitor."""
+    """Data associated with an :class:`.EMEModeSolverMonitor`.
+
+    Notes
+    -----
+        Contains the eigenmodes used in the EME expansion and propagation. These are
+        the modes computed at each EME cell, including their field profiles and complex
+        propagation indices. This data is recorded only within the monitor geometry.
+
+    Example
+    -------
+    >>> from tidy3d import EMEModeSolverMonitor, EMEScalarModeFieldDataArray, EMEModeIndexDataArray
+    >>> from tidy3d import Grid, Coords
+    >>> import numpy as np
+    >>> monitor = EMEModeSolverMonitor(
+    ...     center=(0,0,0), size=(1,1,1), freqs=[2e14], num_modes=2, name="modes"
+    ... )
+    >>> x = [0, 1]
+    >>> y = [0, 1]
+    >>> z = [0]
+    >>> f = [2e14]
+    >>> mode_index = [0, 1]
+    >>> eme_cell_index = [0, 1]
+    >>> sweep_index = [0]
+    >>> field_coords = dict(
+    ...     x=x, y=y, z=z, f=f, sweep_index=sweep_index,
+    ...     eme_cell_index=eme_cell_index, mode_index=mode_index,
+    ... )
+    >>> field = EMEScalarModeFieldDataArray(
+    ...     (1+1j) * np.random.random((2,2,1,1,1,2,2)), coords=field_coords
+    ... )
+    >>> index_coords = dict(
+    ...     f=f, sweep_index=sweep_index, eme_cell_index=eme_cell_index, mode_index=mode_index,
+    ... )
+    >>> n_complex = EMEModeIndexDataArray((1+0.01j) * np.ones((1,1,2,2)), coords=index_coords)
+    >>> grid = Grid(boundaries=Coords(x=[-0.5, 0.5, 1.5], y=[-0.5, 0.5, 1.5], z=[-0.5, 0.5]))
+    >>> data = EMEModeSolverData(
+    ...     monitor=monitor, n_complex=n_complex,
+    ...     Ex=field, Ey=field, Ez=field, Hx=field, Hy=field, Hz=field,
+    ...     grid_expanded=grid,
+    ... )
+    """
 
     monitor: EMEModeSolverMonitor = Field(
         title="EME Mode Solver Monitor",
@@ -32,7 +72,41 @@ class EMEModeSolverData(ElectromagneticFieldData, EMEModeSolverDataset):
 
 
 class EMEFieldData(ElectromagneticFieldData, EMEFieldDataset):
-    """Data associated with an EME field monitor."""
+    """Data associated with an :class:`.EMEFieldMonitor`.
+
+    Notes
+    -----
+        Contains the propagated electromagnetic field assembled from EME modes
+        and their expansion coefficients. The field is stored per excitation port
+        and per excited mode.
+
+    Example
+    -------
+    >>> from tidy3d import EMEFieldMonitor, EMEScalarFieldDataArray
+    >>> from tidy3d import Grid, Coords
+    >>> import numpy as np
+    >>> monitor = EMEFieldMonitor(
+    ...     center=(0,0,0), size=(1,1,0), freqs=[2e14], num_modes=2, name="field"
+    ... )
+    >>> x = [0, 1]
+    >>> y = [0, 1]
+    >>> z = [0]
+    >>> f = [2e14]
+    >>> sweep_index = [0]
+    >>> eme_port_index = [0, 1]
+    >>> mode_index = [0, 1]
+    >>> coords = dict(
+    ...     x=x, y=y, z=z, f=f, sweep_index=sweep_index,
+    ...     eme_port_index=eme_port_index, mode_index=mode_index,
+    ... )
+    >>> field = EMEScalarFieldDataArray((1+1j) * np.random.random((2,2,1,1,1,2,2)), coords=coords)
+    >>> grid = Grid(boundaries=Coords(x=[-0.5, 0.5, 1.5], y=[-0.5, 0.5, 1.5], z=[-0.5, 0.5]))
+    >>> data = EMEFieldData(
+    ...     monitor=monitor,
+    ...     Ex=field, Ey=field, Ez=field, Hx=field, Hy=field, Hz=field,
+    ...     grid_expanded=grid,
+    ... )
+    """
 
     monitor: EMEFieldMonitor = Field(
         title="EME Field Monitor",
@@ -41,7 +115,36 @@ class EMEFieldData(ElectromagneticFieldData, EMEFieldDataset):
 
 
 class EMECoefficientData(AbstractMonitorData, EMECoefficientDataset):
-    """Data associated with an EME coefficient monitor."""
+    """Data associated with an :class:`.EMECoefficientMonitor`.
+
+    Notes
+    -----
+        Contains the forward (``A``) and backward (``B``) mode amplitudes in each
+        EME cell, as well as optional diagnostic quantities such as propagation
+        indices (``n_complex``), power flux (``flux``), interface S matrices
+        (``interface_smatrices``), and mode overlaps (``overlaps``).
+
+    Example
+    -------
+    >>> from tidy3d import EMECoefficientMonitor, EMECoefficientDataArray
+    >>> import numpy as np
+    >>> monitor = EMECoefficientMonitor(
+    ...     center=(0,0,0), size=(1,1,1), freqs=[2e14], num_modes=2, name="coeffs"
+    ... )
+    >>> f = [2e14]
+    >>> sweep_index = [0]
+    >>> eme_port_index = [0, 1]
+    >>> eme_cell_index = [0, 1]
+    >>> mode_index_out = [0, 1]
+    >>> mode_index_in = [0, 1]
+    >>> coords = dict(
+    ...     f=f, sweep_index=sweep_index, eme_port_index=eme_port_index,
+    ...     eme_cell_index=eme_cell_index,
+    ...     mode_index_out=mode_index_out, mode_index_in=mode_index_in,
+    ... )
+    >>> A = EMECoefficientDataArray((1+1j) * np.random.random((1, 1, 2, 2, 2, 2)), coords=coords)
+    >>> data = EMECoefficientData(monitor=monitor, A=A, B=A)
+    """
 
     monitor: EMECoefficientMonitor = Field(
         title="EME Coefficient Monitor",

--- a/tidy3d/components/eme/data/sim_data.py
+++ b/tidy3d/components/eme/data/sim_data.py
@@ -29,7 +29,64 @@ if TYPE_CHECKING:
 
 
 class EMESimulationData(AbstractYeeGridSimulationData):
-    """Data associated with an EME simulation."""
+    """Data associated with an EME simulation.
+
+    Notes
+    -----
+        Contains the results of an :class:`.EMESimulation`, including the scattering matrix
+        (``smatrix``), port modes (``port_modes``), mode coefficients (``coeffs``), and any
+        monitor data recorded during the simulation.
+
+        The scattering matrix is expressed in the basis of the port modes. Use
+        :meth:`smatrix_in_basis` to re-express it in a different modal basis, for example
+        to compute transmission into a specific mode of an output waveguide. Similarly,
+        use :meth:`field_in_basis` to re-express the propagated field.
+
+        **Accessing Results**
+
+        Fundamental-mode transmission and reflection:
+
+        .. code-block:: python
+
+            T = sim_data.smatrix.S21.isel(mode_index_in=0, mode_index_out=0).abs ** 2
+            R = sim_data.smatrix.S11.isel(mode_index_in=0, mode_index_out=0).abs ** 2
+
+        Monitor data recorded by an :class:`.EMEFieldMonitor` or :class:`.EMECoefficientMonitor`
+        can be accessed by name:
+
+        .. code-block:: python
+
+            field_data = sim_data["field_monitor_name"]
+
+        To express the scattering matrix in a custom modal basis (e.g., modes of individual
+        output waveguides), add an :class:`.EMEModeSolverMonitor` at the output port and use
+        :meth:`smatrix_in_basis`:
+
+        .. code-block:: python
+
+            smatrix_custom = sim_data.smatrix_in_basis(modes2=sim_data["output_monitor"])
+
+    See Also
+    --------
+        :class:`.EMESimulation` :
+            The simulation object that produces this data.
+        :class:`.EMESMatrixDataset` :
+            The scattering matrix dataset.
+
+    Example
+    -------
+    >>> import tidy3d as td
+    >>> sim = td.EMESimulation(
+    ...     size=(2, 2, 6),
+    ...     freqs=[2e14],
+    ...     axis=2,
+    ...     eme_grid_spec=td.EMEUniformGrid(
+    ...         num_cells=3, mode_spec=td.EMEModeSpec(num_modes=2)
+    ...     ),
+    ...     grid_spec=td.GridSpec.auto(wavelength=1.55),
+    ... )
+    >>> sim_data = EMESimulationData(simulation=sim, data=())
+    """
 
     simulation: EMESimulation = Field(
         title="EME simulation",
@@ -137,7 +194,15 @@ class EMESimulationData(AbstractYeeGridSimulationData):
 
     @cached_property
     def port_modes_tuple(self) -> tuple[ModeSolverData, ModeSolverData]:
-        """Port modes as a tuple ``(port_modes_1, port_modes_2)``."""
+        """Port modes as a tuple ``(port_modes_1, port_modes_2)``.
+
+        Returns
+        -------
+        tuple[:class:`.ModeSolverData`, :class:`.ModeSolverData`]
+            A pair of :class:`.ModeSolverData` for port 1 and port 2, respectively.
+            Raises :class:`.SetupError` if ``store_port_modes`` was not enabled,
+            or if port modes vary with sweep index (use :attr:`port_modes_list_sweep` instead).
+        """
         if self.port_modes is None:
             raise SetupError(
                 "The field 'port_modes' is 'None'. Please set 'store_port_modes' "
@@ -160,8 +225,15 @@ class EMESimulationData(AbstractYeeGridSimulationData):
 
     @cached_property
     def port_modes_list_sweep(self) -> list[tuple[ModeSolverData, ModeSolverData]]:
-        """Port modes as a list of tuples ``(port_modes_1, port_modes_2)``.
-        There is one entry for every sweep index if the port modes vary with sweep index."""
+        """Port modes as a list of tuples, one per sweep index.
+
+        Returns
+        -------
+        list[tuple[:class:`.ModeSolverData`, :class:`.ModeSolverData`]]
+            A list with one ``(port_modes_1, port_modes_2)`` tuple per sweep index.
+            If the sweep does not change the modes (e.g. :class:`.EMELengthSweep`),
+            the list contains a single entry.
+        """
         if self.port_modes is None:
             raise SetupError(
                 "The field 'port_modes' is 'None'. Please set 'store_port_modes' "
@@ -198,9 +270,9 @@ class EMESimulationData(AbstractYeeGridSimulationData):
         Parameters
         ----------
         modes1: Union[FieldData, ModeData]
-            New modal basis for port 1. If None, use port_modes.
+            New modal basis for port 1. If ``None``, use ``port_modes``.
         modes2: Union[FieldData, ModeData]
-            New modal basis for port 2. If None, use port_modes.
+            New modal basis for port 2. If ``None``, use ``port_modes``.
 
         Returns
         -------
@@ -208,6 +280,31 @@ class EMESimulationData(AbstractYeeGridSimulationData):
             The scattering matrix of the EME simulation, but expressed in the basis
             of the provided modes, rather than in the basis of ``port_modes`` used
             in computation.
+
+        Notes
+        -----
+        This is useful when the computational port modes do not match the modes of
+        interest.  For example, in a waveguide splitter the output port spans multiple
+        waveguides, so the EME port modes are super-modes of the combined structure.
+        To obtain the scattering matrix in the basis of individual waveguide modes,
+        place an :class:`.EMEModeSolverMonitor` over each output waveguide and pass
+        the resulting data here.
+
+        ``store_port_modes`` must be ``True`` in the :class:`.EMESimulation` for this
+        method to work.
+
+        Typical workflow:
+
+        .. code-block:: python
+
+            # 1. Add a monitor over the output waveguide(s)
+            output_mon = td.EMEModeSolverMonitor(
+                size=output_size, center=output_center, name="output", ...
+            )
+
+            # 2. After running, re-express the S-matrix
+            smatrix_custom = sim_data.smatrix_in_basis(modes2=sim_data["output"])
+            T_custom = smatrix_custom.S21.isel(mode_index_in=0, mode_index_out=0).abs ** 2
         """
 
         if self.port_modes is None:
@@ -430,7 +527,7 @@ class EMESimulationData(AbstractYeeGridSimulationData):
         Returns
         -------
         :class:`.EMEFieldData`
-            The propagated electromagnetic fied expressed in the basis
+            The propagated electromagnetic field expressed in the basis
             of the provided modes, rather than in the basis of ``port_modes`` used
             in computation.
         """

--- a/tidy3d/components/eme/grid.py
+++ b/tidy3d/components/eme/grid.py
@@ -30,10 +30,24 @@ MAX_NUM_REPS = 100000
 
 
 class EMEModeSpec(ModeSpec):
-    """Mode spec for EME cells. Overrides some of the defaults and allowed values."""
+    """Mode specification for EME cells.
+
+    Notes
+    -----
+        Inherits from :class:`.ModeSpec` but overrides several defaults and constraints
+        for use in EME simulations:
+
+        - Propagation angles (``angle_theta``, ``angle_phi``) are locked to ``0``.
+          For off-normal injection, use a :class:`.ModeSolverMonitor` together with
+          :meth:`.EMESimulationData.smatrix_in_basis`.
+        - Default precision is ``'auto'`` (double precision for structures with good
+          conductors, single precision otherwise).
+        - Includes an ``interp_spec`` field for frequency interpolation of modes,
+          which can significantly reduce cost for broadband simulations.
+    """
 
     interp_spec: Optional[ModeInterpSpec] = Field(
-        ModeInterpSpec.cheb(num_points=3, reduce_data=True),
+        ModeInterpSpec.cheb(num_points=5, reduce_data=True),
         title="Mode frequency interpolation specification",
         description="Specification for computing modes at a reduced set of frequencies and "
         "interpolating to obtain results at all requested frequencies. This can significantly "

--- a/tidy3d/components/eme/monitor.py
+++ b/tidy3d/components/eme/monitor.py
@@ -23,7 +23,15 @@ BYTES_COMPLEX = 8
 
 
 class EMEMonitor(AbstractMonitor, ABC):
-    """Abstract EME monitor."""
+    """Abstract base class for EME monitors.
+
+    Notes
+    -----
+        EME monitors record data from the EME eigenmode expansion and propagation.
+        Unlike FDTD monitors, they do not record time-domain data; instead they
+        record modal quantities such as eigenmodes, mode coefficients, and
+        fields reconstructed from the EME basis.
+    """
 
     freqs: Optional[FreqArray] = Field(
         None,
@@ -208,7 +216,15 @@ class EMEModeSolverMonitor(EMEMonitor):
 
 
 class EMEFieldMonitor(EMEMonitor, AbstractFieldMonitor):
-    """EME monitor for propagated field.
+    """EME monitor for propagated electromagnetic field.
+
+    Notes
+    -----
+        Records the E and H fields assembled from EME modes and their propagation
+        coefficients. The field is stored as a function of spatial coordinates,
+        frequency, ``sweep_index``, ``eme_port_index``, and ``mode_index``, where
+        ``eme_port_index`` indicates the excitation port and ``mode_index`` indicates
+        the excited mode at that port.
 
     Example
     -------
@@ -274,9 +290,15 @@ class EMEFieldMonitor(EMEMonitor, AbstractFieldMonitor):
 
 
 class EMECoefficientMonitor(EMEMonitor):
-    """EME monitor for mode coefficients.
-    Records the amplitudes of the forward and backward modes in each cell
-    intersecting the monitor geometry.
+    """EME monitor for mode coefficients and related quantities.
+
+    Notes
+    -----
+        Records the amplitudes of the forward (``A``) and backward (``B``) modes
+        in each cell intersecting the monitor geometry. Additional fields can be
+        recorded by including them in the ``fields`` parameter: propagation indices
+        (``n_complex``), power flux (``flux``), interface S matrices
+        (``interface_smatrices``), and mode overlaps (``overlaps``).
 
     Example
     -------

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -102,6 +102,13 @@ class EMESimulation(AbstractYeeGridSimulation):
         The electromagnetic fields are expanded locally in the basis of eigenmodes of the
         waveguide; they are then propagated by imposing continuity conditions in this basis.
 
+        The solver computes the full **bidirectional scattering matrix**, accounting for
+        reflections and mode coupling at every cell interface, with optional passivity or
+        unitarity constraints. Supported features include bent waveguides (via ``bend_radius`` in
+        :class:`.EMEModeSpec`), anisotropic materials (:class:`.AnisotropicMedium`),
+        broadband frequency interpolation, and efficient parameter sweeps over cell lengths,
+        number of modes, and periodic repetitions.
+
         The EME simulation is performed along the propagation axis ``axis`` at frequencies ``freqs``.
         The simulation is divided into cells along the propagation axis, as defined by
         ``eme_grid_spec``. Mode solving is performed at cell centers, and boundary conditions are
@@ -110,6 +117,20 @@ class EMESimulation(AbstractYeeGridSimulation):
 
         An EME simulation always computes the full scattering matrix of the structure.
         Additional data can be recorded by adding 'monitors' to the simulation.
+
+        **Monitors**
+
+        The following monitor types are supported:
+
+        - :class:`.EMEModeSolverMonitor` — record the eigenmodes at each EME cell.
+        - :class:`.EMEFieldMonitor` — record the propagated E and H fields.
+        - :class:`.EMECoefficientMonitor` — record forward/backward mode coefficients and
+          related diagnostic quantities.
+        - :class:`.ModeSolverMonitor` — solve modes at a cross-section (e.g. for use with
+          :meth:`.EMESimulationData.smatrix_in_basis`).
+        - :class:`.PermittivityMonitor` — record the complex relative permittivity tensor.
+        - :class:`.MediumMonitor` — record the complex relative permittivity and permeability
+          tensors.
 
         **Other Bases**
 
@@ -195,6 +216,9 @@ class EMESimulation(AbstractYeeGridSimulation):
         (),
         title="Monitors",
         description="Tuple of monitors in the simulation. "
+        "Supported types: 'EMEModeSolverMonitor', 'EMEFieldMonitor', "
+        "'EMECoefficientMonitor', 'ModeSolverMonitor', 'PermittivityMonitor', "
+        "and 'MediumMonitor'. "
         "Note: monitor names are used to access data after simulation is run.",
     )
 
@@ -334,7 +358,28 @@ class EMESimulation(AbstractYeeGridSimulation):
         vlim: Optional[tuple[float, float]] = None,
         **kwargs: Any,
     ) -> Ax:
-        """Plot the EME ports."""
+        """Plot the EME port locations on a cross-sectional plane.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x, y, z must be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        hlim : tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y range if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
         import matplotlib as mpl
 
         kwargs.setdefault("linewidth", 0.4)
@@ -380,9 +425,32 @@ class EMESimulation(AbstractYeeGridSimulation):
         vlim: Optional[tuple[float, float]] = None,
         **kwargs: Any,
     ) -> Ax:
-        """Plot the EME subgrid boundaries.
+        """Plot the EME subgrid boundaries on a cross-sectional plane.
+
         Does nothing if ``eme_grid_spec`` is not :class:`.EMECompositeGrid`.
-        Operates recursively on subgrids.
+        Operates recursively on nested subgrids.
+
+        Parameters
+        ----------
+        eme_grid_spec : :class:`.EMEGridSpec`
+            The EME grid spec whose subgrid boundaries to plot.
+        x : float = None
+            Position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x, y, z must be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        hlim : tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y range if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
         """
         import matplotlib as mpl
 
@@ -434,7 +502,28 @@ class EMESimulation(AbstractYeeGridSimulation):
         vlim: Optional[tuple[float, float]] = None,
         **kwargs: Any,
     ) -> Ax:
-        """Plot the EME grid."""
+        """Plot the EME cell boundaries on a cross-sectional plane.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x, y, z must be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        hlim : tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y range if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
         import matplotlib as mpl
 
         kwargs.setdefault("linewidth", 0.2)
@@ -559,8 +648,12 @@ class EMESimulation(AbstractYeeGridSimulation):
         scene : :class:`.Scene`
             Scene containing structures information.
         **kwargs
-            Other arguments
+            Other arguments passed to the :class:`.EMESimulation` constructor.
 
+        Returns
+        -------
+        :class:`.EMESimulation`
+            An EME simulation with structures and medium from the provided scene.
         """
         return cls(
             structures=scene.structures,

--- a/tidy3d/components/eme/sweep.py
+++ b/tidy3d/components/eme/sweep.py
@@ -15,7 +15,26 @@ from .grid import MAX_NUM_REPS
 
 
 class EMESweepSpec(Tidy3dBaseModel, ABC):
-    """Abstract spec for sweep done during EME propagation step."""
+    """Abstract spec for a parameter sweep during the EME propagation step.
+
+    Notes
+    -----
+        An EME sweep re-runs the propagation step with varied parameters while reusing
+        previously computed mode data. This makes sweeps much faster than running
+        multiple independent simulations, since the mode solving step is typically the
+        most expensive part of an EME simulation.
+
+    See Also
+    --------
+        :class:`.EMELengthSweep` :
+            Sweep over cell lengths.
+        :class:`.EMEModeSweep` :
+            Sweep over number of modes (convergence testing).
+        :class:`.EMEPeriodicitySweep` :
+            Sweep over number of periodic repetitions.
+        :class:`.EMEFreqSweep` :
+            Sweep over frequency using perturbative mode solving.
+    """
 
     @property
     @abstractmethod
@@ -39,7 +58,19 @@ class EMESweepSpec(Tidy3dBaseModel, ABC):
 
 
 class EMELengthSweep(EMESweepSpec):
-    """Spec for sweeping EME cell lengths."""
+    """Spec for sweeping EME cell lengths.
+
+    Notes
+    -----
+        Varies the lengths of EME cells without re-solving modes. This is useful for
+        optimizing device length, since only the propagation phase accumulated within
+        each cell changes. If a 2D array is provided for ``scale_factors``, different
+        cells can be scaled independently at each sweep index.
+
+    Example
+    -------
+    >>> sweep_spec = EMELengthSweep(scale_factors=[0.5, 1.0, 1.5, 2.0])
+    """
 
     scale_factors: ArrayLike = Field(
         title="Length Scale Factor",
@@ -63,7 +94,12 @@ class EMELengthSweep(EMESweepSpec):
 
 class EMEModeSweep(EMESweepSpec):
     """Spec for sweeping number of modes in EME propagation step.
-    Used for convergence testing."""
+    Used for convergence testing.
+
+    Example
+    -------
+    >>> sweep_spec = EMEModeSweep(num_modes=[1, 2, 5, 10])
+    """
 
     num_modes: ArrayInt1D = Field(
         title="Number of Modes",
@@ -94,7 +130,12 @@ class EMEFreqSweep(EMESweepSpec):
     """Spec for sweeping frequency in EME propagation step.
     Unlike ``sim.freqs``, the frequency sweep is approximate, using a
     perturbative mode solver relative to the simulation EME modes.
-    This can be a faster way to solve at a larger number of frequencies."""
+    This can be a faster way to solve at a larger number of frequencies.
+
+    Example
+    -------
+    >>> sweep_spec = EMEFreqSweep(freq_scale_factors=[0.9, 0.95, 1.0, 1.05, 1.1])
+    """
 
     freq_scale_factors: ArrayFloat1D = Field(
         title="Frequency Scale Factors",


### PR DESCRIPTION
Improving docstrings and changing num_points default from 3 to 5 for frequency interpolation for more robust defaults

FAQ PR: https://github.com/flexcompute/tidy3d-faq/pull/61


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation-only changes; the only behavioral change is increasing the default mode interpolation sampling points, which may slightly increase runtime/memory for multi-frequency EME runs but should improve accuracy.
> 
> **Overview**
> Improves the public EME API documentation by substantially expanding docstrings and adding usage examples across EME datasets, monitor data containers, sweeps, and `EMESimulationData` (including guidance for `smatrix_in_basis` / `field_in_basis`).
> 
> Changes the default frequency-interpolation sampling for EME modes by updating `EMEModeSpec.interp_spec` (and the `EMESimulation` schema) from `num_points=3` to `num_points=5`, and updates the Sphinx API pages to list the EME dataset classes and sweep types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bdf2761c3e29cb8718fb91836c4710b037fad21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->