### PR TITLE
fix: batch monitoring accuracy TCM (FXC-5314)

### DIFF
--- a/tests/test_web/test_local_cache.py
+++ b/tests/test_web/test_local_cache.py
@@ -374,7 +374,7 @@ def _patch_run_pipeline(
         web,
         "get_info",
         lambda task_id, verbose=True: type(
-            "_Info", (), {"solverVersion": "solver-1", "taskType": task_type}
+            "_Info", (), {"solverVersion": "solver-1", "taskType": task_type, "status": "success"}
         )(),
     )
     if patch_autograd:
@@ -382,7 +382,9 @@ def _patch_run_pipeline(
             io_utils,
             "get_info",
             lambda task_id, verbose=True: type(
-                "_Info", (), {"solverVersion": "solver-1", "taskType": task_type}
+                "_Info",
+                (),
+                {"solverVersion": "solver-1", "taskType": task_type, "status": "success"},
             )(),
         )
     if postprocess is not None:

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -86,6 +86,9 @@ class FakeJob:
         self.events.append((self.task_id, "status", status))
         return status
 
+    def get_info(self):
+        return SimpleNamespace(status=self.status)
+
     def download(self, path: PathLike):
         self.events.append((self.task_id, "download", str(path)))
 
@@ -864,6 +867,38 @@ def test_batch_monitor_skips_existing_download(monkeypatch, tmp_path):
     downloads = [event for event in events if event[1] == "download"]
 
     assert downloads == [("task_b_id", "download", os.path.join(str(tmp_path), "task_b_id.hdf5"))]
+
+
+def test_batch_monitor_skips_get_info_for_cached(monkeypatch, tmp_path):
+    """Cached jobs must not trigger get_info() remote calls during monitoring."""
+    events = []
+
+    monkeypatch.setattr("tidy3d.web.api.container.ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr("tidy3d.web.api.container.time.sleep", lambda *_args, **_kwargs: None)
+
+    class CachedFakeJob(FakeJob):
+        @property
+        def load_if_cached(self):
+            return True
+
+        def get_info(self):
+            raise AssertionError("get_info() should not be called for cached jobs")
+
+    sims = {"cached_task": make_sim(), "running_task": make_sim()}
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME, verbose=False)
+    batch._cached_properties = {}
+    fake_jobs = {
+        "cached_task": CachedFakeJob("cached_id", ["success"], events),
+        "running_task": FakeJob("running_id", ["running", "success", "success"], events),
+    }
+    batch._cached_properties["jobs"] = fake_jobs
+
+    batch.monitor(download_on_success=True, path_dir=str(tmp_path))
+
+    # Cached job would have raised AssertionError if get_info() was called.
+    # Verify the non-cached job still downloaded normally.
+    downloads = [e for e in events if e[1] == "download"]
+    assert any(e[0] == "running_id" for e in downloads)
 
 
 def test_batch_download_surfaces_download_errors(monkeypatch, tmp_path):

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -39,10 +39,11 @@ from tidy3d.web.api.states import (
     STATE_PROGRESS_PERCENTAGE,
 )
 from tidy3d.web.api.tidy3d_stub import Tidy3dStub
-from tidy3d.web.api.webapi import restore_simulation_if_cached
+from tidy3d.web.api.webapi import _batch_detail_progress, restore_simulation_if_cached
 from tidy3d.web.cache import _store_mode_solver_in_cache
 from tidy3d.web.core.constants import TaskId, TaskName
 from tidy3d.web.core.task_core import Folder
+from tidy3d.web.core.task_info import BatchDetail
 from tidy3d.web.core.types import PayType
 
 if TYPE_CHECKING:
@@ -1210,8 +1211,16 @@ class Batch(WebContainer):
                 for task_name, job in self.jobs.items():
                     schedule_download(job)
                     if self.verbose:
-                        status = job.status
-                        completed = STATE_PROGRESS_PERCENTAGE.get(status, 0)
+                        if job.load_if_cached:
+                            status = "success"
+                            completed = COMPLETED_PERCENT
+                        else:
+                            info = job.get_info()
+                            status = info.status
+                            if isinstance(info, BatchDetail):
+                                status, _, completed = _batch_detail_progress(info)
+                            else:
+                                completed = STATE_PROGRESS_PERCENTAGE.get(status, 0)
                         desc = pbar_description(task_name, status, max_name_length, 0)
                         pbar_tasks[task_name] = progress.add_task(
                             desc, total=COMPLETED_PERCENT, completed=completed
@@ -1219,13 +1228,18 @@ class Batch(WebContainer):
 
                 while any(check_continue_condition(job) for job in self.jobs.values()):
                     for task_name, job in self.jobs.items():
-                        status = job.status
+                        if job.load_if_cached:
+                            continue
+                        info = job.get_info()
+                        status = info.status
 
                         schedule_download(job)
 
                         if self.verbose:
                             # choose display status & percent
-                            if status != "run_success":
+                            if isinstance(info, BatchDetail):
+                                display_status, _, pct = _batch_detail_progress(info)
+                            elif status != "run_success":
                                 display_status = status
                                 pct = STATE_PROGRESS_PERCENTAGE.get(status, 0)
                             else:
@@ -1251,20 +1265,27 @@ class Batch(WebContainer):
                     schedule_download(job)
 
                     if self.verbose:
-                        status = job.status
-                        if status != "run_success":
-                            display_status = status
-                            pct = STATE_PROGRESS_PERCENTAGE.get(status, COMPLETED_PERCENT)
+                        if job.load_if_cached:
+                            display_status = "success"
+                            pct = COMPLETED_PERCENT
                         else:
-                            post_st = getattr(job, "postprocess_status", None)
-                            if post_st in END_STATES:
-                                display_status = post_st
-                                pct = STATE_PROGRESS_PERCENTAGE.get(post_st, COMPLETED_PERCENT)
+                            info = job.get_info()
+                            status = info.status
+                            if isinstance(info, BatchDetail):
+                                display_status, _, pct = _batch_detail_progress(info)
+                            elif status != "run_success":
+                                display_status = status
+                                pct = STATE_PROGRESS_PERCENTAGE.get(status, COMPLETED_PERCENT)
                             else:
-                                display_status = "postprocess"
-                                pct = STATE_PROGRESS_PERCENTAGE.get(
-                                    "postprocess", COMPLETED_PERCENT
-                                )
+                                post_st = getattr(job, "postprocess_status", None)
+                                if post_st in END_STATES:
+                                    display_status = post_st
+                                    pct = STATE_PROGRESS_PERCENTAGE.get(post_st, COMPLETED_PERCENT)
+                                else:
+                                    display_status = "postprocess"
+                                    pct = STATE_PROGRESS_PERCENTAGE.get(
+                                        "postprocess", COMPLETED_PERCENT
+                                    )
 
                         pbar = pbar_tasks[task_name]
                         desc = pbar_description(task_name, display_status, max_name_length, 0)

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -20,6 +20,7 @@ from tidy3d.exceptions import WebError
 from tidy3d.log import get_logging_console, log
 from tidy3d.web.api.states import (
     ALL_POST_VALIDATE_STATES,
+    COMPLETED_PERCENT,
     END_STATES,
     ERROR_STATES,
     MAX_STEPS,
@@ -1204,6 +1205,61 @@ def load(
     return stub_data
 
 
+def _batch_detail_progress(detail: BatchDetail) -> tuple[str, str, float]:
+    """Compute display status, color status, and progress % from BatchDetail subtasks.
+
+    Used by :meth:`Batch.monitor` to show accurate per-subtask progress for
+    jobs that are modeler batches (TCM / RF tasks).
+
+    Parameters
+    ----------
+    detail : BatchDetail
+        The detailed batch information including subtask statuses.
+
+    Returns
+    -------
+    tuple[str, str, float]
+        ``(display_status, color_status, progress_pct)`` where
+        *display_status* is a human-readable label (e.g. ``"queued (3/5)"``),
+        *color_status* is a canonical status for colour lookup in state sets,
+        and *progress_pct* is a percentage in ``[0, COMPLETED_PERCENT]``.
+    """
+    batch_status = (detail.status or "draft").lower()
+
+    if not detail.tasks:
+        return batch_status, batch_status, STATE_PROGRESS_PERCENTAGE.get(batch_status, 0)
+
+    if batch_status in END_STATES:
+        pct = STATE_PROGRESS_PERCENTAGE.get(batch_status, COMPLETED_PERCENT)
+        return batch_status, batch_status, pct
+
+    # Compute average progress from subtask stages
+    n = len(detail.tasks)
+    stage_acc = 0.0
+    status_counts: dict[str, int] = {}
+    for t in detail.tasks:
+        tstatus = (t.status or "draft").lower()
+        stage_name, idx = status_to_stage(tstatus)
+        stage_acc += idx / MAX_STEPS
+        status_counts[stage_name] = status_counts.get(stage_name, 0) + 1
+
+    task_avg = stage_acc / n
+    # 80 % from subtask average, final 20 % only on completion
+    # (consistent with _monitor_modeler_batch below)
+    pct = task_avg * 0.8 * COMPLETED_PERCENT
+
+    # Derive display status from most common subtask stage
+    dominant_stage = max(status_counts, key=status_counts.get)
+    dominant_count = status_counts[dominant_stage]
+
+    if n > 1 and dominant_count < n:
+        display_status = f"{dominant_stage} ({dominant_count}/{n})"
+    else:
+        display_status = dominant_stage
+
+    return display_status, dominant_stage, pct
+
+
 def _monitor_modeler_batch(
     task_id: str,
     verbose: bool = True,
@@ -1241,10 +1297,10 @@ def _monitor_modeler_batch(
     console.log(header)
     with Progress(*progress_columns, console=console, transient=False) as progress:
         # Phase: Run (aggregate + per-task)
-        stage = status_to_stage(status)[0]
-        p_run = progress.add_task("Run Total", total=1.0, status=f" {stage} ")
+        display_status, _, _ = _batch_detail_progress(detail)
+        p_run = progress.add_task("Run Total", total=1.0, status=f" {display_status} ")
         task_bars: dict[str, int] = {}
-        prev_stage = status_to_stage(status)[0]
+        prev_display_status = display_status
         console.log(f"Batch status = {status}")
 
         # Note: get_status errors if an erroring status occurred
@@ -1252,10 +1308,11 @@ def _monitor_modeler_batch(
         while not end_monitor:
             total = len(detail.tasks)
             r = detail.runSuccess or 0
-            if stage != prev_stage:
-                prev_stage = stage
-                console.log(f"Batch status = {stage}")
-                progress.update(p_run, status=f" {stage} ")
+            display_status, _, _ = _batch_detail_progress(detail)
+            if display_status != prev_display_status:
+                prev_display_status = display_status
+                console.log(f"Batch status = {display_status}")
+                progress.update(p_run, status=f" {display_status} ")
 
             # Create per-task bars as soon as tasks appear
             if total and total <= max_detail_tasks and detail.tasks:
@@ -1316,7 +1373,6 @@ def _monitor_modeler_batch(
             time.sleep(REFRESH_TIME)
             detail = _get_batch_detail_handle_error_status(task)
             status = detail.status.lower()
-            stage = status_to_stage(status)[0]
 
         if console is not None:
             console.log("Modeler has finished running successfully.")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches batch monitoring/polling logic and progress calculations, which could affect download scheduling and user-visible status display; changes are localized and covered by targeted tests.
> 
> **Overview**
> Improves `Batch.monitor()` progress reporting by switching verbose polling from `job.status` to `job.get_info()`, and by deriving progress for modeler batch (TCM/RF) jobs from `BatchDetail` subtask stages via new helper `_batch_detail_progress()`.
> 
> Also avoids remote `get_info()` calls for cached jobs during monitoring (treats them as immediately `success`), and updates tests/mocks to include `status` on `get_info` responses plus a new regression test asserting cached jobs don’t trigger `get_info()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd785f3990f4e620660cd620d153189513880f26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->