### PR TITLE
fix: 2d boundaries validator was running after grid is computed

### DIFF
--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -3095,6 +3095,9 @@ class Simulation(AbstractYeeGridSimulation):
             _ = val.wavelength_from_sources(sources=self.sources)
         return self
 
+    # Must run before validators that trigger grid computation
+    _boundaries_for_zero_dims = validate_boundaries_for_zero_dims()
+
     _sources_in_bounds = assert_objects_in_sim_bounds("sources", strict_inequality=True)
     _lumped_elements_in_bounds = assert_objects_contained_in_sim_bounds(
         "lumped_elements", error=False, strict_inequality=False, strict_for_zero_size_dim=True
@@ -6045,8 +6048,6 @@ class Simulation(AbstractYeeGridSimulation):
             medium=scene.medium,
             **kwargs,
         )
-
-    _boundaries_for_zero_dims = validate_boundaries_for_zero_dims()
 
     def padded_copy(
         self,


### PR DESCRIPTION
So a sneaky bug was introduced by the pydantic v2 migration and was causing one backend test to fail.

The 2d boundary validator has a side-effect: if the simulation has 0 size and absorbing boundaries along some dimension, it overwrites those boundaries to Periodic and issues a warning.

After the refactor, this was running only *after* the grid was computed by some other validators, and cached - causing it to be stored with the wrong number of grid cells (the pml boundaries were added).

The fix to move the validator up works, but this seems kind of flaky. I think in general we try to avoid such types of validators, but this was done to avoid a user annoyance where it was not straightforward to set a default 2D simulation (had to touch the boundary spec, which in many cases users don't have to touch).

What are we thinking going forward?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Pydantic validator ordering; behavior only changes for zero-size dimensions where boundaries are auto-normalized, but it can affect grid sizing/caching in those cases.
> 
> **Overview**
> Fixes validator ordering in `Simulation` so `validate_boundaries_for_zero_dims()` runs *before* any validators that may compute/cache the grid.
> 
> This prevents 2D/zero-thickness simulations with absorbing/PML boundaries from computing grid cells using the wrong (pre-normalized) boundary spec, avoiding incorrect cached grids and related backend test failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cd5bc22c6f964a7a9ef3fe986074c1c0813835f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->