### PR TITLE
FXC-5441: speed up monitor postprocessing and improve capacitance accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added warning in `LayerRefinementSpec` when `dl_min_from_gaps` (derived from automatic gap refinement) is very small relative to the lateral grid size for identifying cases where excessive grid refinement may occur due to very small detected gaps.
 - Added `custom_vjp` and new custom run functions that provide hooks into adjoint for custom gradient calculations.
 - Changed default `num_points` in `EMEModeSpec.interp_spec` from 3 to 5 for improved accuracy of frequency interpolation.
+- Unstructured data plots are now "crinkled", showing the full mesh elements that cover given monitor boundaries. Previously, the mesh elements were "clipped" to the monitor boundaries.
 
 ### Fixed
 - Fixed intermittent "API key not found" errors in parallel job launches by making configuration directory detection race-safe.

--- a/tests/test_components/test_heat.py
+++ b/tests/test_components/test_heat.py
@@ -662,24 +662,35 @@ def test_sim_version_update():
 
 @pytest.mark.parametrize("zero_dim_axis", [None, 0, 2])
 def test_symmetry_expanded(zero_dim_axis):
+    # Test symmetry expansion with mesh that conforms to symmetry axis but not monitor bounds.
+    # The mesh boundary is at the symmetry center, so after expansion there are no duplicate
+    # cells at the join. But the expanded data may extend beyond the monitor, requiring clipping.
+    # sel_inside keeps boundary cells, so final bounds may slightly exceed monitor bounds.
     symmetry_center = [2, 0.5, 0]
     symmetry = [1, 1, 1]
 
     lens = [1, 2, 2]
-    num_points = [7, 4, 11]
+    num_points = [7, 5, 11]
 
     if zero_dim_axis is not None:
         lens[zero_dim_axis] = 0
         num_points[zero_dim_axis] = 1
 
-    mnt_span_x = [1 - lens[0], 1]
-    mnt_span_y = [-lens[1] / 2, lens[1] / 2]
-    mnt_span_z = [1, 1 + lens[2]]
+    # Monitor is smaller than the expanded data, requiring clipping
+    # For x: data [3, 4] mirrors around x=2 to [0, 1], monitor = [0, 1] (exact match)
+    # For y: data [0.5, 2.5] expands around y=0.5 to [-1.5, 2.5], monitor = [-1, 1] (needs clipping)
+    # For z: no expansion needed (monitor doesn't extend into mirror region)
+    mnt_span_x = [1 - lens[0], 1]  # [0, 1] for lens[0]=1
+    mnt_span_y = [-lens[1] / 2, lens[1] / 2]  # [-1, 1] for lens[1]=2
+    mnt_span_z = [1, 1 + lens[2]]  # [1, 3] for lens[2]=2
 
-    # symmetric around symmetry_center
-    data_span_x = [3, 3 + lens[0]]
-    data_span_y = [0.5, 0.5 + lens[1]]
-    data_span_z = [1, 1 + lens[2]]
+    # Data with mesh boundary at symmetry center (conforms to symmetry axis)
+    # - x: reflection_only mirrors [3, 4] to [0, 1]
+    # - y: data starts at symmetry center, expands to cover both sides
+    # - z: no expansion needed
+    data_span_x = [3, 3 + lens[0]]  # [3, 4] → [0, 1] via reflection_only
+    data_span_y = [symmetry_center[1], symmetry_center[1] + lens[1]]  # [0.5, 2.5] → [-1.5, 2.5]
+    data_span_z = [1, 1 + lens[2]]  # [1, 3] stays as is
 
     mnt_bounds = np.array(list(zip(mnt_span_x, mnt_span_y, mnt_span_z)))
     mnt_size = tuple(mnt_bounds[1] - mnt_bounds[0])
@@ -719,10 +730,9 @@ def test_symmetry_expanded(zero_dim_axis):
     data_expanded_cart = mnt_data_cart_expanded.temperature
     data_expanded_ugrid = mnt_data_ugrid_expanded.temperature
 
-    # print(data_expanded_ugrid.bounds)
-    # print(mnt_bounds)
-
-    assert np.all(data_expanded_ugrid.bounds == mnt_bounds)
+    # Unstructured data uses sel_inside for clipping, which keeps boundary cells.
+    # So the final bounds may extend slightly beyond monitor bounds, but must cover them.
+    assert data_expanded_ugrid.does_cover(mnt_bounds)
     assert data_expanded_cart.does_cover(mnt_bounds)
 
 

--- a/tidy3d/components/data/unstructured/base.py
+++ b/tidy3d/components/data/unstructured/base.py
@@ -729,6 +729,9 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
                     f" of grid points ({num_points})."
                 )
 
+            # copy=True is required because vtk_to_numpy may return a view into VTK's
+            # internal memory buffer, which can be invalidated when the VTK object is
+            # modified or garbage collected, causing data corruption.
             values_numpy = np.array(vtk["vtk_to_numpy"](array_vtk), copy=True)
             values_name = array_vtk.GetName()
 

--- a/tidy3d/components/tcad/data/monitor_data/abstract.py
+++ b/tidy3d/components/tcad/data/monitor_data/abstract.py
@@ -130,7 +130,7 @@ class HeatChargeMonitorData(AbstractMonitorData, ABC):
             if isinstance(new_property, SpatialDataArray):
                 new_property = new_property.sel_inside(clip_bounds)
             else:
-                new_property = new_property.box_clip(bounds=clip_bounds)
+                new_property = new_property.sel_inside(bounds=clip_bounds)
 
         return new_property
 

--- a/tidy3d/components/tcad/data/sim_data.py
+++ b/tidy3d/components/tcad/data/sim_data.py
@@ -45,6 +45,44 @@ if TYPE_CHECKING:
     from tidy3d.components.types import Ax, RealFieldVal
 
 
+def _compute_monitor_axis_limits(
+    monitor: Any,
+    sim_bounds: tuple,
+    field_data_bounds: tuple,
+    axis: int,
+) -> tuple[list[float], list[float]]:
+    """Compute axis limits from monitor extent clipped to simulation domain.
+
+    Parameters
+    ----------
+    monitor : Monitor
+        The monitor whose bounds are used for axis limits.
+    sim_bounds : tuple
+        The simulation domain bounds ((xmin, ymin, zmin), (xmax, ymax, zmax)).
+    field_data_bounds : tuple
+        The field data bounds to use as fallback for zero-size dimensions.
+    axis : int
+        The normal axis to exclude from the returned limits.
+
+    Returns
+    -------
+    tuple
+        (ax_min, ax_max) each as a 2-element list for the two tangential axes.
+    """
+    ax_min: list[float] = []
+    ax_max: list[float] = []
+    for d in range(3):
+        if monitor.size[d] > 0:
+            ax_min.append(max(monitor.center[d] - monitor.size[d] / 2, sim_bounds[0][d]))
+            ax_max.append(min(monitor.center[d] + monitor.size[d] / 2, sim_bounds[1][d]))
+        else:
+            ax_min.append(field_data_bounds[0][d])
+            ax_max.append(field_data_bounds[1][d])
+    ax_min.pop(axis)
+    ax_max.pop(axis)
+    return ax_min, ax_max
+
+
 class DeviceCharacteristics(Tidy3dBaseModel):
     """Stores device characteristics. For example, in steady-state it stores
     the steady DC capacitance (provided an array of voltages has been defined
@@ -194,12 +232,17 @@ class AbstractHeatChargeSimulationData(AbstractSimulationData, ABC):
         axis = field_data.normal_axis
         position = field_data.normal_pos
 
-        # compute plot bounds
+        # compute plot bounds from field data for structures
         field_data_bounds = field_data.bounds
         min_bounds = list(field_data_bounds[0])
         max_bounds = list(field_data_bounds[1])
         min_bounds.pop(axis)
         max_bounds.pop(axis)
+
+        # compute axis limits from monitor extent (clipped to simulation domain)
+        ax_min, ax_max = _compute_monitor_axis_limits(
+            monitor_data.monitor, self.simulation.bounds, field_data_bounds, axis
+        )
 
         # select the cross section data
         interp_kwarg = {"xyz"[axis]: position}
@@ -212,12 +255,13 @@ class AbstractHeatChargeSimulationData(AbstractSimulationData, ABC):
             **interp_kwarg,
         )
 
-        # only then overlay the mesh plot
-        field_data.plot(ax=ax, cmap=False, field=False, grid=True)
+        # set axis limits to monitor bounds and disable autoscaling
+        ax.set_xlim(ax_min[0], ax_max[0])
+        ax.set_ylim(ax_min[1], ax_max[1])
+        ax.autoscale(False)
 
-        # set the limits based on the xarray coordinates min and max
-        ax.set_xlim(min_bounds[0], max_bounds[0])
-        ax.set_ylim(min_bounds[1], max_bounds[1])
+        # overlay the mesh plot (will be clipped to the set limits)
+        field_data.plot(ax=ax, cmap=False, field=False, grid=True)
 
         return ax
 
@@ -385,12 +429,13 @@ class HeatChargeSimulationData(AbstractHeatChargeSimulationData):
             axis = field_data.normal_axis
             position = field_data.normal_pos
 
-            # compute plot bounds
+            # compute axis limits from monitor extent (clipped to simulation domain)
             field_data_bounds = field_data.bounds
-            min_bounds = list(field_data_bounds[0])
-            max_bounds = list(field_data_bounds[1])
-            min_bounds.pop(axis)
-            max_bounds.pop(axis)
+            ax_min, ax_max = _compute_monitor_axis_limits(
+                monitor_data.monitor, self.simulation.bounds, field_data_bounds, axis
+            )
+            min_bounds = tuple(ax_min)
+            max_bounds = tuple(ax_max)
 
         if isinstance(field_data, SpatialDataArray):
             # interp out any monitor.size==0 dimensions


### PR DESCRIPTION
- Unstructured plotting to use monitor rather than data bounds
- Switch box_clip to sel in symmetry expansion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes unstructured dataset postprocessing (symmetry expansion clipping and VTK-to-numpy conversion) and TCAD plotting bounds, which could subtly affect returned bounds/visualizations and memory usage.
> 
> **Overview**
> **Improves unstructured TCAD monitor postprocessing and plotting.** Symmetry expansion now clips unstructured datasets using `sel_inside()` (instead of `box_clip()`), preserving boundary cells and avoiding over-clipping; tests were updated to assert coverage rather than exact bounds.
> 
> **Adjusts unstructured mesh/field plotting to use monitor extents.** Plot axis limits are derived from the monitor bounds (clipped to the simulation domain) and autoscaling is disabled before overlaying the unstructured mesh, ensuring plots focus on the requested monitor region.
> 
> **Hardens VTK data ingestion.** Converting VTK point arrays to numpy now forces a copy to prevent potential data corruption from views into VTK-managed buffers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e3eb85d806d4512f6551a96a93e3387a034e217. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->