### PR TITLE
chore(ci): add core testmon telemetry and tune restore keys

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -87,8 +87,9 @@ Primary CI workflow; it runs on PRs (`latest`, `develop`, `pre/*`), merge queue 
 - **Test type control**: `test_type` input ("basic" or "full") can override automatic selection for extras integration tests.
 - **Test selection control**: `test_selection` input (`testmon` or `full`) controls whether local/remote suites run with pytest-testmon (`--testmon --testmon-forceselect`) or full (`--no-testmon`) execution.
 - **Default policy**: PR and manual runs default to `test_selection: testmon`; merge queue (`merge_group`) forces `full` for safety.
-- **Testmon cache strategy**: local/remote testmon caches are shared by runner + Python + dependency hash and anchored to the default branch (`develop`) SHA. PR runs restore from that shared cache and do not write new entries.
+- **Testmon cache strategy**: local/remote testmon caches are shared by runner + Python and anchored to the default branch (`develop`) SHA, with dependency hash in the primary key. Restore keys degrade from exact branch+dependency to broader runner+Python prefixes. PR runs restore from shared caches and do not write new entries.
 - **Cache refresh path**: successful merge queue runs (`merge_group`) execute full coverage in testmon collection mode (`--testmon-noselect`) and write refreshed shared caches; no additional post-merge push run is required.
+- **Core cache telemetry**: local and remote jobs emit lightweight telemetry-only steps for cache outcome (`telemetry-cache-exact-hit`, `telemetry-cache-fallback-hit`, `telemetry-cache-miss`) and selection mode (`telemetry-selection-*`) so CI analytics can be derived from the jobs API without log scraping.
 - **Dynamic scope**: Determines which jobs to run based on the event (draft PRs, approvals, merge queue, manual overrides).
 - **Outputs**: `workflow_success` summarizes whether every required job succeeded; the release workflow uses this to decide if deployment can continue.
 

--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -720,10 +720,30 @@ jobs:
       uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: .testmondata
-        key: testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
+        key: testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
         restore-keys: |
-          testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch }}-
-          testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-
+          testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-
+          testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-
+          testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-
+
+    - name: telemetry-cache-exact-hit
+      if: >-
+        (needs.determine-test-scope.outputs.test_selection == 'testmon' || github.event_name == 'merge_group') &&
+        steps.testmon-cache-restore.outputs.cache-hit == 'true'
+      run: echo "testmon cache exact hit"
+
+    - name: telemetry-cache-fallback-hit
+      if: >-
+        (needs.determine-test-scope.outputs.test_selection == 'testmon' || github.event_name == 'merge_group') &&
+        steps.testmon-cache-restore.outputs.cache-hit != 'true' &&
+        steps.testmon-cache-restore.outputs.cache-matched-key != ''
+      run: echo "testmon cache fallback hit"
+
+    - name: telemetry-cache-miss
+      if: >-
+        (needs.determine-test-scope.outputs.test_selection == 'testmon' || github.event_name == 'merge_group') &&
+        steps.testmon-cache-restore.outputs.cache-matched-key == ''
+      run: echo "testmon cache miss"
 
     - name: install-project
       env:
@@ -753,14 +773,29 @@ jobs:
       run: |
         if [[ "${TEST_SELECTION}" == "testmon" ]]; then
           echo "flags=--testmon --testmon-forceselect" >> "$GITHUB_OUTPUT"
+          echo "mode=testmon_forceselect" >> "$GITHUB_OUTPUT"
           echo "Using pytest testmon selection mode."
         elif [[ "${TEST_SELECTION}" == "full" && "${EVENT_NAME}" == "merge_group" ]]; then
           echo "flags=--testmon-noselect" >> "$GITHUB_OUTPUT"
+          echo "mode=full_with_testmon_collection" >> "$GITHUB_OUTPUT"
           echo "Using full test execution with testmon collection mode."
         else
           echo "flags=--no-testmon" >> "$GITHUB_OUTPUT"
+          echo "mode=full_no_testmon" >> "$GITHUB_OUTPUT"
           echo "Using full pytest execution mode."
         fi
+
+    - name: telemetry-selection-testmon
+      if: steps.pytest-selection-flags.outputs.mode == 'testmon_forceselect'
+      run: echo "pytest selection testmon forceselect"
+
+    - name: telemetry-selection-full-with-testmon-collection
+      if: steps.pytest-selection-flags.outputs.mode == 'full_with_testmon_collection'
+      run: echo "pytest selection full with testmon collection"
+
+    - name: telemetry-selection-full-no-testmon
+      if: steps.pytest-selection-flags.outputs.mode == 'full_no_testmon'
+      run: echo "pytest selection full no testmon"
 
     - name: run-tests-coverage
       env:
@@ -781,7 +816,7 @@ jobs:
       uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: .testmondata
-        key: testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
+        key: testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
 
     - name: diff-coverage-report
       if: >- 
@@ -911,10 +946,30 @@ jobs:
       uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: .testmondata
-        key: testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
+        key: testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
         restore-keys: |
-          testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch }}-
-          testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-
+          testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-
+          testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-
+          testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-
+
+    - name: telemetry-cache-exact-hit
+      if: >-
+        (needs.determine-test-scope.outputs.test_selection == 'testmon' || github.event_name == 'merge_group') &&
+        steps.testmon-cache-restore.outputs.cache-hit == 'true'
+      run: echo "testmon cache exact hit"
+
+    - name: telemetry-cache-fallback-hit
+      if: >-
+        (needs.determine-test-scope.outputs.test_selection == 'testmon' || github.event_name == 'merge_group') &&
+        steps.testmon-cache-restore.outputs.cache-hit != 'true' &&
+        steps.testmon-cache-restore.outputs.cache-matched-key != ''
+      run: echo "testmon cache fallback hit"
+
+    - name: telemetry-cache-miss
+      if: >-
+        (needs.determine-test-scope.outputs.test_selection == 'testmon' || github.event_name == 'merge_group') &&
+        steps.testmon-cache-restore.outputs.cache-matched-key == ''
+      run: echo "testmon cache miss"
 
     - name: install-poetry
       uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # v1.4.1
@@ -985,14 +1040,29 @@ jobs:
       run: |
         if [[ "${TEST_SELECTION}" == "testmon" ]]; then
           echo "flags=--testmon --testmon-forceselect" >> "$GITHUB_OUTPUT"
+          echo "mode=testmon_forceselect" >> "$GITHUB_OUTPUT"
           echo "Using pytest testmon selection mode."
         elif [[ "${TEST_SELECTION}" == "full" && "${EVENT_NAME}" == "merge_group" ]]; then
           echo "flags=--testmon-noselect" >> "$GITHUB_OUTPUT"
+          echo "mode=full_with_testmon_collection" >> "$GITHUB_OUTPUT"
           echo "Using full test execution with testmon collection mode."
         else
           echo "flags=--no-testmon" >> "$GITHUB_OUTPUT"
+          echo "mode=full_no_testmon" >> "$GITHUB_OUTPUT"
           echo "Using full pytest execution mode."
         fi
+
+    - name: telemetry-selection-testmon
+      if: steps.pytest-selection-flags.outputs.mode == 'testmon_forceselect'
+      run: echo "pytest selection testmon forceselect"
+
+    - name: telemetry-selection-full-with-testmon-collection
+      if: steps.pytest-selection-flags.outputs.mode == 'full_with_testmon_collection'
+      run: echo "pytest selection full with testmon collection"
+
+    - name: telemetry-selection-full-no-testmon
+      if: steps.pytest-selection-flags.outputs.mode == 'full_no_testmon'
+      run: echo "pytest selection full no testmon"
 
     - name: run-doctests
       env:
@@ -1017,7 +1087,7 @@ jobs:
       uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: .testmondata
-        key: testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
+        key: testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
 
     - name: create-badge
       if: ${{ github.ref == 'refs/heads/develop' }}


### PR DESCRIPTION
## Summary
- add lightweight core telemetry steps for cache outcomes (exact/fallback/miss) in local + remote test jobs
- add lightweight core telemetry steps for pytest selection mode in local + remote test jobs
- tune testmon cache restore-key hierarchy to degrade from exact branch+dependency to broader runner+python prefixes
- update workflow docs to describe the new telemetry and restore behavior

## Validation
- poetry run pre-commit run --all-files

## Notes
- telemetry is intentionally minimal and derived from job step outcomes (no per-job artifact upload)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI test selection signaling and the `actions/cache` key/restore-key hierarchy, which could affect cache hit rates and test runtime/coverage behavior across local and remote jobs.
> 
> **Overview**
> Adds lightweight, log-only telemetry steps to `tidy3d-python-client-tests.yml` to classify **testmon cache outcomes** (exact hit/fallback hit/miss) and **pytest selection mode** (testmon forceselect vs full runs) for both local and remote test jobs.
> 
> Reworks the testmon cache key layout and restore-key hierarchy so restores degrade from exact `default_branch`+dependency+SHA matches to broader runner/Python prefixes, and updates workflow docs to reflect the new cache/telemetry behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b19b5bec1c6970441a301901a376679ed1c5b6a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->