### PR TITLE
FXC-5539 fix local caching for component modelers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed local cache race conditions causing `FileNotFoundError`.
 - Improved `ModeSolver.solve()` to suppress the accuracy warning when local subpixel averaging is enabled via `tidy3d-extras`, and expanded docstrings for `ModeSolver.solve()`, `ModeSimulation.run_local()`, `Simulation.epsilon()`, and `Simulation.epsilon_on_grid()` to document the `config.simulation.use_local_subpixel` option.
 - Fixed `ModeSolver.validate_pre_upload` not validating `MicrowaveModeSpec` with `AutoImpedanceSpec`, causing cryptic server-side errors for invalid conductor geometries.
+- Fixed local cache not storing results for `ModalComponentModeler` (and `TerminalComponentModeler`) runs, causing cache misses on repeated `web.run()` calls.
 
 ## [2.10.2] - 2026-01-21
 

--- a/tests/test_plugins/smatrix/test_component_modeler_cache.py
+++ b/tests/test_plugins/smatrix/test_component_modeler_cache.py
@@ -1,0 +1,188 @@
+"""Tests that local cache works correctly with component modelers via web.run()."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import tidy3d.plugins.smatrix.analysis.terminal as terminal_analysis
+import tidy3d.plugins.smatrix.utils as smatrix_utils
+from tests.test_plugins.smatrix.terminal_component_modeler_def import (
+    make_component_modeler as make_terminal_component_modeler,
+)
+from tests.test_plugins.smatrix.test_component_modeler import make_component_modeler
+from tests.test_web.test_local_cache import (
+    _isolate_local_cache,  # noqa: F401
+    _patch_run_pipeline,
+    _reset_counters,
+)
+from tests.utils import run_emulated
+from tidy3d import SimulationDataMap
+from tidy3d.plugins.smatrix.data.modal import ModalComponentModelerData
+from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
+from tidy3d.web.api import webapi as web
+from tidy3d.web.cache import resolve_local_cache
+from tidy3d.web.core.types import TaskType
+
+
+class _FakeComponentModelerStubData:
+    """Fake stub data that mimics ComponentModelerData loaded from disk.
+
+    The real ComponentModelerData has a ``modeler`` attribute but no
+    ``simulation`` attribute, so ``getattr(stub_data, 'simulation', None)``
+    returns None inside ``store_result``.  This class reproduces that
+    behaviour faithfully.
+    """
+
+    def __init__(self, modeler, data_cls):
+        sim_dict = modeler.sim_dict
+        batch_data = {task_name: run_emulated(sim) for task_name, sim in sim_dict.items()}
+        port_data = SimulationDataMap(
+            keys=tuple(batch_data.keys()),
+            values=tuple(batch_data.values()),
+        )
+        self._modeler_data = data_cls(modeler=modeler, data=port_data)
+        # Mirror real ComponentModelerData: has .modeler, NOT .simulation
+        self.modeler = modeler
+
+    def smatrix(self):
+        return self._modeler_data.smatrix()
+
+    def __getattr__(self, name):
+        return getattr(self._modeler_data, name)
+
+
+def _patch_terminal_smatrix(monkeypatch, modeler) -> None:
+    monkeypatch.setattr(
+        smatrix_utils,
+        "port_array_inv",
+        lambda matrix: np.eye(len(modeler.matrix_indices_monitor)),
+    )
+    monkeypatch.setattr(
+        smatrix_utils,
+        "compute_F",
+        lambda Z_numpy, s_param_def: 1.0 / (2.0 * np.sqrt(np.abs(Z_numpy) + 1e-4)),
+    )
+    monkeypatch.setattr(
+        terminal_analysis,
+        "check_port_impedance_sign",
+        lambda Z_numpy: np.ndarray([]),
+    )
+
+
+@pytest.mark.parametrize(
+    "make_modeler, data_cls, task_type, patch_smatrix",
+    [
+        (make_component_modeler, ModalComponentModelerData, TaskType.MODAL_CM.value, None),
+        (
+            lambda: make_terminal_component_modeler(planar_pec=False),
+            TerminalComponentModelerData,
+            TaskType.TERMINAL_CM.value,
+            _patch_terminal_smatrix,
+        ),
+    ],
+)
+def test_component_modeler_cache_hit(
+    monkeypatch, tmp_path, make_modeler, data_cls, task_type, patch_smatrix
+):
+    """Test that running a component modeler via web.run stores results in cache
+    and that a second identical run gets a cache hit (no upload/start/monitor/download)."""
+    modeler = make_modeler()
+    fake_stub = _FakeComponentModelerStubData(modeler, data_cls)
+    counters = _patch_run_pipeline(
+        monkeypatch,
+        task_type=task_type,
+        postprocess=lambda path, lazy=False: fake_stub,
+        load_simulation_fn=lambda task_id, path="simulation.json", verbose=True: modeler,
+        patch_autograd=False,
+    )
+    if patch_smatrix is not None:
+        patch_smatrix(monkeypatch, modeler)
+    cache = resolve_local_cache(use_cache=True)
+    cache.clear()
+
+    out_path = tmp_path / f"{task_type.lower()}_modeler_result.hdf5"
+
+    # First run: should make web calls and store in cache
+    data = web.run(
+        modeler,
+        task_name=f"{task_type.lower()}_modeler_cache_test",
+        path=str(out_path),
+    )
+    assert counters["upload"] == 1
+    assert counters["start"] == 1
+    assert counters["monitor"] == 1
+    assert counters["download"] == 1
+
+    s_matrix = data.smatrix()
+    assert s_matrix is not None
+
+    # Verify cache has an entry
+    assert len(cache) == 1, (
+        f"Expected 1 cache entry after first run, got {len(cache)}. "
+        "The ComponentModelerData was not stored in cache."
+    )
+
+    # Second run: should be served from cache (no web calls)
+    _reset_counters(counters)
+    data2 = web.run(
+        modeler,
+        task_name=f"{task_type.lower()}_modeler_cache_test",
+        path=str(out_path),
+    )
+    assert counters["upload"] == 0, "Expected no upload on cache hit"
+    assert counters["start"] == 0, "Expected no start on cache hit"
+    assert counters["monitor"] == 0, "Expected no monitor on cache hit"
+    assert counters["download"] == 0, "Expected no download on cache hit"
+
+    s_matrix2 = data2.smatrix()
+    assert s_matrix2 is not None
+
+
+@pytest.mark.parametrize(
+    "make_modeler, data_cls, workflow_type",
+    [
+        (make_component_modeler, ModalComponentModelerData, TaskType.MODAL_CM.value),
+        (
+            lambda: make_terminal_component_modeler(planar_pec=False),
+            TerminalComponentModelerData,
+            TaskType.TERMINAL_CM.value,
+        ),
+    ],
+)
+def test_component_modeler_cache_stores_entry(
+    monkeypatch, tmp_path, make_modeler, data_cls, workflow_type
+):
+    """Test that cache.store_result works for ComponentModelerData.
+
+    The core issue: ComponentModelerData has a ``modeler`` attribute,
+    not ``simulation``.  ``store_result`` uses
+    ``getattr(stub_data, 'simulation', None)`` to obtain the simulation
+    object for hashing.  This returns None for modeler data, so the entry
+    is never stored.
+    """
+    modeler = make_modeler()
+    cache = resolve_local_cache(use_cache=True)
+    cache.clear()
+
+    # Create fake modeler data (mirrors real ModalComponentModelerData: no .simulation)
+    fake_data = _FakeComponentModelerStubData(modeler, data_cls)
+
+    # Write a dummy artifact file (store_result needs a file to copy)
+    artifact = tmp_path / f"{workflow_type.lower()}_dummy.hdf5"
+    artifact.write_text("dummy-payload")
+
+    # Try storing — this tests the core issue
+    stored = cache.store_result(
+        stub_data=fake_data,
+        task_id="test-task-123",
+        path=str(artifact),
+        workflow_type=workflow_type,
+    )
+
+    assert stored, (
+        "cache.store_result returned False for ComponentModelerData. "
+        "This likely means getattr(stub_data, 'simulation', None) returned None "
+        "because the attribute is 'modeler' not 'simulation'."
+    )
+    assert len(cache) == 1

--- a/tests/test_web/test_local_cache.py
+++ b/tests/test_web/test_local_cache.py
@@ -252,7 +252,13 @@ def fake_data(monkeypatch, basic_simulation):
     return calls
 
 
-def _patch_run_pipeline(monkeypatch):
+def _patch_run_pipeline(
+    monkeypatch,
+    task_type: str = "FDTD",
+    postprocess=None,
+    load_simulation_fn=None,
+    patch_autograd: bool = True,
+):
     """Patch upload, start, monitor, and download to avoid network calls and map sims."""
     counters = {"upload": 0, "start": 0, "monitor": 0, "download": 0}
     _reset_fake_maps()  # isolate between tests
@@ -275,8 +281,11 @@ def _patch_run_pipeline(monkeypatch):
 
     def _fake_upload(**kwargs):
         counters["upload"] += 1
-        task_id = f"{MOCK_TASK_ID}{kwargs['simulation']._hash_self()}"
         sim = _extract_simulation(kwargs)
+        if sim is not None:
+            task_id = f"{MOCK_TASK_ID}{sim._hash_self()}"
+        else:
+            task_id = f"{MOCK_TASK_ID}-{counters['upload']}"
         if sim is not None:
             TASK_TO_SIM[task_id] = sim
         return task_id
@@ -296,6 +305,8 @@ def _patch_run_pipeline(monkeypatch):
             PATH_TO_SIM[str(Path(path))] = sim
 
     def _fake_load_simulation(task_id, path="simulation.json", verbose=True):
+        if load_simulation_fn is not None:
+            return load_simulation_fn(task_id=task_id, path=path, verbose=verbose)
         sim = TASK_TO_SIM.get(task_id)
         if sim is None:
             sim = next(iter(PATH_TO_SIM.values()), None)
@@ -344,10 +355,11 @@ def _patch_run_pipeline(monkeypatch):
     def _fake_field_map_from_file(*args, **kwargs):
         return FieldMap(tracers=())
 
-    monkeypatch.setattr(io_utils, "download_file", _fake_download_file)
-    monkeypatch.setattr(autograd, "postprocess_fwd", _fake_postprocess_fwd)
-    monkeypatch.setattr(autograd, "postprocess_adj", _fake_postprocess_adj)
-    monkeypatch.setattr(FieldMap, "from_file", _fake_field_map_from_file)
+    if patch_autograd:
+        monkeypatch.setattr(io_utils, "download_file", _fake_download_file)
+        monkeypatch.setattr(autograd, "postprocess_fwd", _fake_postprocess_fwd)
+        monkeypatch.setattr(autograd, "postprocess_adj", _fake_postprocess_adj)
+        monkeypatch.setattr(FieldMap, "from_file", _fake_field_map_from_file)
     monkeypatch.setattr(WebContainer, "_check_folder", _fake__check_folder)
     monkeypatch.setattr(web, "upload", _fake_upload)
     monkeypatch.setattr(web, "start", _fake_start)
@@ -356,29 +368,27 @@ def _patch_run_pipeline(monkeypatch):
     monkeypatch.setattr(web, "load_simulation", _fake_load_simulation)
     monkeypatch.setattr(web, "estimate_cost", lambda *args, **kwargs: 0.0)
     monkeypatch.setattr(Job, "status", property(_fake_status))
-    monkeypatch.setattr(engine, "upload_sim_fields_keys", lambda *args, **kwargs: None)
+    if patch_autograd:
+        monkeypatch.setattr(engine, "upload_sim_fields_keys", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         web,
         "get_info",
         lambda task_id, verbose=True: type(
-            "_Info", (), {"solverVersion": "solver-1", "taskType": "FDTD"}
+            "_Info", (), {"solverVersion": "solver-1", "taskType": task_type}
         )(),
     )
+    if patch_autograd:
+        monkeypatch.setattr(
+            io_utils,
+            "get_info",
+            lambda task_id, verbose=True: type(
+                "_Info", (), {"solverVersion": "solver-1", "taskType": task_type}
+            )(),
+        )
+    if postprocess is not None:
+        monkeypatch.setattr(web.Tidy3dStubData, "postprocess", staticmethod(postprocess))
     monkeypatch.setattr(
-        io_utils,
-        "get_info",
-        lambda task_id, verbose=True: type(
-            "_Info", (), {"solverVersion": "solver-1", "taskType": "FDTD"}
-        )(),
-    )
-    monkeypatch.setattr(
-        web, "load_simulation", lambda task_id, *args, **kwargs: TASK_TO_SIM[task_id]
-    )
-    monkeypatch.setattr(
-        io_utils, "load_simulation", lambda task_id, *args, **kwargs: TASK_TO_SIM[task_id]
-    )
-    monkeypatch.setattr(
-        SimulationTask, "get", lambda *args, **kwargs: SimpleNamespace(taskType="FDTD")
+        SimulationTask, "get", lambda *args, **kwargs: SimpleNamespace(taskType=task_type)
     )
     monkeypatch.setattr(
         BatchTask, "detail", lambda *args, **kwargs: SimpleNamespace(status="success")

--- a/tidy3d/web/api/autograd/io_utils.py
+++ b/tidy3d/web/api/autograd/io_utils.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import tidy3d as td
 from tidy3d.components.autograd.field_map import FieldMap, TracerKeys
-from tidy3d.web.api.webapi import get_info, load_simulation
+from tidy3d.web.api.webapi import _load_simulation_via_tempfile, get_info
 from tidy3d.web.cache import resolve_local_cache
 from tidy3d.web.core.s3utils import download_file, upload_file  # type: ignore
 
@@ -14,6 +14,23 @@ from .constants import SIM_FIELDS_KEYS_FILE, SIM_VJP_FILE
 
 if TYPE_CHECKING:
     from tidy3d.components.autograd import AutogradFieldMap
+
+
+def _store_vjp_cache_entry(task_id_adj: str, field_map: FieldMap, *, artifact_path: str) -> None:
+    """Store adjoint VJP fields in the local cache when available."""
+    simulation_cache = resolve_local_cache()
+    if simulation_cache is None:
+        return
+    info = get_info(task_id_adj, verbose=False)
+    workflow_type = getattr(info, "taskType", None)
+    simulation = _load_simulation_via_tempfile(task_id_adj)
+    simulation_cache.store_result(
+        stub_data=field_map,
+        task_id=task_id_adj,
+        path=artifact_path,
+        workflow_type=workflow_type,
+        simulation=simulation,
+    )
 
 
 def upload_sim_fields_keys(
@@ -44,21 +61,7 @@ def get_vjp_traced_fields(task_id_adj: str, verbose: bool) -> AutogradFieldMap:
     try:
         download_file(task_id_adj, SIM_VJP_FILE, to_file=fname, verbose=verbose)
         field_map = FieldMap.from_file(fname)
-
-        simulation_cache = resolve_local_cache()
-        if simulation_cache is not None:
-            info = get_info(task_id_adj, verbose=False)
-            workflow_type = getattr(info, "taskType", None)
-            simulation = None
-            with tempfile.NamedTemporaryFile(suffix=".hdf5") as tmp_file:
-                simulation = load_simulation(task_id_adj, path=tmp_file.name, verbose=False)
-            simulation_cache.store_result(
-                stub_data=field_map,
-                task_id=task_id_adj,
-                path=fname,
-                workflow_type=workflow_type,
-                simulation=simulation,
-            )
+        _store_vjp_cache_entry(task_id_adj, field_map, artifact_path=fname)
     except Exception as e:
         td.log.error(f"Error occurred while getting VJP traced fields: {e}")
         raise e

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 import time
 from pathlib import Path
@@ -176,6 +177,19 @@ def _copy_simulation_data_from_cache_entry(entry: CacheEntry, path: PathLike) ->
         except Exception:
             return False
     return False
+
+
+def _load_simulation_via_tempfile(task_id: TaskId) -> Optional[WorkflowType]:
+    """Load a simulation into a temp file for cache bookkeeping (Windows-safe)."""
+    handle, fname = tempfile.mkstemp(suffix=".hdf5")
+    os.close(handle)
+    try:
+        return load_simulation(task_id, path=fname, verbose=False)
+    finally:
+        try:
+            os.unlink(fname)
+        except FileNotFoundError:
+            pass
 
 
 def restore_simulation_if_cached(
@@ -1175,8 +1189,7 @@ def load(
             simulation = None
             if lazy:  # get simulation via web to avoid unpacking of lazy object in store_result
                 try:
-                    with tempfile.NamedTemporaryFile(suffix=".hdf5") as tmp_file:
-                        simulation = load_simulation(task_id, path=tmp_file.name, verbose=False)
+                    simulation = _load_simulation_via_tempfile(task_id)
                 except Exception as e:
                     log.info(f"Failed to load simulation for storing results: {e}.")
                     return stub_data

--- a/tidy3d/web/cache.py
+++ b/tidy3d/web/cache.py
@@ -365,7 +365,12 @@ class LocalCache:
     def __len__(self) -> int:
         """Return number of valid cache entries."""
         with self._with_cache_state_lock():
-            count = self._load_stats().total_entries
+            stats = self._load_stats()
+            count = stats.total_entries
+            actual = sum(1 for _ in self._iter_entries())
+            if actual != count:
+                self._schedule_sync()
+                count = actual
         return count
 
     def _store(
@@ -676,7 +681,14 @@ class LocalCache:
             if simulation is not None:
                 simulation_obj = simulation
             else:
-                simulation_obj = getattr(stub_data, "simulation", None)
+                workflow_name = (
+                    workflow_type.value if isinstance(workflow_type, TaskType) else workflow_type
+                )
+                if workflow_name in {TaskType.MODAL_CM.value, TaskType.TERMINAL_CM.value}:
+                    # ComponentModelerData types use 'modeler' instead of 'simulation'
+                    simulation_obj = getattr(stub_data, "modeler", None)
+                else:
+                    simulation_obj = getattr(stub_data, "simulation", None)
                 if simulation_obj is None:
                     log.debug(
                         "Failed storing local cache entry: Could not find simulation data in stub_data."


### PR DESCRIPTION
supersedes https://github.com/flexcompute/tidy3d/pull/3249

Fix local cache storage for component modeler results by using the workflow type to select `modeler` vs `simulation` when building cache keys.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches caching key derivation and cache bookkeeping paths used by `web.run()` and autograd, so mistakes could cause unexpected cache misses/hits or stale stats, but changes are scoped and covered by new tests.
> 
> **Overview**
> Fixes local caching for `ModalComponentModeler`/`TerminalComponentModeler` results by teaching `LocalCache.store_result()` to derive the hash input from `stub_data.modeler` (instead of `stub_data.simulation`) for those workflow types.
> 
> Adds a Windows-safe helper (`_load_simulation_via_tempfile`) and reuses it when loading simulations solely for cache bookkeeping, including refactoring adjoint VJP caching into `_store_vjp_cache_entry`. Updates cache length reporting to self-heal when stats drift, and adds regression tests to ensure component modeler runs are cached and produce cache hits on identical reruns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3010b3e54462aa53207d668ac3ebb6ccc7a4c721. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->