### PR TITLE
fix(tidy3d): SCRF-2777 validate AutoImpedanceSpec in ModeSolver for 2.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.3] - Unreleased
+
+### Fixed
+- Fixed `ModeSolver.validate_pre_upload` not validating `MicrowaveModeSpec` with `AutoImpedanceSpec`, causing cryptic server-side errors for invalid conductor geometries.
+
 ## [2.10.2] - 2026-01-21
 
 ### Added

--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -1281,6 +1281,57 @@ def test_mode_solver_with_microwave_mode_spec():
     )
 
 
+def test_mode_solver_validate_auto_impedance_spec():
+    """Test that ModeSolver.validate_pre_upload catches invalid AutoImpedanceSpec geometry."""
+    freq0 = 10e9
+    sim_size = (10 * mm, 10 * mm, 10 * mm)
+    plane_size = (0, 8 * mm, 8 * mm)
+
+    # Coaxial structure: axis-aligned bounding boxes of conductors overlap,
+    # which causes AutoImpedanceSpec setup to fail
+    coaxial = td.Structure(
+        geometry=td.GeometryGroup(
+            geometries=(
+                td.ClipOperation(
+                    operation="difference",
+                    geometry_a=td.Cylinder(
+                        axis=0, radius=2.5 * mm, center=(0, 0, 0), length=td.inf
+                    ),
+                    geometry_b=td.Cylinder(
+                        axis=0, radius=1.3 * mm, center=(0, 0, 0), length=td.inf
+                    ),
+                ),
+                td.Cylinder(axis=0, radius=1 * mm, center=(0, 0, 0), length=td.inf),
+            )
+        ),
+        medium=td.PEC,
+    )
+
+    mode_spec = td.MicrowaveModeSpec(
+        num_modes=2,
+        target_neff=1.8,
+        impedance_specs=(td.AutoImpedanceSpec(), td.AutoImpedanceSpec()),
+    )
+
+    sim = td.Simulation(
+        run_time=1e-9,
+        size=sim_size,
+        sources=[],
+        structures=[coaxial],
+        grid_spec=td.GridSpec.uniform(dl=0.1 * mm),
+    )
+
+    mode_solver = ModeSolver(
+        simulation=sim,
+        plane=td.Box(center=(0, 0, 0), size=plane_size),
+        mode_spec=mode_spec,
+        freqs=[freq0],
+    )
+
+    with pytest.raises(SetupError):
+        mode_solver.validate_pre_upload()
+
+
 def test_mode_solver_with_microwave_group_index():
     """Test that group_index calculation with MicrowaveModeSpec correctly filters frequencies."""
 

--- a/tidy3d/components/microwave/mode_spec.py
+++ b/tidy3d/components/microwave/mode_spec.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 import pydantic.v1 as pd
@@ -11,6 +11,7 @@ from tidy3d.components.base import cached_property
 from tidy3d.components.geometry.base import Box
 from tidy3d.components.geometry.bound_ops import bounds_contains
 from tidy3d.components.microwave.base import MicrowaveBaseModel
+from tidy3d.components.microwave.path_integrals.mode_plane_analyzer import ModePlaneAnalyzer
 from tidy3d.components.microwave.path_integrals.specs.impedance import (
     AutoImpedanceSpec,
     ImpedanceSpecType,
@@ -19,6 +20,12 @@ from tidy3d.components.mode_spec import AbstractModeSpec
 from tidy3d.components.types import annotate_type
 from tidy3d.constants import fp_eps
 from tidy3d.exceptions import SetupError
+
+if TYPE_CHECKING:
+    from tidy3d.components.grid.grid import Grid
+    from tidy3d.components.structure import Structure
+    from tidy3d.components.types import Coordinate, Size, Symmetry
+
 
 TEM_POLARIZATION_THRESHOLD = 0.995
 QTEM_POLARIZATION_THRESHOLD = 0.95
@@ -167,3 +174,32 @@ class MicrowaveModeSpec(AbstractModeSpec, MicrowaveBaseModel):
                         f"'{impedance_ind}' was provided with a {spec_type} path specification with bounds "
                         f"'{spec.bounds}', but the mode plane bounds are '{box.bounds}'."
                     )
+
+    def _validate_auto_impedance_setup(
+        self,
+        center: Coordinate,
+        size: Size,
+        colocate: bool,
+        volumetric_structures: list[Structure],
+        grid: Grid,
+        symmetry: tuple[Symmetry, Symmetry, Symmetry],
+        simulation_geometry: Box,
+        label: str = "",
+    ) -> None:
+        """Validate that auto impedance specification can be set up for the given mode plane."""
+        if not self._using_auto_current_spec:
+            return
+        mode_plane_analyzer = ModePlaneAnalyzer(
+            center=center,
+            size=size,
+            field_data_colocated=colocate,
+        )
+        try:
+            mode_plane_analyzer.get_conductor_bounding_boxes(
+                volumetric_structures,
+                grid,
+                symmetry,
+                simulation_geometry,
+            )
+        except SetupError as e:
+            raise SetupError(f"Failed to setup auto impedance specification{label}. {e!s}") from e

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -2721,9 +2721,26 @@ class ModeSolver(Tidy3dBaseModel):
                 "frequencies or modes."
             )
 
+    def _validate_auto_impedance_spec(self) -> None:
+        """Raise error if the microwave mode specification with ``AutoImpedanceSpec`` will
+        fail to instantiate."""
+        if not self._has_microwave_mode_spec:
+            return
+        self.mode_spec._validate_auto_impedance_setup(
+            center=self.plane.center,
+            size=self.plane.size,
+            colocate=self.colocate,
+            volumetric_structures=self.simulation.volumetric_structures,
+            grid=self.simulation.grid,
+            symmetry=self.simulation.symmetry,
+            simulation_geometry=self.simulation.simulation_geometry,
+            label=" for mode solver",
+        )
+
     def validate_pre_upload(self) -> None:
         """Validate the fully initialized mode solver is ok for upload to our servers."""
         self._validate_modes_size()
+        self._validate_auto_impedance_spec()
 
     @cached_property
     def reduced_simulation_copy(self):

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -84,7 +84,6 @@ from .medium import (
     PECMedium,
 )
 from .microwave.monitor import MicrowaveModeMonitor, MicrowaveModeSolverMonitor
-from .microwave.path_integrals.mode_plane_analyzer import ModePlaneAnalyzer
 from .monitor import (
     AbstractFieldProjectionMonitor,
     AbstractModeMonitor,
@@ -4743,21 +4742,16 @@ class Simulation(AbstractYeeGridSimulation):
             if not isinstance(monitor, (MicrowaveModeMonitor, MicrowaveModeSolverMonitor)):
                 continue
 
-            if monitor.mode_spec._using_auto_current_spec:
-                mode_plane_analyzer = ModePlaneAnalyzer(
-                    center=monitor.center, size=monitor.size, field_data_colocated=monitor.colocate
-                )
-                try:
-                    _ = mode_plane_analyzer.get_conductor_bounding_boxes(
-                        self.volumetric_structures,
-                        self.grid,
-                        self.symmetry,
-                        self.simulation_geometry,
-                    )
-                except SetupError as e:
-                    raise SetupError(
-                        f"Failed to setup auto impedance specification for monitor '{monitor.name}'. {e!s}"
-                    ) from e
+            monitor.mode_spec._validate_auto_impedance_setup(
+                center=monitor.center,
+                size=monitor.size,
+                colocate=monitor.colocate,
+                volumetric_structures=self.volumetric_structures,
+                grid=self.grid,
+                symmetry=self.symmetry,
+                simulation_geometry=self.simulation_geometry,
+                label=f" for monitor '{monitor.name}'",
+            )
 
     @cached_property
     def monitors_data_size(self) -> dict[str, float]:


### PR DESCRIPTION
## Summary
- Cherry-pick of SCRF-2777 fix from develop onto `v2.10.2` for a 2.10.3 patch
- Adds early validation of `AutoImpedanceSpec` in `ModeSolver.validate_pre_upload` so that microwave mode solver setup errors (e.g., "No valid isolated conductors found") are caught before upload rather than failing during preprocessing
- Moves the auto impedance validation logic from `Simulation` into `MicrowaveModeSpec._validate_auto_impedance_setup` so it can be shared by both `Simulation` and `ModeSolver`

## Test plan
- [ ] CI passes on patch branch
- [ ] Verify with SCRF-2777 reproduction case (microstrip line with wide ground plane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-upload validation behavior for `ModeSolver`/microwave monitors, which may surface new `SetupError`s earlier for previously-uploaded models; logic is localized to validation paths only.
> 
> **Overview**
> Adds client-side pre-upload validation for `MicrowaveModeSpec` when using `AutoImpedanceSpec` in `ModeSolver`, so invalid conductor geometries fail locally instead of producing cryptic server-side preprocessing errors.
> 
> Refactors the auto-impedance setup check into `MicrowaveModeSpec._validate_auto_impedance_setup` (reused by both `Simulation` monitor validation and the new `ModeSolver.validate_pre_upload` step), and adds a regression test covering the new early failure. Updates the changelog for `2.10.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff59e25dd688ee4e952e117b206853f74e01fb11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->