### PR TITLE
fix(tidy3d): FXC-5538-fix-missing-copy-of-pydantic-extra-in-lazy-proxy

### DIFF
--- a/tests/test_web/test_tidy3d_stub.py
+++ b/tests/test_web/test_tidy3d_stub.py
@@ -164,6 +164,27 @@ def test_stub_data_lazy_loading(tmp_path):
         td.log.set_capture(False)
 
 
+@responses.activate
+def test_sim_data_lazy_materialize_then_copy(tmp_path):
+    """Regression test for copying lazily loaded SimulationData after materialization."""
+    sim_data = make_sim_data()
+    file_path = os.path.join(tmp_path, "test_lazy_copy.hdf5")
+    sim_data.to_file(file_path)
+
+    sim_data_lazy = SimulationData.from_file(file_path, lazy=True)
+    assert is_lazy_object(sim_data_lazy)
+
+    # Materialize the proxy first, then verify regular copy semantics work.
+    _ = sim_data_lazy.data
+    assert isinstance(sim_data_lazy, SimulationData)
+    assert hasattr(sim_data_lazy, "__pydantic_extra__")
+
+    sim_data_copy = sim_data_lazy.copy(deep=False)
+    assert isinstance(sim_data_copy, SimulationData)
+    assert sim_data_copy.simulation == sim_data_lazy.simulation
+    assert len(sim_data_copy.data) == len(sim_data_lazy.data)
+
+
 @pytest.mark.parametrize(
     "path_builder",
     (

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -1887,6 +1887,10 @@ def _make_lazy_proxy(
                 if pvt is not None:
                     object.__setattr__(self, "__pydantic_private__", pvt)
 
+                object.__setattr__(
+                    self, "__pydantic_extra__", getattr(target, "__pydantic_extra__", None)
+                )
+
                 if on_load is not None:
                     on_load(self)
 


### PR DESCRIPTION
Fixes a lazy-proxy materialization bug where SimulationData became a real model without __pydantic_extra__, causing copy()/updated_copy() to crash via Pydantic model_copy().
_make_lazy_proxy now restores __pydantic_extra__ during materialization, aligning with other restored internals.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix to lazy-loading materialization logic plus a regression test; low risk but could affect any code path relying on `from_file(lazy=True)` followed by `copy()`/`updated_copy()`.
> 
> **Overview**
> Fixes a lazy-loading materialization bug where a `Tidy3dBaseModel` proxy would become a real Pydantic model without `__pydantic_extra__`, causing `copy()`/`updated_copy()` to fail after the proxy is materialized.
> 
> `_make_lazy_proxy` now restores `__pydantic_extra__` alongside other Pydantic internals during materialization, and a new regression test asserts that a lazily loaded `SimulationData` can be materialized and then copied successfully.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c533ea0a4d54d02e1c2849a333ffac9497bd8d06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->