### PR TITLE
refactor(tidy3d): FXC-5286-pydantic-v-2-refactor-validator-sprawl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@
 - Public APIs covered in `docs/` should use the existing Numpy-inspired block pattern rendered by our Sphinx Book Theme; lean on current API examples or the theme reference at https://sphinx-book-theme.readthedocs.io/en/stable/reference/api-numpy.html. Internal helpers may keep short docstrings but match local tone.
 - Prefer `tidy3d.log.log` and `tidy3d.exceptions` for contributor-facing messages; touch stdlib `logging` only when muting external libraries such as `pyroots`.
 - Reuse types from `tidy3d/components/types`, domain constants from `tidy3d/constants`, and runtime defaults from `tidy3d/config`.
+- For the `Medium` and `Simulation` class families, centralize `@model_validator(mode="after")` logic in `_run_after_validators()` with a short docstring, and call dependent checks in explicit order instead of relying on decorator registration.
+- For those same families, prefix validator helpers with `_` (e.g., `_check_*`, `_validate_*`) and use `call_wrapped_validator(...)` for validator factories so ordering stays explicit.
 
 ## Testing Guidelines
 - Mirror the source tree with `test_<feature>.py`, add a short module docstring, and import `tidy3d as td`; keep single-use fixtures local but upstream broadly useful helpers into `tests/conftest.py`.

--- a/tests/test_components/test_custom.py
+++ b/tests/test_components/test_custom.py
@@ -675,6 +675,14 @@ def test_custom_isotropic_medium(unstructured):
     assert mat.is_spatially_uniform
 
 
+def test_custom_medium_validator_order():
+    permittivity = make_spatial_data(value=0)
+    conductivity = make_spatial_data(value=-0.5)
+
+    with pytest.raises(ValidationError, match="'permittivity' must be no less than one."):
+        _ = CustomMedium(permittivity=permittivity, conductivity=conductivity)
+
+
 def verify_custom_dispersive_medium_methods(mat, reduced_fields):
     """Verify that the methods in custom dispersive medium is producing expected results."""
     verify_custom_medium_methods(mat, reduced_fields)

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -20,6 +20,7 @@ from tidy3d.plugins.mode import ModeSolver
 from ..utils import (
     SIM_FULL,
     AssertLogLevel,
+    AssertLogLevelHandler,
     AssertLogStr,
     cartesian_to_unstructured,
     run_emulated,
@@ -423,12 +424,6 @@ def test_validate_normalize_index():
         size=(0, 0, 0),
         polarization="Ex",
     )
-    src0 = td.UniformCurrentSource(
-        source_time=td.GaussianPulse(freq0=2.0e12, fwidth=1.0e12, amplitude=0),
-        size=(0, 0, 0),
-        polarization="Ex",
-    )
-
     # negative normalize index
     with pytest.raises(ValidationError):
         td.Simulation(
@@ -457,6 +452,11 @@ def test_validate_normalize_index():
         RuntimeWarning,
         match=r"invalid value encountered in scalar divide",
     ):
+        src0 = td.UniformCurrentSource(
+            source_time=td.GaussianPulse(freq0=2.0e12, fwidth=1.0e12, amplitude=0),
+            size=(0, 0, 0),
+            polarization="Ex",
+        )
         with pytest.raises(ValidationError):
             td.Simulation(
                 size=(1, 1, 1),
@@ -464,6 +464,48 @@ def test_validate_normalize_index():
                 grid_spec=td.GridSpec.uniform(dl=0.1),
                 sources=(src0,),
             )
+
+
+def test_simulation_validator_warning_order():
+    src_cw = td.UniformCurrentSource(
+        source_time=td.ContinuousWave(freq0=2.0e12, fwidth=0.5e12),
+        size=(0, 0, 0),
+        polarization="Ex",
+    )
+    src_pulse = td.UniformCurrentSource(
+        source_time=td.GaussianPulse(freq0=3.0e12, fwidth=0.5e12),
+        size=(0, 0, 0),
+        polarization="Ex",
+    )
+
+    handler = AssertLogLevelHandler()
+    td.log.handlers["validator_order"] = handler
+    try:
+        _ = td.Simulation(
+            size=(1, 1, 1),
+            run_time=1e-12,
+            grid_spec=td.GridSpec.uniform(dl=0.01),
+            sources=(src_cw, src_pulse),
+            normalize_index=0,
+            boundary_spec=td.BoundarySpec.all_sides(boundary=td.ABCBoundary()),
+        )
+    finally:
+        del td.log.handlers["validator_order"]
+
+    messages = [message for _level, message in handler.records]
+    mode_abc_msg = (
+        "At least one 'ModeABCBoundary' does not specify frequency at which the absorbed mode "
+        "must be evaluated. The central frequency of the first source will be used."
+    )
+    normalize_msg = (
+        "'normalize_index' 0 is a source with 'ContinuousWave' time dependence. Normalizing "
+        "frequency-domain monitors by this source is not meaningful because field decay does "
+        "not occur. Consider setting 'normalize_index' to 'None' instead."
+    )
+
+    assert mode_abc_msg in messages
+    assert normalize_msg in messages
+    assert messages.index(mode_abc_msg) < messages.index(normalize_msg)
 
 
 def test_validate_plane_wave_boundaries():

--- a/tests/test_components/test_validator_policy.py
+++ b/tests/test_components/test_validator_policy.py
@@ -1,0 +1,61 @@
+"""Tests enforcing validator policy for selected class families."""
+
+from __future__ import annotations
+
+from pydantic import model_validator
+
+import tidy3d as td
+from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.base_sim.simulation import AbstractSimulation
+from tidy3d.components.medium import AbstractMedium
+
+
+def _iter_subclasses(cls: type) -> list[type]:
+    subclasses: list[type] = []
+    for subcls in cls.__subclasses__():
+        subclasses.append(subcls)
+        subclasses.extend(_iter_subclasses(subcls))
+    return subclasses
+
+
+ALLOWED_AFTER_MODEL_VALIDATORS = {
+    "_run_after_validators",
+    "__tidy3d_end_capture__",
+}
+
+
+def _find_after_model_validators(classes: list[type], allowed: set[str]) -> list[tuple[type, str]]:
+    violations: list[tuple[type, str]] = []
+    for cls in classes:
+        decorators = getattr(cls, "__pydantic_decorators__", None)
+        if not decorators:
+            continue
+        for name, decorator in decorators.model_validators.items():
+            if decorator.info.mode == "after" and name not in allowed:
+                violations.append((cls, name))
+    return violations
+
+
+def test_no_after_model_validators_in_medium_and_simulation_families() -> None:
+    _ = td.Medium
+    classes = [AbstractMedium, AbstractSimulation]
+    classes.extend(_iter_subclasses(AbstractMedium))
+    classes.extend(_iter_subclasses(AbstractSimulation))
+
+    violations = _find_after_model_validators(classes, ALLOWED_AFTER_MODEL_VALIDATORS)
+
+    assert not violations, (
+        "Found @model_validator(mode='after') outside _run_after_validators(): "
+        + ", ".join(f"{cls.__module__}.{cls.__name__}.{name}" for cls, name in violations)
+    )
+
+
+def test_after_model_validator_policy_detection_example() -> None:
+    class BadModel(Tidy3dBaseModel):
+        @model_validator(mode="after")
+        def _bad_validator(self) -> BadModel:
+            return self
+
+    violations = _find_after_model_validators([BadModel], ALLOWED_AFTER_MODEL_VALIDATORS)
+
+    assert violations == [(BadModel, "_bad_validator")]

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -18,6 +18,7 @@ from tidy3d.components.validators import (
     _warn_unsupported_traced_argument,
     assert_objects_in_sim_bounds,
     assert_unique_names,
+    call_wrapped_validator,
 )
 from tidy3d.components.viz import add_ax_if_none, equal_aspect, plot_params_symmetry
 from tidy3d.exceptions import Tidy3dKeyError
@@ -150,13 +151,9 @@ class AbstractSimulation(Box, ABC):
     _unique_structure_names = assert_unique_names("structures")
     _unique_source_names = assert_unique_names("sources")
 
-    _monitors_in_bounds = assert_objects_in_sim_bounds("monitors", strict_inequality=True)
-    _structures_in_bounds = assert_objects_in_sim_bounds("structures", error=False)
-
     _warn_traced_center = _warn_unsupported_traced_argument("center")
     _warn_traced_size = _warn_unsupported_traced_argument("size")
 
-    @model_validator(mode="after")
     def _structures_not_at_edges(self) -> Self:
         """Warn if any structures lie at the simulation boundaries."""
         if not self.structures:
@@ -185,6 +182,15 @@ class AbstractSimulation(Box, ABC):
         return self
 
     """ Post-init validators """
+
+    @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        call_wrapped_validator(
+            assert_objects_in_sim_bounds, self, "monitors", strict_inequality=True
+        )
+        call_wrapped_validator(assert_objects_in_sim_bounds, self, "structures", error=False)
+        return self
 
     def _validate_structures_not_at_edges(self) -> None:
         """Warn if any structures lie at the simulation boundaries (post-init check with full field access)."""
@@ -242,7 +248,6 @@ class AbstractSimulation(Box, ABC):
                             custom_loc=["structures", istruct],
                         )
 
-    @model_validator(mode="after")
     def _validate_scene(self) -> Self:
         _ = self.scene
         return self

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -21,7 +21,12 @@ from tidy3d.components.simulation import (
 )
 from tidy3d.components.types import Axis, FreqArray
 from tidy3d.components.types.base import discriminated_union
-from tidy3d.components.validators import MIN_FREQUENCY, validate_freqs_min, validate_freqs_not_empty
+from tidy3d.components.validators import (
+    MIN_FREQUENCY,
+    call_wrapped_validator,
+    validate_freqs_min,
+    validate_freqs_not_empty,
+)
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
 from tidy3d.constants import C_0, inf
 from tidy3d.exceptions import SetupError, ValidationError
@@ -711,21 +716,36 @@ class EMESimulation(AbstractYeeGridSimulation):
         )
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        self._structures_not_at_edges()
+        self._validate_scene()
+        call_wrapped_validator(validate_boundaries_for_zero_dims, self, warn_on_change=False)
+        super()._run_after_validators()
+        self._validate_grid()
+        self._validate_eme_grid()
+        self._validate_mode_solver_monitors()
+        self._validate_cell_index_pairs()
+        self._validate_too_close_to_edges()
+        self._validate_port_offsets()
+        self._validate_symmetry()
+        self._validate_sweep_spec()
+        self._validate_monitor_setup()
+        self._validate_interp_specs()
+        return self
+
     def _validate_grid(self) -> Self:
         _ = self.grid
         return self
 
-    @model_validator(mode="after")
     def _validate_eme_grid(self) -> Self:
         _ = self.eme_grid
         return self
 
-    @model_validator(mode="after")
     def _validate_mode_solver_monitors(self) -> Self:
         _ = self.mode_solver_monitors
         return self
 
-    @model_validator(mode="after")
     def _validate_cell_index_pairs(self) -> Self:
         _ = self.mode_solver_monitors
         return self
@@ -742,7 +762,6 @@ class EMESimulation(AbstractYeeGridSimulation):
         # self._warn_monitor_interval()
         log.end_capture(self)
 
-    @model_validator(mode="after")
     def _validate_too_close_to_edges(self) -> Self:
         """Can't have mode planes closer to boundary than extreme Yee grid center."""
         cell_centers = self.eme_grid.centers
@@ -784,7 +803,6 @@ class EMESimulation(AbstractYeeGridSimulation):
                 "reducing the number of modes or setting 'constraint=None'."
             )
 
-    @model_validator(mode="after")
     def _validate_port_offsets(self) -> Self:
         """Port offsets cannot jointly exceed simulation length."""
         total_offset = self.port_offsets[0] + self.port_offsets[1]
@@ -797,7 +815,6 @@ class EMESimulation(AbstractYeeGridSimulation):
             )
         return self
 
-    @model_validator(mode="after")
     def _validate_symmetry(self) -> Self:
         """Symmetry in propagation direction is not supported."""
         if self.symmetry[self.axis] != 0:
@@ -827,7 +844,6 @@ class EMESimulation(AbstractYeeGridSimulation):
                 f"which exceeds the maximum allowed '{MAX_NUM_SWEEP}'."
             )
 
-    @model_validator(mode="after")
     def _validate_sweep_spec(self) -> Self:
         """Validate sweep spec."""
         if self.sweep_spec is None:
@@ -898,7 +914,6 @@ class EMESimulation(AbstractYeeGridSimulation):
                 )
         return self
 
-    @model_validator(mode="after")
     def _validate_monitor_setup(self) -> Self:
         """Check monitor setup."""
         for i, monitor in enumerate(self.monitors):
@@ -962,7 +977,6 @@ class EMESimulation(AbstractYeeGridSimulation):
                     )
         return self
 
-    @model_validator(mode="after")
     def _validate_interp_specs(self) -> Self:
         """Require that the interp_specs are identical."""
         interp_specs = []
@@ -1443,5 +1457,3 @@ class EMESimulation(AbstractYeeGridSimulation):
         else:
             pairs = set(self.eme_grid_spec._cell_index_pairs)
         return list(pairs)
-
-    _boundaries_for_zero_dims = validate_boundaries_for_zero_dims(warn_on_change=False)

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -81,7 +81,7 @@ from .parameter_perturbation import (
 )
 from .time_modulation import ModulationSpec
 from .types import TYPE_TAG_STR, FreqBound, InterpMethod, TensorReal
-from .validators import validate_name_str, validate_parameter_perturbation
+from .validators import call_wrapped_validator, validate_name_str, validate_parameter_perturbation
 from .viz import VisualizationSpec, add_ax_if_none
 
 if TYPE_CHECKING:
@@ -237,6 +237,13 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
     )
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        self._validate_nonlinear_spec()
+        self._check_either_modulation_or_nonlinear_spec()
+        self._validate_modulation_spec_after()
+        return self
+
     def _validate_nonlinear_spec(self) -> Self:
         """Check compatibility with nonlinear_spec."""
         if self.__class__.__name__ == "AnisotropicMedium" and any(
@@ -276,7 +283,6 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
                 )
         return self
 
-    @model_validator(mode="after")
     def _check_either_modulation_or_nonlinear_spec(self) -> Self:
         """Check compatibility with modulation_spec."""
         val = self.modulation_spec
@@ -291,7 +297,6 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
 
     _name_validator = validate_name_str()
 
-    @model_validator(mode="after")
     def _validate_modulation_spec_after(self) -> Self:
         """Check compatibility with nonlinear_spec."""
         if self.__class__.__name__ == "Medium2D" and any(
@@ -1487,6 +1492,14 @@ class Medium(AbstractMedium):
     )
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        self._passivity_validation()
+        self._permittivity_modulation_validation()
+        self._passivity_modulation_validation()
+        return self
+
     def _passivity_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.conductivity
@@ -1498,7 +1511,6 @@ class Medium(AbstractMedium):
             )
         return self
 
-    @model_validator(mode="after")
     def _permittivity_modulation_validation(self) -> Self:
         """Assert modulated permittivity cannot be <= 0."""
         val = self.permittivity
@@ -1513,7 +1525,6 @@ class Medium(AbstractMedium):
             )
         return self
 
-    @model_validator(mode="after")
     def _passivity_modulation_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.conductivity
@@ -1693,6 +1704,17 @@ class CustomIsotropicMedium(AbstractCustomMedium, Medium):
         return val
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        # Keep ordering explicit; avoid super() to prevent passivity from running before
+        # conductivity shape checks (and to avoid duplicate passivity calls).
+        AbstractMedium._run_after_validators(self)
+        self._permittivity_modulation_validation()
+        self._passivity_modulation_validation()
+        self._conductivity_real_and_correct_shape()
+        self._passivity_validation()
+        return self
+
     def _conductivity_real_and_correct_shape(self) -> Self:
         """Assert conductivity is real and of right shape."""
         val = self.conductivity
@@ -1707,7 +1729,6 @@ class CustomIsotropicMedium(AbstractCustomMedium, Medium):
             raise SetupError("'permittivity' and 'conductivity' must have the same coordinates.")
         return self
 
-    @model_validator(mode="after")
     def _passivity_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.conductivity
@@ -1889,6 +1910,16 @@ class CustomMedium(AbstractCustomMedium):
         return data
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        self._deprecation_dataset()
+        self._eps_dataset_eps_inf_greater_no_less_than_one_sigma_positive()
+        self._eps_inf_greater_no_less_than_one()
+        self._conductivity_non_negative_correct_shape()
+        self._passivity_modulation_validation()
+        return self
+
     def _deprecation_dataset(self) -> Self:
         """Raise deprecation warning if dataset supplied and convert to dataset."""
 
@@ -1955,7 +1986,6 @@ class CustomMedium(AbstractCustomMedium):
                 )
         return val
 
-    @model_validator(mode="after")
     def _eps_dataset_eps_inf_greater_no_less_than_one_sigma_positive(self) -> Self:
         """Assert any eps_inf must be >=1"""
         val = self.eps_dataset
@@ -2004,7 +2034,6 @@ class CustomMedium(AbstractCustomMedium):
                 )
         return self
 
-    @model_validator(mode="after")
     def _eps_inf_greater_no_less_than_one(self) -> Self:
         """Assert any eps_inf must be >=1"""
         val = self.permittivity
@@ -2028,7 +2057,6 @@ class CustomMedium(AbstractCustomMedium):
 
         return self
 
-    @model_validator(mode="after")
     def _conductivity_non_negative_correct_shape(self) -> Self:
         """Assert conductivity>=0"""
         val = self.conductivity
@@ -2052,7 +2080,6 @@ class CustomMedium(AbstractCustomMedium):
 
         return self
 
-    @model_validator(mode="after")
     def _passivity_modulation_validation(self) -> Self:
         """Assert passive medium at any time during modulation if ``allow_gain`` is False."""
         val = self.conductivity
@@ -2672,6 +2699,15 @@ class DispersiveMedium(AbstractMedium, ABC):
 
         return _validate_conductivity_modulation
 
+    @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        if "eps_inf" in self.model_fields:
+            call_wrapped_validator(DispersiveMedium._permittivity_modulation_validation, self)
+        call_wrapped_validator(DispersiveMedium._conductivity_modulation_validation, self)
+        return self
+
     @abstractmethod
     def _pole_residue_dict(self) -> dict:
         """Dict representation of Medium as a pole-residue model."""
@@ -2967,9 +3003,6 @@ class PoleResidue(DispersiveMedium):
             if np.any(abs(_get_numpy_array(c)) > LARGEST_FP_NUMBER):
                 raise ValidationError("The value of some 'c_i' is too large.")
         return val
-
-    _validate_permittivity_modulation = DispersiveMedium._permittivity_modulation_validation()
-    _validate_conductivity_modulation = DispersiveMedium._conductivity_modulation_validation()
 
     @staticmethod
     def _eps_model(eps_inf: PositiveFloat, poles: PolesAndResidues, frequency: float) -> complex:
@@ -3550,6 +3583,12 @@ class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
         return val
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        self._poles_correct_shape()
+        return self
+
     def _poles_correct_shape(self) -> Self:
         """poles must have the same shape."""
         val = self.poles
@@ -3820,6 +3859,13 @@ class Sellmeier(DispersiveMedium):
     )
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        AbstractMedium._run_after_validators(self)
+        self._passivity_validation()
+        call_wrapped_validator(DispersiveMedium._conductivity_modulation_validation, self)
+        return self
+
     def _passivity_validation(self) -> Self:
         """Assert passive medium if `allow_gain` is False."""
         val = self.coeffs
@@ -3851,8 +3897,6 @@ class Sellmeier(DispersiveMedium):
                 "The minimum permittivity value with modulation applied was found to be negative."
             )
         return val
-
-    _validate_conductivity_modulation = DispersiveMedium._conductivity_modulation_validation()
 
     def _n_model(self, frequency: float) -> complex:
         """Complex-valued refractive index as a function of frequency."""
@@ -4056,7 +4100,6 @@ class CustomSellmeier(CustomDispersiveMedium, Sellmeier):
                 raise SetupError("'C' must be positive.")
         return val
 
-    @model_validator(mode="after")
     def _passivity_validation(self) -> Self:
         """Assert passive medium if `allow_gain` is False."""
         val = self.coeffs
@@ -4327,6 +4370,13 @@ class Lorentz(DispersiveMedium):
         return val
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        self._validate_coeffs_shape()
+        self._passivity_validation()
+        return self
+
     def _passivity_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.coeffs
@@ -4342,8 +4392,9 @@ class Lorentz(DispersiveMedium):
                 )
         return self
 
-    _validate_permittivity_modulation = DispersiveMedium._permittivity_modulation_validation()
-    _validate_conductivity_modulation = DispersiveMedium._conductivity_modulation_validation()
+    def _validate_coeffs_shape(self) -> Self:
+        """Hook for subclasses that need coeff shape checks."""
+        return self
 
     @ensure_freq_in_range
     def eps_model(self, frequency: float) -> complex:
@@ -4602,7 +4653,6 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
         """
         return val
 
-    @model_validator(mode="after")
     def _coeffs_correct_shape(self) -> Self:
         """coeffs must have consistent shape."""
         val = self.coeffs
@@ -4620,6 +4670,9 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
                 raise SetupError("All terms in 'coeffs' must be real.")
         return self
 
+    def _validate_coeffs_shape(self) -> Self:
+        return self._coeffs_correct_shape()
+
     @field_validator("coeffs")
     @classmethod
     def _coeffs_delta_all_smaller_or_larger_than_fi(
@@ -4636,7 +4689,6 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
                 )
         return val
 
-    @model_validator(mode="after")
     def _passivity_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.coeffs
@@ -4842,9 +4894,6 @@ class Drude(DispersiveMedium):
         json_schema_extra={"units": (HERTZ, HERTZ)},
     )
 
-    _validate_permittivity_modulation = DispersiveMedium._permittivity_modulation_validation()
-    _validate_conductivity_modulation = DispersiveMedium._conductivity_modulation_validation()
-
     @ensure_freq_in_range
     def eps_model(self, frequency: float) -> complex:
         """Complex-valued permittivity as a function of frequency."""
@@ -5007,6 +5056,12 @@ class CustomDrude(CustomDispersiveMedium, Drude):
         return val
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        self._coeffs_correct_shape_and_sign()
+        return self
+
     def _coeffs_correct_shape_and_sign(self) -> Self:
         """coeffs must have consistent shape and sign."""
         val = self.coeffs
@@ -5190,6 +5245,13 @@ class Debye(DispersiveMedium):
     )
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        self._validate_coeffs_shape()
+        self._passivity_validation()
+        return self
+
     def _passivity_validation(self) -> Self:
         """Assert passive medium if `allow_gain` is False."""
         val = self.coeffs
@@ -5205,8 +5267,9 @@ class Debye(DispersiveMedium):
                 )
         return self
 
-    _validate_permittivity_modulation = DispersiveMedium._permittivity_modulation_validation()
-    _validate_conductivity_modulation = DispersiveMedium._conductivity_modulation_validation()
+    def _validate_coeffs_shape(self) -> Self:
+        """Hook for subclasses that need coeff shape checks."""
+        return self
 
     @ensure_freq_in_range
     def eps_model(self, frequency: float) -> complex:
@@ -5366,7 +5429,6 @@ class CustomDebye(CustomDispersiveMedium, Debye):
             raise SetupError("'eps_inf' must be positive.")
         return val
 
-    @model_validator(mode="after")
     def _coeffs_correct_shape(self) -> Self:
         """coeffs must have consistent shape."""
         val = self.coeffs
@@ -5381,6 +5443,9 @@ class CustomDebye(CustomDispersiveMedium, Debye):
             if not CustomDispersiveMedium._validate_isreal_dataarray_tuple((de, tau)):
                 raise SetupError("All terms in 'coeffs' must be real.")
         return self
+
+    def _validate_coeffs_shape(self) -> Self:
+        return self._coeffs_correct_shape()
 
     @field_validator("coeffs")
     @classmethod
@@ -5436,7 +5501,6 @@ class CustomDebye(CustomDispersiveMedium, Debye):
 
         return grads
 
-    @model_validator(mode="after")
     def _passivity_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.coeffs
@@ -6057,6 +6121,12 @@ class AnisotropicMedium(AbstractMedium):
         return val
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        self._ignored_fields()
+        return self
+
     def _ignored_fields(self) -> Self:
         """The field is ignored."""
         if self.xx is not None and self.allow_gain is not None:
@@ -6350,7 +6420,14 @@ class FullyAnisotropicMedium(AbstractMedium):
         return val
 
     @model_validator(mode="after")
-    def conductivity_commutes(self) -> Self:
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        self._conductivity_commutes()
+        self._passivity_validation()
+        return self
+
+    def _conductivity_commutes(self) -> Self:
         """Check that the symmetric part of conductivity tensor commutes with permittivity tensor
         (that is, simultaneously diagonalizable).
         """
@@ -6367,7 +6444,6 @@ class FullyAnisotropicMedium(AbstractMedium):
 
         return self
 
-    @model_validator(mode="after")
     def _passivity_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.conductivity
@@ -6641,7 +6717,6 @@ class CustomAnisotropicMedium(AbstractCustomMedium, AnisotropicMedium):
             raise SetupError(f"The {info.field_name}-component medium type is not isotropic.")
         return val
 
-    @model_validator(mode="after")
     def _ignored_fields(self) -> Self:
         """The field is ignored."""
         if self.xx is not None:
@@ -6956,6 +7031,12 @@ class PerturbationMedium(Medium, AbstractPerturbationMedium):
     )
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        self._check_overdefining()
+        return self
+
     def _check_overdefining(self) -> Self:
         """Check that perturbation model is provided either directly or through
         ``perturbation_spec``, but not both.
@@ -7133,6 +7214,12 @@ class PerturbationPoleResidue(PoleResidue, AbstractPerturbationMedium):
     )
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        self._check_overdefining()
+        return self
+
     def _check_overdefining(self) -> Self:
         """Check that perturbation model is provided either directly or through
         ``perturbation_spec``, but not both.
@@ -7348,6 +7435,12 @@ class Medium2D(AbstractMedium):
         return val
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        self._validate_inplane_pec()
+        return self
+
     def _validate_inplane_pec(self) -> Self:
         """ss/tt components must be both PEC or non-PEC."""
         val = self.tt

--- a/tidy3d/components/mode/simulation.py
+++ b/tidy3d/components/mode/simulation.py
@@ -26,6 +26,7 @@ from tidy3d.components.source.field import ModeSource
 from tidy3d.components.types import Direction, EMField, FreqArray
 from tidy3d.components.types.base import TYPE_TAG_STR, discriminated_union
 from tidy3d.components.types.mode_spec import ModeSpecType
+from tidy3d.components.validators import call_wrapped_validator
 from tidy3d.constants import C_0
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
@@ -126,9 +127,6 @@ class ModeSimulation(AbstractYeeGridSimulation):
     **Lectures:**
         * `Prelude to Integrated Photonics Simulation: Mode Injection <https://www.flexcompute.com/fdtd101/Lecture-4-Prelude-to-Integrated-Photonics-Simulation-Mode-Injection/>`_
     """
-
-    # This validator needs to run before others that might access _mode_solver
-    _boundaries_for_zero_dims = validate_boundaries_for_zero_dims(warn_on_change=False)
 
     mode_spec: ModeSpecType = Field(
         title="Mode specification",
@@ -231,7 +229,7 @@ class ModeSimulation(AbstractYeeGridSimulation):
 
     @model_validator(mode="before")
     @classmethod
-    def is_plane(cls, data: dict[str, Any]) -> dict[str, Any]:
+    def _is_plane(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Raise validation error if not planar."""
         if hasattr(data, "get") and data.get("plane") is None:
             val = Box(size=data.get("size"), center=data.get("center"))
@@ -244,19 +242,28 @@ class ModeSimulation(AbstractYeeGridSimulation):
         return data
 
     @model_validator(mode="after")
-    def plane_in_sim_bounds(self) -> Self:
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        call_wrapped_validator(validate_boundaries_for_zero_dims, self, warn_on_change=False)
+        self._structures_not_at_edges()
+        self._validate_scene()
+        super()._run_after_validators()
+        self._plane_in_sim_bounds()
+        self._validate_mode_solver()
+        self._validate_grid()
+        return self
+
+    def _plane_in_sim_bounds(self) -> Self:
         """Check that the plane is at least partially inside the simulation bounds."""
         sim_box = Box(size=self.size, center=self.center)
         if not sim_box.intersects(self.plane):
             raise SetupError("'ModeSimulation.plane' must intersect 'ModeSimulation.geometry.")
         return self
 
-    @model_validator(mode="after")
     def _validate_mode_solver(self) -> Self:
         _ = self._mode_solver
         return self
 
-    @model_validator(mode="after")
     def _validate_grid(self) -> Self:
         _ = self.grid
         return self

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -117,6 +117,7 @@ from .types.monitor import MonitorType
 from .validators import (
     assert_objects_contained_in_sim_bounds,
     assert_objects_in_sim_bounds,
+    call_wrapped_validator,
     named_obj_descr,
     validate_mode_objects_symmetry,
 )
@@ -409,6 +410,14 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         return "tidy3d" if val is None else val
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        self._validate_num_lumped_elements()
+        self._check_3d_simulation_with_lumped_elements()
+        self._validate_boundary_spec_symmetry()
+        return self
+
     def _validate_num_lumped_elements(self) -> Self:
         """Error if too many lumped elements present."""
         val = self.lumped_elements
@@ -425,7 +434,6 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
 
         return self
 
-    @model_validator(mode="after")
     def _check_3d_simulation_with_lumped_elements(self) -> Self:
         """Error if Simulation contained lumped elements and is not a 3D simulation"""
         val = self.lumped_elements
@@ -458,7 +466,6 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             return sum(num_cells_in_monitor(mnt) for mnt in monitor.integration_surfaces)
         return num_cells_in_monitor(monitor)
 
-    @model_validator(mode="after")
     def _validate_boundary_spec_symmetry(self) -> Self:
         """Error if symmetry is imposed along an axis but the boundary conditions are not the same
         on both sides."""
@@ -3104,6 +3111,50 @@ class Simulation(AbstractYeeGridSimulation):
         return updater.update_to_current()
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        call_wrapped_validator(validate_boundaries_for_zero_dims, self)
+        self._validate_auto_grid_wavelength()
+        call_wrapped_validator(
+            assert_objects_in_sim_bounds, self, "sources", strict_inequality=True
+        )
+        call_wrapped_validator(
+            assert_objects_contained_in_sim_bounds,
+            self,
+            "lumped_elements",
+            error=False,
+            strict_inequality=False,
+            strict_for_zero_size_dim=True,
+        )
+        call_wrapped_validator(validate_mode_objects_symmetry, self, "sources")
+        call_wrapped_validator(validate_mode_objects_symmetry, self, "monitors")
+        self._structures_not_at_edges()
+        self._bloch_with_symmetry()
+        self._plane_wave_boundaries()
+        self._bloch_boundaries_diff_mnt()
+        self._tfsf_boundaries()
+        self._tfsf_with_symmetry()
+        self._check_fixed_angle_components()
+        self._validate_frequency_mode_abc()
+        self._validate_absorber_in_zero_dims()
+        self._warn_monitor_mediums_frequency_range()
+        self._warn_monitor_simulation_frequency_range()
+        self._diffraction_monitor_boundaries()
+        self._projection_monitors_homogeneous()
+        self._abc_boundaries_homogeneous()
+        self._proj_distance_for_approx()
+        self._integration_surfaces_in_bounds()
+        self._projection_monitors_distance()
+        self._projection_mnts_2d()
+        self._diffraction_and_directivity_monitor_medium()
+        self._warn_grid_size_too_small()
+        self._source_homogeneous_isotropic()
+        self._check_normalize_index()
+        self._validate_low_freq_smoothing()
+        self._validate_scene()
+        return self
+
     def _validate_auto_grid_wavelength(self) -> Self:
         """Check that wavelength can be defined if there is auto grid spec."""
         val = self.grid_spec
@@ -3111,14 +3162,6 @@ class Simulation(AbstractYeeGridSimulation):
             _ = val.wavelength_from_sources(sources=self.sources)
         return self
 
-    _sources_in_bounds = assert_objects_in_sim_bounds("sources", strict_inequality=True)
-    _lumped_elements_in_bounds = assert_objects_contained_in_sim_bounds(
-        "lumped_elements", error=False, strict_inequality=False, strict_for_zero_size_dim=True
-    )
-    _mode_sources_symmetries = validate_mode_objects_symmetry("sources")
-    _mode_monitors_symmetries = validate_mode_objects_symmetry("monitors")
-
-    @model_validator(mode="after")
     def _structures_not_at_edges(self) -> Self:
         """Override :class:`.AbstractSimulation` validator for :class:`.Simulation`.
 
@@ -3134,8 +3177,7 @@ class Simulation(AbstractYeeGridSimulation):
     # _resolution_fine_enough = validate_resolution()
     # _plane_waves_in_homo = validate_plane_wave_intersections()
 
-    @model_validator(mode="after")
-    def bloch_with_symmetry(self) -> Self:
+    def _bloch_with_symmetry(self) -> Self:
         """Error if a Bloch boundary is applied with symmetry"""
         val = self.boundary_spec
         boundaries = val.to_list
@@ -3148,8 +3190,7 @@ class Simulation(AbstractYeeGridSimulation):
                 )
         return self
 
-    @model_validator(mode="after")
-    def plane_wave_boundaries(self) -> Self:
+    def _plane_wave_boundaries(self) -> Self:
         """Error if there are plane wave sources incompatible with boundary conditions."""
         boundaries = self.boundary_spec.to_list
         sources = self.sources
@@ -3201,8 +3242,7 @@ class Simulation(AbstractYeeGridSimulation):
                         )
         return self
 
-    @model_validator(mode="after")
-    def bloch_boundaries_diff_mnt(self) -> Self:
+    def _bloch_boundaries_diff_mnt(self) -> Self:
         """Error if there are diffraction monitors incompatible with boundary conditions."""
 
         monitors = self.monitors
@@ -3240,8 +3280,7 @@ class Simulation(AbstractYeeGridSimulation):
                     )
         return self
 
-    @model_validator(mode="after")
-    def tfsf_boundaries(self) -> Self:
+    def _tfsf_boundaries(self) -> Self:
         """Error if the boundary conditions are incompatible with TFSF sources, if any."""
         boundaries = self.boundary_spec.to_list
         sources = self.sources
@@ -3313,8 +3352,7 @@ class Simulation(AbstractYeeGridSimulation):
 
         return self
 
-    @model_validator(mode="after")
-    def tfsf_with_symmetry(self) -> Self:
+    def _tfsf_with_symmetry(self) -> Self:
         """Error if a TFSF source is applied with symmetry"""
         for source in self.sources:
             if isinstance(source, TFSF) and not all(sym == 0 for sym in self.symmetry):
@@ -3329,8 +3367,7 @@ class Simulation(AbstractYeeGridSimulation):
             source for source in sources if isinstance(source, PlaneWave) and source._is_fixed_angle
         ]
 
-    @model_validator(mode="after")
-    def check_fixed_angle_components(self) -> Self:
+    def _check_fixed_angle_components(self) -> Self:
         """Error if a fixed-angle plane wave is combined with other sources
         or fully anisotropic mediums or gain mediums."""
 
@@ -3377,7 +3414,6 @@ class Simulation(AbstractYeeGridSimulation):
 
         return self
 
-    @model_validator(mode="after")
     def _validate_frequency_mode_abc(self) -> Self:
         """Warn if ModeABCBoundary expects a frequency from a source, but there are multiple sources with different central frequencies."""
 
@@ -3420,7 +3456,6 @@ class Simulation(AbstractYeeGridSimulation):
 
         return self
 
-    @model_validator(mode="after")
     def _validate_absorber_in_zero_dims(self) -> Self:
         """Error if internal absorber is oriented along zero size dim."""
         val = self.internal_absorbers
@@ -3516,7 +3551,6 @@ class Simulation(AbstractYeeGridSimulation):
                     )
         return val
 
-    @model_validator(mode="after")
     def _warn_monitor_mediums_frequency_range(self) -> Self:
         """Warn user if any DFT monitors have frequencies outside of medium frequency range."""
         val = self.monitors
@@ -3569,7 +3603,6 @@ class Simulation(AbstractYeeGridSimulation):
                         )
         return self
 
-    @model_validator(mode="after")
     def _warn_monitor_simulation_frequency_range(self) -> Self:
         """Warn if any DFT monitors have frequencies outside of the simulation frequency range."""
         val = self.monitors
@@ -3605,8 +3638,7 @@ class Simulation(AbstractYeeGridSimulation):
                     )
         return self
 
-    @model_validator(mode="after")
-    def diffraction_monitor_boundaries(self) -> Self:
+    def _diffraction_monitor_boundaries(self) -> Self:
         """If any :class:`.DiffractionMonitor` exists, ensure boundary conditions in the
         transverse directions are periodic or Bloch."""
         monitors = self.monitors
@@ -3629,7 +3661,6 @@ class Simulation(AbstractYeeGridSimulation):
                         )
         return self
 
-    @model_validator(mode="after")
     def _projection_monitors_homogeneous(self) -> Self:
         """Error if any field projection monitor is not in a homogeneous region."""
         val = self.monitors
@@ -3713,7 +3744,6 @@ class Simulation(AbstractYeeGridSimulation):
 
         return mediums
 
-    @model_validator(mode="after")
     def _abc_boundaries_homogeneous(self) -> Self:
         """Error if abc boundaries intersect multiple mediums or anisotropic mediums."""
         val = self.boundary_spec
@@ -3826,8 +3856,7 @@ class Simulation(AbstractYeeGridSimulation):
 
         return val
 
-    @model_validator(mode="after")
-    def proj_distance_for_approx(self) -> Self:
+    def _proj_distance_for_approx(self) -> Self:
         """Warn if projection distance for projection monitors is not large compared to monitor or,
         simulation size, yet far_field_approx is True."""
         val = self.monitors
@@ -3856,7 +3885,6 @@ class Simulation(AbstractYeeGridSimulation):
                     )
         return self
 
-    @model_validator(mode="after")
     def _integration_surfaces_in_bounds(self) -> Self:
         """Error if all of the integration surfaces are outside of the simulation domain."""
         val = self.monitors
@@ -3877,7 +3905,6 @@ class Simulation(AbstractYeeGridSimulation):
 
         return self
 
-    @model_validator(mode="after")
     def _projection_monitors_distance(self) -> Self:
         """Warn if the projection distance is large for exact projections."""
         val = self.monitors
@@ -3910,7 +3937,6 @@ class Simulation(AbstractYeeGridSimulation):
                         )
         return self
 
-    @model_validator(mode="after")
     def _projection_mnts_2d(self) -> Self:
         """
         Validate if the field projection monitor is set up for a 2D simulation and
@@ -4015,8 +4041,7 @@ class Simulation(AbstractYeeGridSimulation):
 
         return self
 
-    @model_validator(mode="after")
-    def diffraction_and_directivity_monitor_medium(self) -> Self:
+    def _diffraction_and_directivity_monitor_medium(self) -> Self:
         """If any :class:`.DiffractionMonitor` or  :class:`.DirectivityMonitor` exists, ensure it does not lie in a lossy medium."""
         monitors = self.monitors
         structures = self.structures
@@ -4033,7 +4058,6 @@ class Simulation(AbstractYeeGridSimulation):
                     raise SetupError(f"'{monitor.type}' must not lie in a lossy medium.")
         return self
 
-    @model_validator(mode="after")
     def _warn_grid_size_too_small(self) -> Self:
         """Warn user if any grid size is too large compared to minimum wavelength in material."""
         val = self.grid_spec
@@ -4096,7 +4120,6 @@ class Simulation(AbstractYeeGridSimulation):
 
         return self
 
-    @model_validator(mode="after")
     def _source_homogeneous_isotropic(self) -> Self:
         """Error if a plane wave or gaussian beam source is not in a homogeneous and isotropic
         region.
@@ -4212,7 +4235,6 @@ class Simulation(AbstractYeeGridSimulation):
 
         return self
 
-    @model_validator(mode="after")
     def _check_normalize_index(self) -> Self:
         """Check validity of normalize index in context of simulation.sources."""
         val = self.normalize_index
@@ -4251,7 +4273,6 @@ class Simulation(AbstractYeeGridSimulation):
 
         return self
 
-    @model_validator(mode="after")
     def _validate_low_freq_smoothing(self) -> Self:
         """Validate the low frequency smoothing parameters."""
         # check that all monitors are present and they are mode monitors
@@ -4269,7 +4290,6 @@ class Simulation(AbstractYeeGridSimulation):
                 )
         return self
 
-    @model_validator(mode="after")
     def _validate_scene(self) -> Self:
         _ = self.scene
         self._validate_structures_not_at_edges()
@@ -4661,7 +4681,6 @@ class Simulation(AbstractYeeGridSimulation):
                 fields += medium.nonlinear_spec.aux_fields
         return fields
 
-    @model_validator(mode="after")
     def _validate_internal_abc_no_fully_anisotropic(self) -> Self:
         """Error if internal absorber intersect fully anisotropic mediums."""
 
@@ -6056,8 +6075,6 @@ class Simulation(AbstractYeeGridSimulation):
             medium=scene.medium,
             **kwargs,
         )
-
-    _boundaries_for_zero_dims = validate_boundaries_for_zero_dims()
 
     def padded_copy(
         self,

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -408,7 +408,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
     @field_validator("structures")
     @classmethod
-    def check_unsupported_geometries(cls, val: tuple[Structure, ...]) -> tuple[Structure, ...]:
+    def _check_unsupported_geometries(cls, val: tuple[Structure, ...]) -> tuple[Structure, ...]:
         """Error if structures contain unsupported yet geometries."""
         for ind, structure in enumerate(val):
             bbox = structure.geometry.bounding_box
@@ -486,6 +486,30 @@ class HeatChargeSimulation(AbstractSimulation):
         return obj_do_not_cross_solid_idx, obj_do_not_cross_cond_idx
 
     @model_validator(mode="after")
+    def _run_after_validators(self) -> Self:
+        """Run post-init validations in an explicit, dependency-aware order."""
+        super()._run_after_validators()
+        self._structures_not_at_edges()
+        self._validate_scene()
+        self._monitors_cross_solids()
+        self._check_voltage_array_if_capacitance()
+        self._names_exist_bcs()
+        self._check_natural_convection_bc()
+        self._check_freqs_requires_ac_source()
+        self._check_charge_simulation()
+        self._not_all_neumann()
+        self._names_exist_grid_spec()
+        self._warn_if_minimal_mesh_size_override()
+        self._names_exist_sources()
+        self._check_medium_specs()
+        self._check_coupling_source_can_be_applied()
+        self._check_heat_sim()
+        self._check_conduction_sim()
+        self._estimate_charge_mesh_size()
+        self._check_transient_heat()
+        self._check_non_isothermal_is_possible()
+        return self
+
     def _monitors_cross_solids(self) -> Self:
         """Error if monitors does not cross any solid medium."""
         val = self.monitors
@@ -518,8 +542,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
         return self
 
-    @model_validator(mode="after")
-    def check_voltage_array_if_capacitance(self) -> Self:
+    def _check_voltage_array_if_capacitance(self) -> Self:
         """Make sure an array of voltages has been defined if a
         SteadyCapacitanceMonitor' has been defined"""
         boundary_spec = self.boundary_spec
@@ -547,7 +570,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
     @field_validator("boundary_spec")
     @classmethod
-    def check_single_ssac(
+    def _check_single_ssac(
         cls, boundary_spec: Union[HeatChargeBoundarySpec, HeatBoundarySpec]
     ) -> Union[HeatChargeBoundarySpec, HeatBoundarySpec]:
         ssac_present = False
@@ -562,8 +585,7 @@ class HeatChargeSimulation(AbstractSimulation):
                         ssac_present = True
         return boundary_spec
 
-    @model_validator(mode="after")
-    def check_natural_convection_bc(self) -> Self:
+    def _check_natural_convection_bc(self) -> Self:
         """Make sure that natural convection BCs are defined correctly."""
         boundary_spec = self.boundary_spec
         if not boundary_spec:
@@ -603,7 +625,7 @@ class HeatChargeSimulation(AbstractSimulation):
             placement = bc.placement
 
             # Case 1: The fluid medium is inferred from the placement interface.
-            # We use direct dictionary access, assuming 'names_exist_bcs' validator has already run.
+            # We use direct dictionary access, assuming '_names_exist_bcs' validator has already run.
             if natural_conv_model.medium is None:
                 if isinstance(placement, MediumMediumInterface):
                     med1 = media[placement.mediums[0]]
@@ -640,7 +662,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
     @field_validator("size")
     @classmethod
-    def check_zero_dim_domain(cls, val: Any) -> Any:
+    def _check_zero_dim_domain(cls, val: Any) -> Any:
         """Error if heat domain have zero dimensions."""
 
         dim_names = ["x", "y", "z"]
@@ -660,8 +682,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
         return val
 
-    @model_validator(mode="after")
-    def names_exist_bcs(self) -> Self:
+    def _names_exist_bcs(self) -> Self:
         """Error if boundary conditions point to non-existing structures/media."""
         structures = self.structures
         structures_names = {s.name for s in structures}
@@ -697,7 +718,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
     @field_validator("boundary_spec")
     @classmethod
-    def check_only_one_voltage_array_provided(cls, val: Any) -> Any:
+    def _check_only_one_voltage_array_provided(cls, val: Any) -> Any:
         """Issue error if more than one voltage array is provided.
         Currently we only allow to sweep over one voltage array.
         """
@@ -720,8 +741,7 @@ class HeatChargeSimulation(AbstractSimulation):
                         )
         return val
 
-    @model_validator(mode="after")
-    def check_freqs_requires_ac_source(self) -> Self:
+    def _check_freqs_requires_ac_source(self) -> Self:
         """Ensure that if freqs is provided, at least one ACVoltageSource is present."""
         analysis_spec = self.analysis_spec
         if (
@@ -744,8 +764,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
         return self
 
-    @model_validator(mode="after")
-    def check_charge_simulation(self) -> Self:
+    def _check_charge_simulation(self) -> Self:
         """Makes sure that Charge simulations are set correctly."""
 
         simulation_types = self._check_simulation_types()
@@ -788,8 +807,7 @@ class HeatChargeSimulation(AbstractSimulation):
                 )
         return self
 
-    @model_validator(mode="after")
-    def not_all_neumann(self) -> Self:
+    def _not_all_neumann(self) -> Self:
         """Make sure not all BCs are of Neumann type"""
 
         NeumannBCsHeat = (HeatFluxBC,)
@@ -827,8 +845,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
         return self
 
-    @model_validator(mode="after")
-    def names_exist_grid_spec(self) -> Self:
+    def _names_exist_grid_spec(self) -> Self:
         """Warn if 'UniformUnstructuredGrid' points at a non-existing structure."""
         structures_names = {s.name for s in self.structures}
         for structure_name in self.grid_spec.non_refined_structures:
@@ -839,8 +856,7 @@ class HeatChargeSimulation(AbstractSimulation):
                 )
         return self
 
-    @model_validator(mode="after")
-    def warn_if_minimal_mesh_size_override(self) -> Self:
+    def _warn_if_minimal_mesh_size_override(self) -> Self:
         """Warn if minimal mesh size limit overrides desired mesh size."""
         val = self.grid_spec
         max_size = np.max(self.size)
@@ -859,8 +875,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
         return self
 
-    @model_validator(mode="after")
-    def names_exist_sources(self) -> Self:
+    def _names_exist_sources(self) -> Self:
         """Error if a heat-charge source point to non-existing structures."""
         structures_names = {s.name for s in self.structures}
 
@@ -875,8 +890,7 @@ class HeatChargeSimulation(AbstractSimulation):
                     )
         return self
 
-    @model_validator(mode="after")
-    def check_medium_specs(self) -> Self:
+    def _check_medium_specs(self) -> Self:
         """Error if no appropriate specs."""
 
         sim_box = (Box(size=self.size, center=self.center),)
@@ -949,8 +963,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
         return set(simulation_types)
 
-    @model_validator(mode="after")
-    def check_coupling_source_can_be_applied(self) -> Self:
+    def _check_coupling_source_can_be_applied(self) -> Self:
         """Error if material doesn't have the right specifications"""
 
         HeatSourceTypes_noCoupling = (UniformHeatSource, HeatSource)
@@ -968,8 +981,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
         return self
 
-    @model_validator(mode="after")
-    def check_heat_sim(self) -> Self:
+    def _check_heat_sim(self) -> Self:
         """Make sure that heat simulations have at least one monitor defined."""
 
         simulation_types = self._check_simulation_types()
@@ -983,8 +995,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
         return self
 
-    @model_validator(mode="after")
-    def check_conduction_sim(self) -> Self:
+    def _check_conduction_sim(self) -> Self:
         """Make sure that conduction simulations have at least one monitor defined."""
 
         simulation_types = self._check_simulation_types()
@@ -1025,8 +1036,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
         return self
 
-    @model_validator(mode="after")
-    def estimate_charge_mesh_size(self) -> Self:
+    def _estimate_charge_mesh_size(self) -> Self:
         """Make an estimate of the mesh size and raise a warning if too big.
         NOTE: this is a very rough estimate. The back-end will actually stop
         execution based on actual node-count."""
@@ -1083,8 +1093,7 @@ class HeatChargeSimulation(AbstractSimulation):
             )
         return self
 
-    @model_validator(mode="after")
-    def check_transient_heat(self) -> Self:
+    def _check_transient_heat(self) -> Self:
         """Make sure transient heat simulations can run."""
 
         analysis_type = self.analysis_spec
@@ -1149,8 +1158,7 @@ class HeatChargeSimulation(AbstractSimulation):
                 )
         return self
 
-    @model_validator(mode="after")
-    def check_non_isothermal_is_possible(self) -> Self:
+    def _check_non_isothermal_is_possible(self) -> Self:
         """Make sure that when a non-isothermal case is defined the structures
         have both electrical and thermal properties."""
 

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -45,6 +45,10 @@ T = TypeVar("T")
     class body, e.g. ``_plane_validator = assert_plane()``. Avoid reusing the same attribute
     name for multiple validators, or earlier validators may be overwritten.
 
+    For the ``Medium`` and ``Simulation`` class families, prefer explicit orchestration of
+    cross-field checks in ``_run_after_validators()`` (with a short docstring) and call validator
+    factories via ``call_wrapped_validator(...)`` to keep ordering explicit.
+
     For more details: `Pydantic validators <https://docs.pydantic.dev/latest/concepts/validators/>`_
 """
 
@@ -60,6 +64,13 @@ def named_obj_descr(obj: Any, field_name: str, position_index: int) -> str:
     if hasattr(obj, "name") and obj.name:
         descr = f"'{obj.name}' (simulation.{field_name}[{position_index}])"
     return descr
+
+
+def call_wrapped_validator(
+    factory: Callable[..., Any], instance: Any, *args: Any, **kwargs: Any
+) -> Any:
+    """Call the wrapped pydantic validator produced by a factory."""
+    return factory(*args, **kwargs).wrapped(instance)
 
 
 def assert_line() -> Callable[[type, tuple[float, ...]], tuple[float, ...]]:


### PR DESCRIPTION
Refactors validator hotspots by consolidating multiple @model_validator(mode="after") hooks into a single orchestrator validator that invokes ordered helper methods. This preserves existing warning/error ordering and messages while improving readability and maintainability. Tests are added/updated to lock in validation order where needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad refactor of validation ordering across core `Simulation`/`Medium` models; while intended to preserve messages, subtle ordering changes can affect which warnings/errors users see first and may break edge-case setups.
> 
> **Overview**
> Refactors Pydantic v2 post-init validation across the `Simulation` and `Medium` families by replacing many separate `@model_validator(mode="after")` hooks with a single `_run_after_validators()` orchestrator that runs checks in an explicit, dependency-aware order.
> 
> Introduces `call_wrapped_validator(...)` to invoke existing validator factories deterministically, updates several simulations (`Simulation`, `AbstractSimulation`, `ModeSimulation`, `EMESimulation`, `HeatChargeSimulation`) and many medium subclasses accordingly, and adds tests/policy enforcement to lock in warning/error ordering (including new log-order assertions) and prevent new ad-hoc after-validators in these families.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26c1fbee7c0e6cc3d4fe89948c7a16373cda8968. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->