### PR TITLE
FXC-5505: Enable CI test selection with pytest-testmon

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -85,8 +85,14 @@ Primary CI workflow; it runs on PRs (`latest`, `develop`, `pre/*`), merge queue 
 - **Optional suites**: CLI tests, version consistency checks, submodule validation (non-RC release tags only), and `tidy3d-extras` integration tests can be toggled via inputs.
 - **Extras integration tests**: When enabled on merge_group, runs basic smoke tests (4 configurations). When called from release workflow, runs full tests (10 configurations covering all architectures and Python 3.10/3.13).
 - **Test type control**: `test_type` input ("basic" or "full") can override automatic selection for extras integration tests.
+- **Test selection control**: `test_selection` input (`testmon` or `full`) controls whether local/remote suites run with pytest-testmon (`--testmon --testmon-forceselect`) or full (`--no-testmon`) execution.
+- **Default policy**: PR and manual runs default to `test_selection: testmon`; merge queue (`merge_group`) forces `full` for safety.
+- **Testmon cache strategy**: local/remote testmon caches are shared by runner + Python + dependency hash and anchored to the default branch (`develop`) SHA. PR runs restore from that shared cache and do not write new entries.
+- **Cache refresh path**: successful merge queue runs (`merge_group`) execute full coverage in testmon collection mode (`--testmon-noselect`) and write refreshed shared caches; no additional post-merge push run is required.
 - **Dynamic scope**: Determines which jobs to run based on the event (draft PRs, approvals, merge queue, manual overrides).
 - **Outputs**: `workflow_success` summarizes whether every required job succeeded; the release workflow uses this to decide if deployment can continue.
+
+Manual full-suite safety run: trigger `tidy3d-python-client-tests.yml` with `workflow_dispatch` and set `test_selection=full`.
 
 > The previous `tidy3d-python-client-release-tests.yml` workflow has been removed. Release-specific suites now live entirely inside this unified workflow.
 
@@ -131,6 +137,7 @@ The workflow ensures that the `tidy3d-extras` package installs and functions cor
 Scheduled at 05:00 UTC and also manually runnable. It fans out to:
 - `tidy3d-python-client-update-lockfile.yml` – keeps dependencies fresh.
 - `tidy3d-python-client-release.yml` – runs a daily draft release (`daily-0.0.0`) with client and CLI tests enabled to catch breaking changes early. This validates that the package can be built and tested against the latest develop branch without actually publishing artifacts.
+  - The release workflow explicitly calls the tests workflow with `test_selection: full`, so daily release validation keeps full non-testmon coverage.
 
 ### `tidy3d-python-client-update-lockfile.yml`
 

--- a/.github/workflows/tidy3d-python-client-release.yml
+++ b/.github/workflows/tidy3d-python-client-release.yml
@@ -426,6 +426,7 @@ jobs:
       version_match_tests: true
       extras_integration_tests: ${{ needs.determine-workflow-scope.outputs.run_extras_integration_tests == 'true' }}
       test_type: full
+      test_selection: full
     secrets: inherit # zizmor: ignore[secrets-inherit]
   
   compile-tests-results:

--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -36,6 +36,13 @@ on:
           - basic
           - full
         default: 'basic'
+      test_selection:
+        description: 'test-selection (testmon or full)'
+        type: choice
+        options:
+          - testmon
+          - full
+        default: 'testmon'
       release_tag:
         description: 'Release Tag (v2.10.0, v2.10.0rc1)'
         required: false
@@ -79,6 +86,11 @@ on:
         type: string
         required: false
         default: 'basic'
+      test_selection:
+        description: 'Test selection mode for local and remote tests (testmon or full)'
+        type: string
+        required: false
+        default: 'testmon'
       release_tag:
         description: 'Release Tag (v2.10.0, v2.10.0rc1)'
         required: false
@@ -121,6 +133,7 @@ jobs:
       version_match_tests: ${{ steps.determine-test-type.outputs.version_match_tests }}
       extras_integration_tests: ${{ steps.determine-test-type.outputs.extras_integration_tests }}
       test_type: ${{ steps.determine-test-type.outputs.test_type }}
+      test_selection: ${{ steps.determine-test-type.outputs.test_selection }}
     steps:
       - name: determine-test-type
         id: determine-test-type
@@ -136,6 +149,7 @@ jobs:
           INPUT_VERSION_MATCH: ${{ github.event.inputs.version_match_tests || inputs.version_match_tests }}
           INPUT_EXTRAS_INTEGRATION: ${{ github.event.inputs.extras_integration_tests || inputs.extras_integration_tests }}
           INPUT_TEST_TYPE: ${{ github.event.inputs.test_type || inputs.test_type }}
+          INPUT_TEST_SELECTION: ${{ github.event.inputs.test_selection || inputs.test_selection }}
         run: |
           echo "Event: $EVENT_NAME"
           echo "Draft: $DRAFT_STATE"
@@ -148,6 +162,7 @@ jobs:
           echo "Input version_match: $INPUT_VERSION_MATCH"
           echo "Input extras_integration: $INPUT_EXTRAS_INTEGRATION"
           echo "Input test_type: $INPUT_TEST_TYPE"
+          echo "Input test_selection: $INPUT_TEST_SELECTION"
 
           remote_tests=false
           local_tests=false
@@ -158,6 +173,7 @@ jobs:
           pr_review_tests=false
           extras_integration_tests=false
           test_type="basic"
+          test_selection="testmon"
           
             # Workflow_dispatch and workflow_call input override
           if [[ "$EVENT_NAME" == "workflow_dispatch" || "$EVENT_NAME" == "workflow_call" ]]; then
@@ -186,6 +202,10 @@ jobs:
             if [[ "$INPUT_EXTRAS_INTEGRATION" == "true" ]]; then
               extras_integration_tests=true
             fi
+
+            if [[ -n "$INPUT_TEST_SELECTION" ]]; then
+              test_selection="$INPUT_TEST_SELECTION"
+            fi
           fi
 
           # All PRs that have been triggered need local tests (remote reserved for merge queue/manual)
@@ -193,6 +213,7 @@ jobs:
               local_tests=true
               code_quality_tests=true
               pr_review_tests=true
+              test_selection="testmon"
           fi
 
           if [[ "$EVENT_NAME" == "merge_group" ]]; then
@@ -201,6 +222,7 @@ jobs:
               code_quality_tests=true
               extras_integration_tests=true
               test_type="basic"
+              test_selection="full"
           fi
 
           # Set test_type based on input or event
@@ -217,6 +239,7 @@ jobs:
           echo "pr_review_tests=$pr_review_tests" >> $GITHUB_OUTPUT
           echo "extras_integration_tests=$extras_integration_tests" >> $GITHUB_OUTPUT
           echo "test_type=$test_type" >> $GITHUB_OUTPUT
+          echo "test_selection=$test_selection" >> $GITHUB_OUTPUT
           echo "code_quality_tests=$code_quality_tests"
           echo "pr_review_tests=$pr_review_tests"
           echo "local_tests=$local_tests"
@@ -226,6 +249,7 @@ jobs:
           echo "version_match_tests=$version_match_tests"
           echo "extras_integration_tests=$extras_integration_tests"
           echo "test_type=$test_type"
+          echo "test_selection=$test_selection"
       
 
   move-type-imports:
@@ -639,6 +663,7 @@ jobs:
       PIP_ONLY_BINARY: gdstk
       MPLBACKEND: agg
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || inputs.release_tag }}
+      TEST_SELECTION: ${{ needs.determine-test-scope.outputs.test_selection }}
     permissions:
         pull-requests: write
     steps:
@@ -658,6 +683,47 @@ jobs:
         fetch-depth: 0
         submodules: false
         persist-credentials: false
+
+    - name: compute-testmon-cache-key
+      id: testmon-cache-key
+      if: needs.determine-test-scope.outputs.test_selection == 'testmon' || github.event_name == 'merge_group'
+      env:
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'develop' }}
+      run: |
+        default_branch="$DEFAULT_BRANCH"
+        case "$default_branch" in
+          ''|*[!A-Za-z0-9._/-]*)
+            echo "::warning::Invalid default branch '$default_branch'; using 'develop'."
+            default_branch="develop"
+            ;;
+        esac
+        default_branch_sha=$(git ls-remote --heads origin "refs/heads/${default_branch}" | awk '{print $1}')
+        if [[ -z "${default_branch_sha}" ]]; then
+          echo "::warning::Unable to resolve SHA for default branch '${default_branch}'."
+          default_branch_sha="unknown"
+        fi
+
+        dep_hash=$(
+          {
+            git show HEAD:pyproject.toml
+            git show HEAD:poetry.lock
+          } | sha256sum | awk '{print $1}'
+        )
+
+        echo "default_branch=$default_branch" >> "$GITHUB_OUTPUT"
+        echo "default_branch_sha=$default_branch_sha" >> "$GITHUB_OUTPUT"
+        echo "dep_hash=$dep_hash" >> "$GITHUB_OUTPUT"
+
+    - name: restore-testmon-cache
+      id: testmon-cache-restore
+      if: needs.determine-test-scope.outputs.test_selection == 'testmon' || github.event_name == 'merge_group'
+      uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+      with:
+        path: .testmondata
+        key: testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
+        restore-keys: |
+          testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch }}-
+          testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-
 
     - name: install-project
       env:
@@ -680,18 +746,42 @@ jobs:
         echo "Testing vtk is correctly installed."
         python -c "import vtk"
 
+    - name: determine-pytest-selection-flags
+      id: pytest-selection-flags
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+      run: |
+        if [[ "${TEST_SELECTION}" == "testmon" ]]; then
+          echo "flags=--testmon --testmon-forceselect" >> "$GITHUB_OUTPUT"
+          echo "Using pytest testmon selection mode."
+        elif [[ "${TEST_SELECTION}" == "full" && "${EVENT_NAME}" == "merge_group" ]]; then
+          echo "flags=--testmon-noselect" >> "$GITHUB_OUTPUT"
+          echo "Using full test execution with testmon collection mode."
+        else
+          echo "flags=--no-testmon" >> "$GITHUB_OUTPUT"
+          echo "Using full pytest execution mode."
+        fi
+
     - name: run-tests-coverage
       env:
         PYTHONUNBUFFERED: "1"
+        PYTEST_SELECTION_FLAGS: ${{ steps.pytest-selection-flags.outputs.flags }}
       run: |
         source ${GITHUB_WORKSPACE}/.venv/bin/activate
         # pytest --cov=tidy3d -rF --tb=short tests/_test_data/_test_datasets_no_vtk.py
-        pytest --cov=tidy3d -rF --tb=short tests
+        pytest ${PYTEST_SELECTION_FLAGS} --cov=tidy3d -rF --tb=short tests
         coverage report -m
         coverage xml -o ${GITHUB_WORKSPACE}/coverage.xml
         TOTAL_COVERAGE=$(coverage report --format=total)
         echo "total=$TOTAL_COVERAGE" >> "$GITHUB_ENV"
         echo "### Total coverage: ${TOTAL_COVERAGE}%"
+
+    - name: save-testmon-cache
+      if: success() && github.event_name == 'merge_group' && steps.testmon-cache-restore.outputs.cache-hit != 'true' && hashFiles('.testmondata') != ''
+      uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+      with:
+        path: .testmondata
+        key: testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
 
     - name: diff-coverage-report
       if: >- 
@@ -765,6 +855,7 @@ jobs:
       PIP_ONLY_BINARY: gdstk
       MPLBACKEND: agg
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || inputs.release_tag }}
+      TEST_SELECTION: ${{ needs.determine-test-scope.outputs.test_selection }}
 
     steps:
     - name: checkout-head
@@ -783,6 +874,47 @@ jobs:
         fetch-depth: 1
         submodules: false
         persist-credentials: false
+
+    - name: compute-testmon-cache-key
+      id: testmon-cache-key
+      if: needs.determine-test-scope.outputs.test_selection == 'testmon' || github.event_name == 'merge_group'
+      env:
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'develop' }}
+      run: |
+        default_branch="$DEFAULT_BRANCH"
+        case "$default_branch" in
+          ''|*[!A-Za-z0-9._/-]*)
+            echo "::warning::Invalid default branch '$default_branch'; using 'develop'."
+            default_branch="develop"
+            ;;
+        esac
+        default_branch_sha=$(git ls-remote --heads origin "refs/heads/${default_branch}" | awk '{print $1}')
+        if [[ -z "${default_branch_sha}" ]]; then
+          echo "::warning::Unable to resolve SHA for default branch '${default_branch}'."
+          default_branch_sha="unknown"
+        fi
+
+        dep_hash=$(
+          {
+            git show HEAD:pyproject.toml
+            git show HEAD:poetry.lock
+          } | sha256sum | awk '{print $1}'
+        )
+
+        echo "default_branch=$default_branch" >> "$GITHUB_OUTPUT"
+        echo "default_branch_sha=$default_branch_sha" >> "$GITHUB_OUTPUT"
+        echo "dep_hash=$dep_hash" >> "$GITHUB_OUTPUT"
+
+    - name: restore-testmon-cache
+      id: testmon-cache-restore
+      if: needs.determine-test-scope.outputs.test_selection == 'testmon' || github.event_name == 'merge_group'
+      uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+      with:
+        path: .testmondata
+        key: testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
+        restore-keys: |
+          testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch }}-
+          testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-
 
     - name: install-poetry
       uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # v1.4.1
@@ -846,20 +978,46 @@ jobs:
         poetry run pip install gdstk --only-binary gdstk
         poetry install -E dev
 
-    - name: run-doctests
+    - name: determine-pytest-selection-flags
+      id: pytest-selection-flags
+      env:
+        EVENT_NAME: ${{ github.event_name }}
       run: |
-        poetry run pytest -rF --tb=short tidy3d
+        if [[ "${TEST_SELECTION}" == "testmon" ]]; then
+          echo "flags=--testmon --testmon-forceselect" >> "$GITHUB_OUTPUT"
+          echo "Using pytest testmon selection mode."
+        elif [[ "${TEST_SELECTION}" == "full" && "${EVENT_NAME}" == "merge_group" ]]; then
+          echo "flags=--testmon-noselect" >> "$GITHUB_OUTPUT"
+          echo "Using full test execution with testmon collection mode."
+        else
+          echo "flags=--no-testmon" >> "$GITHUB_OUTPUT"
+          echo "Using full pytest execution mode."
+        fi
+
+    - name: run-doctests
+      env:
+        PYTEST_SELECTION_FLAGS: ${{ steps.pytest-selection-flags.outputs.flags }}
+      run: |
+        poetry run pytest ${PYTEST_SELECTION_FLAGS} -rF --tb=short tidy3d
 
     - name: run-tests-coverage
       env:
         PYTHONUNBUFFERED: "1"
+        PYTEST_SELECTION_FLAGS: ${{ steps.pytest-selection-flags.outputs.flags }}
       run: |
-        poetry run pytest --cov=tidy3d -rF --tb=short tests/_test_data/_test_datasets_no_vtk.py
-        poetry run pytest --cov=tidy3d -rF --tb=short tests
+        poetry run pytest ${PYTEST_SELECTION_FLAGS} --cov=tidy3d -rF --tb=short tests/_test_data/_test_datasets_no_vtk.py
+        poetry run pytest ${PYTEST_SELECTION_FLAGS} --cov=tidy3d -rF --tb=short tests
         poetry run coverage report -m
         TOTAL_COVERAGE=$(poetry run coverage report --format=total)
         echo "total=$TOTAL_COVERAGE" >> "$GITHUB_ENV"
         echo "### Total coverage: ${TOTAL_COVERAGE}%"
+
+    - name: save-testmon-cache
+      if: success() && github.event_name == 'merge_group' && steps.testmon-cache-restore.outputs.cache-hit != 'true' && hashFiles('.testmondata') != ''
+      uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+      with:
+        path: .testmondata
+        key: testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
 
     - name: create-badge
       if: ${{ github.ref == 'refs/heads/develop' }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1505,7 +1505,7 @@ jax = ">=0.8.1"
 msgpack = "*"
 numpy = [
     {version = ">=1.26.0,<2.4.0", markers = "python_version >= \"3.12\""},
-    {version = ">=1.23.2,<2.4.0", markers = "python_version >= \"3.11\""},
+    {version = ">=1.23.2,<2.4.0", markers = "python_version == \"3.11\""},
 ]
 optax = "*"
 orbax-checkpoint = "*"
@@ -2280,7 +2280,7 @@ description = "Type annotations and runtime checking for shape and dtype of JAX/
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"docs\" or python_version >= \"3.11\""
+markers = "python_version >= \"3.11\" or extra == \"dev\" or extra == \"docs\""
 files = [
     {file = "jaxtyping-0.3.7-py3-none-any.whl", hash = "sha256:303ab8599edf412eeb40bf06c863e3168fa186cf0e7334703fa741ddd7046e66"},
     {file = "jaxtyping-0.3.7.tar.gz", hash = "sha256:3bd7d9beb7d3cb01a89f93f90581c6f4fff3e5c5dc3c9307e8f8687a040d10c4"},
@@ -3331,10 +3331,10 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.21.2", markers = "python_version >= \"3.10\""},
     {version = ">=2.1.0", markers = "python_version >= \"3.13\""},
     {version = ">=1.26.0", markers = "python_version == \"3.12\""},
     {version = ">=1.23.3", markers = "python_version >= \"3.11\""},
+    {version = ">=1.21.2", markers = "python_version >= \"3.10\""},
 ]
 
 [package.extras]
@@ -3493,7 +3493,7 @@ description = "Type system extensions for programs checked with the mypy type ch
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"docs\" or python_version >= \"3.11\""
+markers = "python_version >= \"3.11\" or extra == \"dev\" or extra == \"docs\""
 files = [
     {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
     {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
@@ -4425,9 +4425,9 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -5115,9 +5115,9 @@ files = [
 astroid = ">=4.0.2,<=4.1.dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
-    {version = ">=0.2", markers = "python_version < \"3.11\""},
     {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
-    {version = ">=0.3.6", markers = "python_version == \"3.11\""},
+    {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
+    {version = ">=0.2", markers = "python_version < \"3.11\""},
 ]
 isort = ">=5,<5.13 || >5.13,<8"
 mccabe = ">=0.6,<0.8"
@@ -5267,6 +5267,23 @@ tomli = {version = ">=2.2.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["covdefaults (>=2.3)", "coverage (>=7.10.7)", "pytest-mock (>=3.15.1)"]
+
+[[package]]
+name = "pytest-testmon"
+version = "2.2.0"
+description = "selects tests affected by changed files and methods"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"dev\" or extra == \"tests\""
+files = [
+    {file = "pytest_testmon-2.2.0-py3-none-any.whl", hash = "sha256:2604ca44a54d61a2e830d9ce828b41a837075e4ebc1f81b148add8e90d34815b"},
+    {file = "pytest_testmon-2.2.0.tar.gz", hash = "sha256:01f488e955ed0e0049777bee598bf1f647dd524e06f544c31a24e68f8d775a51"},
+]
+
+[package.dependencies]
+coverage = ">=6,<8"
+pytest = ">=5,<10"
 
 [[package]]
 name = "pytest-timeout"
@@ -6338,7 +6355,7 @@ description = "Easily download, build, install, upgrade, and uninstall Python pa
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"dev\" or extra == \"docs\" or python_version >= \"3.12\") and (sys_platform == \"darwin\" or extra == \"dev\" or extra == \"docs\" or extra == \"pytorch\") and (python_version >= \"3.12\" or extra == \"dev\" or extra == \"docs\" or extra == \"pytorch\") and (extra == \"dev\" or extra == \"pytorch\" or extra == \"docs\")"
+markers = "python_version >= \"3.12\" and (extra == \"dev\" or extra == \"pytorch\" or extra == \"docs\") or (extra == \"dev\" or extra == \"docs\") and (extra == \"dev\" or extra == \"docs\" or extra == \"pytorch\")"
 files = [
     {file = "setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173"},
     {file = "setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70"},
@@ -7162,59 +7179,59 @@ python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"extras\""
 files = [
-    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:3475dce4940a65d208742a9d4b537bd231716431f83b2bd0f87df2d5f8a79cd1"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:32002b4272c33aa758c04cd9f5b0dc036fda3c8561a201ed19966af8cea64dbc"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96b5c6d5665b1e619c6d7082310626356775309146a269cd3cfa31c2a5d41854"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30fcd7190b523f17af329be278d37621c4be25f0d8385f9389b9c9b3d8c94997"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c4eb7f346ccea81078071fded1025371b756383495b40baf77c6de92e34721c"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:55a15090ea4adc7857d41f8ebbdb26085888dc68d98d4fa10f29acf13be1251d"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:913d212ea02eeb03f4a89ca0ce7f5a180f150a8aabac780f3880a02b06b38533"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6b39b69a8b388a430807edb7c06be735aaa6bf234368a6c4c4160ba94e6cff87"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b561aacc5692c1c3bdb54ef10463b10415e794045a36f6f60c8f3037c78f6207"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:86cadf21c999ac434e8de34f76cb29d4ad6c730c71a5d16f498a9b9ba124732e"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-win_amd64.whl", hash = "sha256:2e5f363b07cf114d17182e49f1dc208c6f9e3a94e1de56868c4fd2ecf785b05c"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:3677b0d6353ea0cb686d52a71ffc24a41d728da8a1a8a42daf74d285d6bbd5bc"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:85a6d09fcf9fa1263850b2211f66b3d4d1cce05af12c9b6f7f4a77c50c30f274"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c37f77db69a782067d1e1d3d1d6c726f6e97094aadc31ece833bcab08a04024c"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:76a4f47242c25b3c285479b3f90f6c1ef47aabb7c9f425f52a5fdb7254a154a0"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c03888eba50ecd835c8f813643190513dcf11eeac1e650521d39a35085e567f"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:73e0c64603d3e1fae979248da4997a38cac0faf7653e4b615f6200d56aee6d6d"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:6122f13035d33821ddac0c025ca71c7d52a779a4ae6d3d3f2a314ad1f605976d"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cdd21507804830ce25bef7968b5cd0bf2e65aad01c232ede5ef7d5b8a5b1a8c7"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:63d199a29f292579c15d7efcc9baac5b9406a527edf17f71984b349b6b326509"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1349322900e1115338f13b986a8909fd1483c4f8fa98468db057eafcf3632e87"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-win_amd64.whl", hash = "sha256:ce830399ebc2a3df2bac7362cc9639986b11142c0228dfb608c2ab2a344db771"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:8c5021bee5f8fd4305f30e804c6a5cb09321516edc6be0f25ff63bfb2cad72c4"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:09c4086302f1f7fe51e3fd1d2b0b2b8c4acf824a61de5800de154693416ee9ea"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:af19e4c1e9e07bf90d9c0670d7dec4fec834f49c5edf7abb36510cfbccad50da"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a3ea803b1c5bf54c19be1d131bb7f8c14a5cf902330f781afd1e58281b63ce47"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bd89c068d35a06176af30b3c06af677edaa9cb835c05cc4280fa7bf19cde016"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8a2564989050917c5ab49af720768320feffd3176a8a0a0f969e501c42fbafe3"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:e014103e5ca4df176a3887c1c38cbde988f350285365eb714f261d397aa4f2c3"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5575aefca7f4035232005d28d4aeb3104b3e58a20cd414dc1568c0a4629e384e"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dbdf92ede96d40d29710858a2c414f752d40170561634db00cb37ad7f58eb4fb"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d72acf47f200ce318d97ea35d947478b8d73984231072d5a917c20171a32455a"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-win_amd64.whl", hash = "sha256:eb04503782a3473e2f32385b06d8e5a9cda8eec7d9f0cf31b14e2e56c093f8ec"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:b2592c5707def848d191ce44bfb87b3b7eca398b261145cb0431cd799cbfdcff"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:8854b6c5e9e215eece55779400be8a206d667cff625456d2bc35d63413eb085c"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed826f8c6c81d68dccd6a1da8767bc2c475d9c4d0979652bca2782c68187a1cf"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43278730625afa8e286c04568b7cc327db3185258ff6e925028fdc1e272853a9"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4db614f4927b9fc01d0f5e68d469b9cc7049acfbae05281b0163f772077a763"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:3574d34299f4e33c8eefbaf2176a5fcff5ccaa342855ca9c5f253af1600fe075"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8b362005e89236c16a71daba557a5330766c0d638f843f3b3cab9ce485bc57a1"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0a9c5c0aa96cfdecea360cb380bc6f30104e09507338258d7145c72b0a2adddf"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c2e9d10c8f8883adc2791c2dc22b2594d1999536ed5f93907aa7a45089a737e1"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cbdab7ea44593577e271b1522c3b784b615fa2ca5027d20ce5eecdf818691715"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-win_amd64.whl", hash = "sha256:e051a39bb2dfdb0613cd8cca1d835036f5cd72adb82bc4d2534a9a9e3d51f9ec"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:f2f1253d0c1a811de1dfd2be427ae26b81416bd638ec3daae578caf1ddb96348"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1425a55d79caadd7293826989748251ccf788b1b30980c184461945688cd5095"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e925bb470515b70ce7ea5ea341b73bafb93f3d4291c4f0417c98a307cbecd99e"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:914f683958e9f60412fcafcbfa2f30f22f7c74a696d3bacc24b715f7840a3c71"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:5412d58a4bc9b74444f40cd5016a060a185ddd28742b65adda6f38499333021f"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:aa75eb89963b928b238c94bad515d5241fe7a7f74fa56539207ea51bc0873424"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a4d75b7cc3954b2f6cae55a4b42f70e5c72f6b42dc2117c301f4469629c0fbb2"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:5e6e562862f1bbd2b3be88b2202af2c042638846f04e5a5f6229e9e5519c4cf5"},
-    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a66596009186f0140279ea675a8ae29aa105fa96cefa8f7df38a5c21302fdf33"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:e5024a655beeac186f7987f35019a7a97048e53e027c3aa148babbd885c00cf8"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:99df649d025ab44234fa29521e876796a6506a1483147a6d7f18475b25fb0573"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78732051cbf901583e21637a07729caaccb8649954093576c5cf8989bbe6c778"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c0f5d0d9631185938272b84603291c49817ebbee89027513b562ec3128e72db7"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7982cc5ca7d88c7e77de7b89363251c301a7f6ad037971aed7d2ae5db5f951"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:8185cddc7721e7a5650018cd77467a75ba89c9608b976f045ef9ef0f03895c06"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6a700f737b2ff3f0e84fb547ef3222dd06554a62ef6b48f96f8bdc7e76c61f53"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b41cf923d0c620168ba7e03049e10792d8b77d01ff92cc41ea49c694f62e8e43"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:8dba487e7028111c7ae38df2d148516ed465fe8585bba3301e0ac9ec1dc0b250"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9370dd1407042de03b90e87cc066da910c7f59603b3752eedf70842b26a8d42e"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp310-cp310-win_amd64.whl", hash = "sha256:94152fc55e0c14c3d0f8c15d19dae484e348d02faa50ce1da071e8e15b64a7ff"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:103ffc31a66c469964c8dfe2a101b7b025d2dd9d0352f8922c5a878a0e621aeb"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:feb6cf83d505f3182cc6d1a82fa80bc0291bc0d2eddfeaab2c1ff4006a6f8e34"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7399dd63c8cce25031bb3c5d6ce938ea36a7e8930251b96e78c75a57c7f44ac4"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:376434c02ae7534a5f58bdcc006cf85acd6fb74fee59aeff0a879d2600290b3e"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77e896e24f06bf2916583a7398d55ded1cfb7cb4d77d10d24859c245b994e8e6"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:56b0ca4134a4433be48c3d8d34d20f658e3092b5f0e8ddf8506ea319f27d9a8f"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:224168561185b507d6baffff44715f0c2ed5cdbb2c14152d7e4c57f0db96b66b"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:313b472f41f3170bfc0403a8b2c8275d5ae1b7b8b5b52105e0bace349f161ea1"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:dd122c4d8c94ef14f3e4aeb92f1ed2ac1a2500caa4ee3cc798434c3b7cfa738c"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bcaf9c88925886b454bda130c952462550dbc40de704d1793fd17ebc120f1055"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp311-cp311-win_amd64.whl", hash = "sha256:b9c37fdd305215520f2e2a0b21c2201a63c42ae5864cab58b4ef3a143103a956"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e373d0445b0df74d62ca6891a413a51cf5beff0029c22a6cd6d8c3695ddf536b"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:c0202779511a3005a2f6c213535af804a662b39966ff70ebb4c7f9e7fcc12ed3"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b36c112feff05ebca70d155e8ae5b69bc1b4034a5f642f68b8503a00a762470"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9e2060303318ea8ac13bf8a662f3fcf757f6522935035b26bbd79e9d2d5ffd5f"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba831832142c9326faef08c6595d0c1ccfe88eea42de0c0a0ee9489b5f819a7a"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f20c0c035f99b306baba7b520d94b066d767ea3545b5687babc1ce5368178493"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:08c5c415687c698b56833eae01e185d1a1acbca8b49719a8c556d222f84d6978"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5a8ad64d4ccf5a167614cca070e084e441864779cd502b48727ecb4dd0976da4"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:224b541e4c41c6c16ae65b34638518ffc3896ac6a2b43f5562a29f2180fc209b"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:42359f318084946912b6854b6a8717b1b1eed9ed5bf95a869c060d4b66f7681b"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp312-cp312-win_amd64.whl", hash = "sha256:61379b9ccc3af3039b3b8a748909ba2ecfa7bcf23bd308a84bb76377d0cb2d82"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:6f3db24893329c466ab92864f88da88733ea3be50d26e9585ce04bef1b6d3ca8"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:dc35246312721b39ce908c213333b5928b7dd344517208d305d11d18e17ef83d"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade4d40484d4ed8b1a5b8a3d13510a7c4add89239123c613d26669515e3c7959"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:936ca3dd4f4d1dd81ec0104293a9705ebbd11e07472ecd46a3d57b78b6f7cf9c"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3bb82304b5285e13f3a6ec1605551b7478f176d421cbe538facc079bf5035471"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a1fb6a8761dd05c2a348a784bcb05bfe5e93cfb6100031fce4dc9e17c20b743d"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3f56819df0800da1270990854eb25773e90720af4fab3257f8aa45ab3121c3d2"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8a099b83fb854c650168bd5710daba8dcc1e447cb5326ddd0a0012be14b18839"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:129e53adbde1dd4d198126d3a226b5d98a590b49e72f4d345f93b389f7e7ff7d"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2875d553751850947e4205dcb98524cbb1b9258d69e3157302226ab8f21b5f02"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp313-cp313-win_amd64.whl", hash = "sha256:1980a604a0c2a8e6c2abc3ce2a39d6818d2cde7675d5fdbd6769f3b61a59486f"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:360e4307ad79b96a54771aef54536ea305f5d818a073b331cf17fa86b300060a"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c56a1a737d10ce757ab0ef178d79ff2e5bf402318f02e30ecf6f6613dc5064ff"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:850fff0c26a410f5b4966e49909a324eaba5a1bd887631067fe364fbc9a5e9d6"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8c9ad9629140da9f5722ceb326f588dbc44d32ddbc0b82156cd21b4ced12bf0"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:c1735856a69221f227384311ec6ca1e7f24871d136cc7c1cbceaf4a1f124987e"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:c9ee1a424d185e300f59094ecf77931f6a74e90f2ace028e13f483ff7965a0ea"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:afe3fd75df3aa1f4fdb37c01810b47ce69962553248464fd23c9ebc2328ff37a"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:ee16b6ea784663b6e7766a531651f264eedd56db84bb449e6fdd868568314956"},
+    {file = "tidy3d_extras-2.11.0.dev0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c36f4f59af0975a1fa23b5da2abc5644e34afabec8cc77e549c206a2f139f9b7"},
 ]
 
 [package.dependencies]
@@ -7826,7 +7843,7 @@ description = "A Wadler–Lindig pretty-printer for Python."
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"docs\" or python_version >= \"3.11\""
+markers = "python_version >= \"3.11\" or extra == \"dev\" or extra == \"docs\""
 files = [
     {file = "wadler_lindig-0.1.7-py3-none-any.whl", hash = "sha256:e3ec83835570fd0a9509f969162aeb9c65618f998b1f42918cfc8d45122fe953"},
     {file = "wadler_lindig-0.1.7.tar.gz", hash = "sha256:81d14d3fe77d441acf3ebd7f4aefac20c74128bf460e84b512806dccf7b2cd55"},
@@ -8004,7 +8021,7 @@ files = [
 
 [extras]
 design = ["bayesian-optimization", "pygad", "pyswarms"]
-dev = ["bayesian-optimization", "cma", "coverage", "diff-cover", "dill", "gdstk", "grcwa", "ipython", "ipython", "jinja2", "jupyter", "memory_profiler", "mypy", "myst-parser", "nbconvert", "nbdime", "nbsphinx", "networkx", "openpyxl", "optax", "pre-commit", "psutil", "pydata-sphinx-theme", "pygad", "pylint", "pyswarms", "pytest", "pytest-cov", "pytest-env", "pytest-timeout", "pytest-xdist", "rtree", "ruff", "sax", "scikit-rf", "signac", "sphinx", "sphinx-book-theme", "sphinx-copybutton", "sphinx-design", "sphinx-favicon", "sphinx-notfound-page", "sphinx-sitemap", "sphinx-tabs", "sphinxemoji", "tmm", "torch", "torch", "tox", "trimesh", "vtk", "zizmor"]
+dev = ["bayesian-optimization", "cma", "coverage", "diff-cover", "dill", "gdstk", "grcwa", "ipython", "ipython", "jinja2", "jupyter", "memory_profiler", "mypy", "myst-parser", "nbconvert", "nbdime", "nbsphinx", "networkx", "openpyxl", "optax", "pre-commit", "psutil", "pydata-sphinx-theme", "pygad", "pylint", "pyswarms", "pytest", "pytest-cov", "pytest-env", "pytest-testmon", "pytest-timeout", "pytest-xdist", "rtree", "ruff", "sax", "scikit-rf", "signac", "sphinx", "sphinx-book-theme", "sphinx-copybutton", "sphinx-design", "sphinx-favicon", "sphinx-notfound-page", "sphinx-sitemap", "sphinx-tabs", "sphinxemoji", "tmm", "torch", "torch", "tox", "trimesh", "vtk", "zizmor"]
 docs = ["cma", "gdstk", "grcwa", "ipython", "jinja2", "jupyter", "myst-parser", "nbconvert", "nbdime", "nbsphinx", "openpyxl", "optax", "pydata-sphinx-theme", "pylint", "sax", "signac", "sphinx", "sphinx-book-theme", "sphinx-copybutton", "sphinx-design", "sphinx-favicon", "sphinx-notfound-page", "sphinx-sitemap", "sphinx-tabs", "sphinxemoji", "tmm"]
 extras = ["tidy3d-extras"]
 gdstk = ["gdstk"]
@@ -8012,11 +8029,11 @@ heatcharge = ["trimesh", "vtk"]
 pytorch = ["torch", "torch"]
 ruff = ["ruff"]
 scikit-rf = ["scikit-rf"]
-tests = ["pre-commit", "psutil", "pylint", "pytest", "pytest-cov", "pytest-env", "pytest-timeout", "pytest-xdist", "trimesh"]
+tests = ["pre-commit", "psutil", "pylint", "pytest", "pytest-cov", "pytest-env", "pytest-testmon", "pytest-timeout", "pytest-xdist", "trimesh"]
 trimesh = ["networkx", "rtree", "trimesh"]
 vtk = ["vtk"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "d40911527adee41086854bc401746fa174adfa7dd6dc607a9ced1647a29b1aea"
+content-hash = "e66fa832054926b574dd96a3bfdb0f485475803696cd9acb3c7fad3f3a0937d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ pytest-timeout = { version = "^2.4.0", optional = true }
 pytest-xdist = "^3.6.1"
 pytest-cov = "^6.0.0"
 pytest-env = "^1.1.5"
+pytest-testmon = { version = "^2.1.3", optional = true }
 tox = { version = "^4.33.0", optional = true }
 diff-cover = { version = "^10.1.0", optional = true }
 zizmor = { version = "^1.20.0", optional = true }
@@ -155,6 +156,7 @@ dev = [
   'pytest-xdist',
   'pytest-env',
   'pytest-cov',
+  'pytest-testmon',
   'rtree',
   'ruff',
   'sax',
@@ -188,6 +190,7 @@ tests = [
   'pytest-xdist',
   'pytest-env',
   'pytest-cov',
+  'pytest-testmon',
   'trimesh'
 ]
 docs = [

--- a/tests/test_web/test_webapi_mode.py
+++ b/tests/test_web/test_webapi_mode.py
@@ -423,12 +423,12 @@ def test_batch(mock_webapi, mock_job_status, tmp_path, monkeypatch, unique_proje
 
 
 @responses.activate
-def test_async(mock_webapi, mock_job_status, monkeypatch, tmp_path):
+def test_async(mock_webapi, mock_job_status, monkeypatch, tmp_path, unique_project_name):
     # monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
     monkeypatch.setattr(f"{api_path}.load", lambda *args, **kwargs: True)
 
     sims = {TASK_NAME: make_mode_sim()}
-    _ = run_async(sims, folder_name=PROJECT_NAME, path_dir=str(tmp_path))
+    _ = run_async(sims, folder_name=unique_project_name, path_dir=str(tmp_path))
 
 
 @responses.activate

--- a/tests/test_web/test_webapi_mode_sim.py
+++ b/tests/test_web/test_webapi_mode_sim.py
@@ -417,7 +417,7 @@ def test_batch(mock_webapi, mock_job_status, tmp_path, unique_project_name):
 
 
 @responses.activate
-def test_async(mock_webapi, mock_job_status, tmp_path):
+def test_async(mock_webapi, mock_job_status, tmp_path, unique_project_name):
     # monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
     sims = {TASK_NAME: make_mode_sim()}
-    _ = run_async(sims, folder_name=PROJECT_NAME, path_dir=str(tmp_path))
+    _ = run_async(sims, folder_name=unique_project_name, path_dir=str(tmp_path))


### PR DESCRIPTION
## Summary
- add CI `test_selection` input (`testmon|full`) to `tidy3d-python-client-tests.yml`
- default PR/manual CI to testmon, force `merge_group` to full
- add `.testmondata` cache restore/save in local and remote CI jobs with scoped keys
- force release/daily path to full by passing `test_selection: full` from release workflow
- document workflow behavior and manual full-run trigger in workflow README
- fix async webapi test flake by using unique project names in mode/mode_sim async tests

## Why
Roll out pytest-testmon in CI while keeping full-suite safety coverage for merge queue and release/daily flows.

## Checks Run
- `poetry run pre-commit run --files .github/workflows/tidy3d-python-client-tests.yml .github/workflows/tidy3d-python-client-release.yml .github/workflows/README.md tests/test_web/test_webapi_mode.py tests/test_web/test_webapi_mode_sim.py`
- `poetry run pytest -q tests/test_web/test_webapi_mode.py::test_async tests/test_web/test_webapi_mode_sim.py::test_async -n 4 --dist worksteal --no-testmon`
- `poetry run pytest -q tests/test_web/test_webapi_mode.py::test_async tests/test_web/test_webapi_mode_sim.py::test_async -n 4 --dist worksteal --testmon --testmon-forceselect`

## Notes
- numerical tests remain excluded by existing pytest markers in `pyproject.toml`.
- docs updated: `.github/workflows/README.md`.
- no schema assets changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to changes in CI test execution semantics and caching; misconfiguration could skip tests or cause inconsistent cache behavior across branches/runners.
> 
> **Overview**
> Adds a `test_selection` input to `tidy3d-python-client-tests.yml` to switch local/remote pytest runs between *testmon-selected* execution and full runs, defaulting PR/manual runs to `testmon` and forcing `merge_group` to `full` (with `--testmon-noselect` collection to refresh selection data).
> 
> Implements `.testmondata` cache restore/save for both local and remote jobs using keys scoped by runner, Python version, dependency hash, and default-branch SHA; updates the release workflow to always pass `test_selection: full`, documents the behavior in `.github/workflows/README.md`, and fixes async web API test flakes by using unique project names in mode/mode-sim async tests. Also adds `pytest-testmon` to optional dev/tests dependencies (lockfile updated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d43333c8f4815733a01aabc0de6ac042207d11c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->