### PR TITLE
FXC-5586: request EM Core review on ready PRs

### DIFF
--- a/.github/workflows/tidy3d-request-core-review.yml
+++ b/.github/workflows/tidy3d-request-core-review.yml
@@ -9,7 +9,6 @@ on:
       - synchronize
 
 permissions:
-  members: read
   pull-requests: write
 
 jobs:
@@ -20,6 +19,7 @@ jobs:
       - name: Request @flexcompute/core team review
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GH_PAT || github.token }}
           script: |
             const { owner, repo } = context.repo;
             const pull_number = context.payload.pull_request.number;

--- a/.github/workflows/tidy3d-request-core-review.yml
+++ b/.github/workflows/tidy3d-request-core-review.yml
@@ -6,8 +6,10 @@ on:
       - opened
       - reopened
       - ready_for_review
+      - synchronize
 
 permissions:
+  members: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/tidy3d-request-core-review.yml
+++ b/.github/workflows/tidy3d-request-core-review.yml
@@ -6,7 +6,6 @@ on:
       - opened
       - reopened
       - ready_for_review
-      - synchronize
 
 permissions:
   pull-requests: write
@@ -17,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Request @flexcompute/core team review
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GH_PAT || github.token }}
           script: |

--- a/.github/workflows/tidy3d-request-core-review.yml
+++ b/.github/workflows/tidy3d-request-core-review.yml
@@ -1,0 +1,54 @@
+name: Request EM Core Review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-core-review:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request @flexcompute/core team review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            const teamSlug = "core";
+
+            try {
+              const requested = await github.rest.pulls.listRequestedReviewers({
+                owner,
+                repo,
+                pull_number,
+              });
+
+              const alreadyRequested = (requested.data.teams || []).some(
+                (team) => team.slug === teamSlug,
+              );
+
+              if (alreadyRequested) {
+                core.info(`Team ${teamSlug} already requested for PR #${pull_number}.`);
+                return;
+              }
+
+              await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number,
+                team_reviewers: [teamSlug],
+              });
+
+              core.info(`Requested team ${teamSlug} review for PR #${pull_number}.`);
+            } catch (error) {
+              core.warning(
+                `Could not request team ${teamSlug} review for PR #${pull_number}: ${error.message}`,
+              );
+            }


### PR DESCRIPTION
## Summary
- add a workflow that requests `@flexcompute/core` team review for PRs
- trigger on `opened`, `reopened`, and `ready_for_review`
- skip draft PRs so review requests start once PRs are ready
- avoid duplicate requests if `core` is already in requested reviewers

## Why
- keep path-specific `CODEOWNERS` ownership intact
- ensure EM Core is consistently tagged for an optional code-quality pass

## Notes
- this does not make EM Core review mandatory
- uses `pull_request` trigger (not `pull_request_target`) to satisfy workflow security linting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that affects review automation, not runtime code; primary risk is noisy/incorrect review requests or token/permission misconfiguration.
> 
> **Overview**
> Automatically requests `@flexcompute/core` review via a new workflow (`.github/workflows/tidy3d-request-core-review.yml`) when PRs are `opened`, `reopened`, or `ready_for_review`, and skips draft PRs.
> 
> The workflow uses `actions/github-script` to check existing requested reviewers to avoid duplicate team requests, and logs a warning (without failing) if the reviewer request API call errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c60ddb43079c1bb22c7b599fcb6d3d749696d50f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->