### PR TITLE
fix(tidy3d): FXC-5400-disable-cache-racing-tests

### DIFF
--- a/tests/test_web/test_local_cache.py
+++ b/tests/test_web/test_local_cache.py
@@ -70,7 +70,7 @@ def _isolate_local_cache(tmp_path, monkeypatch):
 
     def _safe_remove_cache_dir(path, *, recreate):
         target = Path(path).resolve()
-        allowed_root = tmp_path.resolve().parent
+        allowed_root = tmp_path.resolve()
         try:
             target.relative_to(allowed_root)
         except ValueError:
@@ -819,6 +819,10 @@ def test_cache_stats_sync(monkeypatch, tmp_path_factory, basic_simulation):
     cache.clear()
 
 
+@pytest.mark.skipif(
+    (os.getenv("GITHUB_ACTIONS") or "").lower() == "true",
+    reason="Skip on CI due to resource problems. Activate temporarily for targeted testing.",
+)
 def test_cache_stats_concurrent_updates():
     cache = resolve_local_cache(use_cache=True)
     cache.clear()
@@ -875,6 +879,10 @@ def test_cache_stats_concurrent_updates():
     assert set(stats["last_used"].keys()) == {key1, key2}
 
 
+@pytest.mark.skipif(
+    (os.getenv("GITHUB_ACTIONS") or "").lower() == "true",
+    reason="Skip on CI due to resource problems. Activate temporarily for targeted testing.",
+)
 def test_cache_stats_store_invalidate_race():
     cache = resolve_local_cache(use_cache=True)
     cache.clear()


### PR DESCRIPTION
The newly introduced tests for local cache race conditions seem to run instable in CI as processes do not spawn properly. This is why I would skip those tests by default. They might be temporally activated for local testing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test code, primarily skipping flaky CI tests and tightening a temp-directory safety check, with no production behavior impact.
> 
> **Overview**
> Improves local-cache test safety and CI stability.
> 
> The local-cache isolation fixture now only allows cache directory deletion within the test `tmp_path` (tightening the guard to avoid touching parent paths). Two multiprocessing race-condition tests for cache stats are now **skipped on GitHub Actions** via `pytest.mark.skipif` due to CI process-spawn/resource instability, while remaining available for targeted local runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ce1c02bb1c969776734e6a00ce4bac89e83a74d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->