### PR TITLE
FXC-5469 fix(tidy3d): add discriminator to simulation type union fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved `ModeSolver.solve()` to suppress the accuracy warning when local subpixel averaging is enabled via `tidy3d-extras`, and expanded docstrings for `ModeSolver.solve()`, `ModeSimulation.run_local()`, `Simulation.epsilon()`, and `Simulation.epsilon_on_grid()` to document the `config.simulation.use_local_subpixel` option.
 - Fixed `ModeSolver.validate_pre_upload` not validating `MicrowaveModeSpec` with `AutoImpedanceSpec`, causing cryptic server-side errors for invalid conductor geometries.
 - Fixed local cache not storing results for `ModalComponentModeler` (and `TerminalComponentModeler`) runs, causing cache misses on repeated `web.run()` calls.
+- Fixed spurious `ModeSimulation` error logs during deserialization of `SimulationDataMap` by adding discriminators to `SimulationType` and `SimulationDataType` unions.
 
 ## [2.10.2] - 2026-01-21
 

--- a/tests/test_components/test_map.py
+++ b/tests/test_components/test_map.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 
 from tidy3d import SimulationMap
 
-from ..utils import SAMPLE_SIMULATIONS
+from ..utils import SAMPLE_SIMULATIONS, AssertLogStr
 
 # Reusable test constants
 SIM_MAP_DATA = {
@@ -55,3 +55,12 @@ def test_simulation_map_getitem_key_error():
     s_map = make_simulation_map()
     with pytest.raises(KeyError):
         _ = s_map["not_a_real_key"]
+
+
+def test_simulation_map_roundtrip_no_spurious_errors():
+    """Regression test for FXC-5469: deserializing SimulationMap should not
+    produce spurious ERROR logs from pydantic trying ModeSimulation validators."""
+    s_map = make_simulation_map()
+
+    with AssertLogStr("ERROR", excludes_str=""):
+        SimulationMap.model_validate(s_map.model_dump())

--- a/tests/test_data/test_map_data.py
+++ b/tests/test_data/test_map_data.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 
 from tidy3d import SimulationDataMap
 
-from ..utils import SAMPLE_SIMULATIONS, run_emulated
+from ..utils import SAMPLE_SIMULATIONS, AssertLogStr, run_emulated
 
 # Reusable test constants
 # Base simulation data is needed to generate the SimulationData objects
@@ -64,3 +64,12 @@ def test_simulation_data_map_getitem_key_error():
     sd_map = make_simulation_data_map()
     with pytest.raises(KeyError):
         _ = sd_map["not_a_real_key"]
+
+
+def test_simulation_data_map_roundtrip_no_spurious_errors():
+    """Regression test for FXC-5469: deserializing SimulationDataMap should not
+    produce spurious ERROR logs from pydantic trying ModeSimulation validators."""
+    sd_map = make_simulation_data_map()
+
+    with AssertLogStr("ERROR", excludes_str=""):
+        SimulationDataMap.model_validate(sd_map.model_dump())

--- a/tidy3d/components/data/index.py
+++ b/tidy3d/components/data/index.py
@@ -10,6 +10,7 @@ from collections.abc import Mapping
 from pydantic import Field
 
 from tidy3d.components.index import ValueMap
+from tidy3d.components.types.base import discriminated_union
 from tidy3d.components.types.simulation import SimulationDataType
 
 
@@ -104,7 +105,7 @@ class SimulationDataMap(ValueMap, Mapping[str, SimulationDataType]):
         description="A tuple of unique string identifiers for each simulation data object.",
         alias="keys",
     )
-    values_tuple: tuple[SimulationDataType, ...] = Field(
+    values_tuple: tuple[discriminated_union(SimulationDataType), ...] = Field(
         description=(
             "A tuple of `SimulationDataType` objects, each corresponding to a key at the "
             "same index."

--- a/tidy3d/components/index.py
+++ b/tidy3d/components/index.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import Field, model_validator
 
 from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.types.base import discriminated_union
 from tidy3d.components.types.simulation import SimulationType
 
 if TYPE_CHECKING:
@@ -200,7 +201,7 @@ class SimulationMap(ValueMap, Mapping[str, SimulationType]):
     keys_tuple: tuple[str, ...] = Field(
         description="A tuple of unique string identifiers for each simulation.", alias="keys"
     )
-    values_tuple: tuple[SimulationType, ...] = Field(
+    values_tuple: tuple[discriminated_union(SimulationType), ...] = Field(
         description=(
             "A tuple of `Simulation` objects, each corresponding to a key at the same index."
         ),


### PR DESCRIPTION
Addresses FXC-5469: https://flow360.atlassian.net/browse/FXC-5469

Adds `discriminated_union()` to the `values_tuple` fields of `SimulationMap` and `SimulationDataMap` so pydantic v2 uses the `type` tag to select the correct union variant directly, preventing spurious `ModeSimulation` error logs during deserialization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Pydantic model field typing for `SimulationMap`/`SimulationDataMap`, which can affect validation/serialization behavior across many call sites. Change is small and targeted to union parsing/log noise, but should be watched for any schema or backward-compatibility edge cases.
> 
> **Overview**
> Prevents noisy/spurious pydantic v2 `ERROR` logs during `SimulationMap`/`SimulationDataMap` round-trip deserialization by switching their `values_tuple` fields to use `discriminated_union(...)` over `SimulationType`/`SimulationDataType`.
> 
> Adds regression tests asserting no `ERROR` logs are emitted during `model_dump()`/`model_validate()` roundtrips, and records the fix in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e688eb968efb0f5f62390cf371842a389a282086. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->