### PR TITLE
FXC-0000: simplify testmon cache promotion path

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -334,6 +334,7 @@ jobs:
     needs: determine-test-scope
     if: needs.determine-test-scope.outputs.code_quality_tests == 'true'
     permissions:
+      contents: read
       security-events: write
     steps:
       - name: Checkout repository
@@ -345,9 +346,9 @@ jobs:
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
 
       - name: Run zizmor 🌈
-        run: uvx zizmor .github/workflows/*.y* --format=sarif . > results.sarif
+        run: uvx --from "zizmor==1.19.0" zizmor .github/workflows/*.y* --format=sarif . > results.sarif
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GH_TOKEN: ${{ github.token }}
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
@@ -356,9 +357,9 @@ jobs:
           category: zizmor
       
       - name: run zizmor directly  # this gets a success or fail result
-        run: uvx zizmor  .github/workflows/*.y*
+        run: uvx --from "zizmor==1.19.0" zizmor .github/workflows/*.y*
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GH_TOKEN: ${{ github.token }}
   
   lint-branch-name:
     needs: determine-test-scope
@@ -1337,25 +1338,6 @@ jobs:
       test_type: ${{ needs.determine-test-scope.outputs.test_type }}
     secrets: inherit # zizmor: ignore[secrets-inherit]
 
-  promote-testmon-cache:
-    name: promote-testmon-cache
-    needs:
-      - determine-test-scope
-      - local-tests
-      - remote-tests
-    if: >-
-      needs.determine-test-scope.outputs.local_tests == 'true' &&
-      needs.determine-test-scope.outputs.remote_tests == 'true' &&
-      github.event_name == 'merge_group' &&
-      needs.local-tests.result == 'success' &&
-      needs.remote-tests.result == 'success'
-    permissions:
-      actions: write
-      contents: read
-    with:
-      source_event: ${{ github.event_name }}
-    uses: ./.github/workflows/tidy3d-testmon-cache-promote.yml
-
   workflow-validation:
     name: workflow-validation
     if: always()
@@ -1374,7 +1356,6 @@ jobs:
       - verify-version-consistency
       - test-submodules
       - extras-integration-tests
-      - promote-testmon-cache
     runs-on: ubuntu-latest
     steps:
       - name: move-type-imports
@@ -1453,12 +1434,6 @@ jobs:
         if: ${{ needs.determine-test-scope.outputs.extras_integration_tests == 'true' && needs.extras-integration-tests.result != 'success' && needs.extras-integration-tests.result != 'skipped' }}
         run: |
           echo "❌ tidy3d-extras integration tests failed."
-          exit 1
-
-      - name: check-testmon-cache-promotion
-        if: ${{ github.event_name == 'merge_group' && needs.promote-testmon-cache.result != 'success' && needs.promote-testmon-cache.result != 'skipped' }}
-        run: |
-          echo "❌ Testmon cache promotion workflow failed."
           exit 1
 
       - name: all-checks-passed

--- a/.github/workflows/tidy3d-testmon-cache-promote.yml
+++ b/.github/workflows/tidy3d-testmon-cache-promote.yml
@@ -1,6 +1,13 @@
 name: "public/tidy3d/promote-testmon-cache"
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows:
+      - "public/tidy3d/python-client-tests"
+    types:
+      - completed
+    branches:
+      - "gh-readonly-queue/develop/**"
   workflow_call:
     inputs:
       source_event:
@@ -8,8 +15,8 @@ on:
         required: true
         type: string
       source_run_id:
-        description: "Optional run id for manual/backfill artifact downloads."
-        required: false
+        description: "Run id for artifact downloads."
+        required: true
         type: string
       allow_empty_candidates:
         description: "Allow zero cache candidate artifacts."
@@ -24,8 +31,8 @@ on:
         type: string
         default: merge_group
       source_run_id:
-        description: "Optional run id for manual/backfill artifact downloads."
-        required: false
+        description: "Run id for artifact downloads."
+        required: true
         type: string
       allow_empty_candidates:
         description: "Allow zero cache candidate artifacts."
@@ -39,40 +46,52 @@ permissions:
 
 jobs:
   discover-cache-candidates:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (
+        github.event.workflow_run.event == 'merge_group' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
     runs-on: ubuntu-latest
     outputs:
       candidates: ${{ steps.build-candidates.outputs.candidates }}
+      source_run_id: ${{ steps.resolve-caller-context.outputs.source_run_id }}
     steps:
-      - name: verify-caller-context
+      - name: resolve-caller-context
+        id: resolve-caller-context
         env:
-          SOURCE_EVENT: ${{ inputs.source_event }}
-          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          INPUT_SOURCE_EVENT: ${{ inputs.source_event }}
+          INPUT_SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
-          if [[ "$SOURCE_EVENT" != "merge_group" ]]; then
-            echo "::error::Expected source_event 'merge_group', got '$SOURCE_EVENT'."
-            exit 1
-          fi
-          if [[ -n "$SOURCE_RUN_ID" ]] && ! [[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]; then
-            echo "::error::source_run_id must be numeric when provided."
-            exit 1
+          source_event="${INPUT_SOURCE_EVENT:-}"
+          source_run_id="${INPUT_SOURCE_RUN_ID:-}"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_run" ]]; then
+            source_event="${WORKFLOW_RUN_EVENT:-}"
+            source_run_id="${WORKFLOW_RUN_ID:-}"
           fi
 
-      - name: download-cache-candidate-artifacts-current-run
-        if: inputs.source_run_id == ''
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          pattern: testmon-cache-candidate-*
-          path: cache-candidates
-          merge-multiple: false
+          echo "source_event=$source_event"
+          echo "source_run_id=$source_run_id"
+          if [[ "$source_event" != "merge_group" ]]; then
+            echo "::error::Expected source_event 'merge_group', got '$source_event'."
+            exit 1
+          fi
+          if ! [[ "$source_run_id" =~ ^[0-9]+$ ]]; then
+            echo "::error::source_run_id must be numeric."
+            exit 1
+          fi
+          echo "source_run_id=$source_run_id" >> "$GITHUB_OUTPUT"
 
       - name: download-cache-candidate-artifacts-source-run
-        if: inputs.source_run_id != ''
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
-          run-id: ${{ inputs.source_run_id }}
+          run-id: ${{ steps.resolve-caller-context.outputs.source_run_id }}
           pattern: testmon-cache-candidate-*
           path: cache-candidates
           merge-multiple: false
@@ -81,7 +100,7 @@ jobs:
         id: build-candidates
         env:
           ALLOW_EMPTY_CANDIDATES: ${{ inputs.allow_empty_candidates }}
-          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          SOURCE_RUN_ID: ${{ steps.resolve-caller-context.outputs.source_run_id }}
         run: |
           set -euo pipefail
           mapfile -t metadata_files < <(find cache-candidates -type f -name metadata.json | sort)
@@ -92,11 +111,7 @@ jobs:
               exit 0
             fi
             echo "::error::No cache candidate metadata artifacts found."
-            if [[ -n "$SOURCE_RUN_ID" ]]; then
-              echo "::error::Expected artifacts from source_run_id=$SOURCE_RUN_ID."
-            else
-              echo "::error::Expected artifacts from current workflow run."
-            fi
+            echo "::error::Expected artifacts from source_run_id=$SOURCE_RUN_ID."
             exit 1
           fi
 
@@ -127,7 +142,7 @@ jobs:
 
   promote-testmon-cache:
     needs: discover-cache-candidates
-    if: needs.discover-cache-candidates.outputs.candidates != '[]'
+    if: needs.discover-cache-candidates.result == 'success' && needs.discover-cache-candidates.outputs.candidates != '' && needs.discover-cache-candidates.outputs.candidates != '[]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -135,14 +150,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        candidate: ${{ fromJson(needs.discover-cache-candidates.outputs.candidates) }}
+        candidate: ${{ fromJson(needs.discover-cache-candidates.outputs.candidates || '[]') }}
     steps:
       - name: download-cache-candidate
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
-          run-id: ${{ inputs.source_run_id || github.run_id }}
+          run-id: ${{ needs.discover-cache-candidates.outputs.source_run_id }}
           name: ${{ matrix.candidate.artifact_name }}
           path: cache-candidate
 


### PR DESCRIPTION
## Summary
- remove in-run promotion (`promote-testmon-cache`) from `tidy3d-python-client-tests.yml` and its workflow-validation gate
- add a single promotion entrypoint triggered by `workflow_run` after successful `merge_group` runs
- simplify `tidy3d-testmon-cache-promote.yml` to always require and use `source_run_id` (source-run artifacts only)

## Why
- avoid cache promotion writes in merge-queue refs
- keep one deterministic promotion path instead of dual-path logic

## Validation
- `poetry run pre-commit run --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes alter CI control flow for cache promotion and rely on `workflow_run` context and artifact download behavior; misconfiguration could stop cache promotion or unexpectedly skip it, but production code is unaffected.
> 
> **Overview**
> **Testmon cache promotion is decoupled from the main CI workflow.** The `promote-testmon-cache` job and its `workflow-validation` gating were removed from `tidy3d-python-client-tests.yml`, so the test workflow no longer performs cache writes during merge-queue execution.
> 
> **Cache promotion is now a single, deterministic path.** `tidy3d-testmon-cache-promote.yml` is updated to run on `workflow_run` completion for the tests workflow (restricted to merge-queue branches) and to *always* resolve and require a numeric `source_run_id`, downloading artifacts only from that source run and guarding execution to successful `merge_group` runs from the same repo.
> 
> **CI hardening tweaks.** The `zizmor` job now pins `zizmor==1.19.0`, uses `${{ github.token }}` for `GH_TOKEN`, and explicitly sets `contents: read` permissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70b57e0bc286fdad5b93484b2c6f4eda7e5a790d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->