### PR TITLE
fix(tidy3d): SCRF-2777 validate AutoImpedanceSpec in ModeSolver pre-upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated docstrings for `DerivativeInfo` to more accurately reflect dataclass fields.
 - Fixed local cache race conditions causing `FileNotFoundError`.
 - Improved `ModeSolver.solve()` to suppress the accuracy warning when local subpixel averaging is enabled via `tidy3d-extras`, and expanded docstrings for `ModeSolver.solve()`, `ModeSimulation.run_local()`, `Simulation.epsilon()`, and `Simulation.epsilon_on_grid()` to document the `config.simulation.use_local_subpixel` option.
+- Fixed `ModeSolver.validate_pre_upload` not validating `MicrowaveModeSpec` with `AutoImpedanceSpec`, causing cryptic server-side errors for invalid conductor geometries.
 
 ## [2.10.2] - 2026-01-21
 

--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -1283,6 +1283,57 @@ def test_mode_solver_with_microwave_mode_spec():
     )
 
 
+def test_mode_solver_validate_auto_impedance_spec():
+    """Test that ModeSolver.validate_pre_upload catches invalid AutoImpedanceSpec geometry."""
+    freq0 = 10e9
+    sim_size = (10 * mm, 10 * mm, 10 * mm)
+    plane_size = (0, 8 * mm, 8 * mm)
+
+    # Coaxial structure: axis-aligned bounding boxes of conductors overlap,
+    # which causes AutoImpedanceSpec setup to fail
+    coaxial = td.Structure(
+        geometry=td.GeometryGroup(
+            geometries=(
+                td.ClipOperation(
+                    operation="difference",
+                    geometry_a=td.Cylinder(
+                        axis=0, radius=2.5 * mm, center=(0, 0, 0), length=td.inf
+                    ),
+                    geometry_b=td.Cylinder(
+                        axis=0, radius=1.3 * mm, center=(0, 0, 0), length=td.inf
+                    ),
+                ),
+                td.Cylinder(axis=0, radius=1 * mm, center=(0, 0, 0), length=td.inf),
+            )
+        ),
+        medium=td.PEC,
+    )
+
+    mode_spec = td.MicrowaveModeSpec(
+        num_modes=2,
+        target_neff=1.8,
+        impedance_specs=(td.AutoImpedanceSpec(), td.AutoImpedanceSpec()),
+    )
+
+    sim = td.Simulation(
+        run_time=1e-9,
+        size=sim_size,
+        sources=[],
+        structures=[coaxial],
+        grid_spec=td.GridSpec.uniform(dl=0.1 * mm),
+    )
+
+    mode_solver = ModeSolver(
+        simulation=sim,
+        plane=td.Box(center=(0, 0, 0), size=plane_size),
+        mode_spec=mode_spec,
+        freqs=[freq0],
+    )
+
+    with pytest.raises(SetupError):
+        mode_solver.validate_pre_upload()
+
+
 def test_mode_solver_with_microwave_group_index():
     """Test that group_index calculation with MicrowaveModeSpec correctly filters frequencies."""
 

--- a/tidy3d/components/microwave/mode_spec.py
+++ b/tidy3d/components/microwave/mode_spec.py
@@ -10,6 +10,7 @@ from pydantic import Field, model_validator
 from tidy3d.components.base import cached_property
 from tidy3d.components.geometry.bound_ops import bounds_contains
 from tidy3d.components.microwave.base import MicrowaveBaseModel
+from tidy3d.components.microwave.path_integrals.mode_plane_analyzer import ModePlaneAnalyzer
 from tidy3d.components.microwave.path_integrals.specs.impedance import (
     AutoImpedanceSpec,
     ImpedanceSpecType,
@@ -21,6 +22,9 @@ from tidy3d.exceptions import SetupError
 if TYPE_CHECKING:
     from tidy3d.compat import Self
     from tidy3d.components.geometry.base import Box
+    from tidy3d.components.grid.grid import Grid
+    from tidy3d.components.structure import Structure
+    from tidy3d.components.types import Coordinate, Size, Symmetry
 
 TEM_POLARIZATION_THRESHOLD = 0.995
 QTEM_POLARIZATION_THRESHOLD = 0.95
@@ -170,3 +174,32 @@ class MicrowaveModeSpec(AbstractModeSpec, MicrowaveBaseModel):
                         f"'{impedance_ind}' was provided with a {spec_type} path specification with bounds "
                         f"'{spec.bounds}', but the mode plane bounds are '{box.bounds}'."
                     )
+
+    def _validate_auto_impedance_setup(
+        self,
+        center: Coordinate,
+        size: Size,
+        colocate: bool,
+        volumetric_structures: list[Structure],
+        grid: Grid,
+        symmetry: tuple[Symmetry, Symmetry, Symmetry],
+        simulation_geometry: Box,
+        label: str = "",
+    ) -> None:
+        """Validate that auto impedance specification can be set up for the given mode plane."""
+        if not self._using_auto_current_spec:
+            return
+        mode_plane_analyzer = ModePlaneAnalyzer(
+            center=center,
+            size=size,
+            field_data_colocated=colocate,
+        )
+        try:
+            mode_plane_analyzer.get_conductor_bounding_boxes(
+                volumetric_structures,
+                grid,
+                symmetry,
+                simulation_geometry,
+            )
+        except SetupError as e:
+            raise SetupError(f"Failed to setup auto impedance specification{label}. {e!s}") from e

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -2747,9 +2747,26 @@ class ModeSolver(Tidy3dBaseModel):
                 "frequencies or modes."
             )
 
+    def _validate_auto_impedance_spec(self) -> None:
+        """Raise error if the microwave mode specification with ``AutoImpedanceSpec`` will
+        fail to instantiate."""
+        if not self._has_microwave_mode_spec:
+            return
+        self.mode_spec._validate_auto_impedance_setup(
+            center=self.plane.center,
+            size=self.plane.size,
+            colocate=self.colocate,
+            volumetric_structures=self.simulation.volumetric_structures,
+            grid=self.simulation.grid,
+            symmetry=self.simulation.symmetry,
+            simulation_geometry=self.simulation.simulation_geometry,
+            label=" for mode solver",
+        )
+
     def validate_pre_upload(self) -> None:
         """Validate the fully initialized mode solver is ok for upload to our servers."""
         self._validate_modes_size()
+        self._validate_auto_impedance_spec()
 
     @cached_property
     def reduced_simulation_copy(self) -> Self:

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -75,7 +75,6 @@ from .medium import (
     PECMedium,
 )
 from .microwave.monitor import MicrowaveModeMonitor, MicrowaveModeSolverMonitor
-from .microwave.path_integrals.mode_plane_analyzer import ModePlaneAnalyzer
 from .monitor import (
     AbstractFieldProjectionMonitor,
     AbstractModeMonitor,
@@ -4895,21 +4894,16 @@ class Simulation(AbstractYeeGridSimulation):
             if not isinstance(monitor, (MicrowaveModeMonitor, MicrowaveModeSolverMonitor)):
                 continue
 
-            if monitor.mode_spec._using_auto_current_spec:
-                mode_plane_analyzer = ModePlaneAnalyzer(
-                    center=monitor.center, size=monitor.size, field_data_colocated=monitor.colocate
-                )
-                try:
-                    _ = mode_plane_analyzer.get_conductor_bounding_boxes(
-                        self.volumetric_structures,
-                        self.grid,
-                        self.symmetry,
-                        self.simulation_geometry,
-                    )
-                except SetupError as e:
-                    raise SetupError(
-                        f"Failed to setup auto impedance specification for monitor '{monitor.name}'. {e!s}"
-                    ) from e
+            monitor.mode_spec._validate_auto_impedance_setup(
+                center=monitor.center,
+                size=monitor.size,
+                colocate=monitor.colocate,
+                volumetric_structures=self.volumetric_structures,
+                grid=self.grid,
+                symmetry=self.symmetry,
+                simulation_geometry=self.simulation_geometry,
+                label=f" for monitor '{monitor.name}'",
+            )
 
     @cached_property
     def monitors_data_size(self) -> dict[str, float]:


### PR DESCRIPTION
## Summary

- `ModeSolver.validate_pre_upload` was missing the `AutoImpedanceSpec` conductor geometry validation that `Simulation.validate_pre_upload` already performed, causing cryptic server-side errors
- Extract shared `_validate_auto_impedance_setup` method on `MicrowaveModeSpec` and call it from both `Simulation._validate_microwave_mode_specs` and `ModeSolver._validate_auto_impedance_spec`
- Add test in `test_microwave.py` verifying `ModeSolver.validate_pre_upload` raises `SetupError` for invalid conductor geometries (overlapping bounding boxes in a coaxial structure)

## Test plan

- [x] New test `test_mode_solver_validate_auto_impedance_spec` passes
- [x] Existing `test_validate_microwave_mode_spec` (Simulation-level) still passes
- [x] Full `test_mode_solver.py` suite passes (50 tests)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-upload validation behavior for microwave mode solves and may cause some previously-submitted jobs to fail earlier with client-side errors; logic is localized and covered by a new regression test.
> 
> **Overview**
> `ModeSolver.validate_pre_upload()` now validates that `MicrowaveModeSpec` configurations using `AutoImpedanceSpec` can be set up (via a shared `MicrowaveModeSpec._validate_auto_impedance_setup()` helper), mirroring the existing `Simulation`/monitor pre-upload checks and producing clearer `SetupError` messages.
> 
> Adds a regression test that constructs an invalid coaxial conductor geometry and asserts `ModeSolver.validate_pre_upload()` fails early, and records the fix in the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f63567059d3a38df494b33d51f65ebce39f2fb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->