### PR TITLE
fix(adjoint): optional argument for postprocess_adj for backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved `ModeSolver.solve()` to suppress the accuracy warning when local subpixel averaging is enabled via `tidy3d-extras`, and expanded docstrings for `ModeSolver.solve()`, `ModeSimulation.run_local()`, `Simulation.epsilon()`, and `Simulation.epsilon_on_grid()` to document the `config.simulation.use_local_subpixel` option.
 - Fixed `ModeSolver.validate_pre_upload` not validating `MicrowaveModeSpec` with `AutoImpedanceSpec`, causing cryptic server-side errors for invalid conductor geometries.
 - Fixed local cache not storing results for `ModalComponentModeler` (and `TerminalComponentModeler`) runs, causing cache misses on repeated `web.run()` calls.
+- Fixed `custom_vjp` in `postprocess_adj` in adjoint pipeline to be optional argument for backend integration.
 
 ## [2.10.2] - 2026-01-21
 

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -283,7 +283,6 @@ def use_emulated_run(monkeypatch):
                 sim_data_orig=sim_data_orig,
                 sim_data_fwd=sim_data_fwd,
                 sim_fields_keys=sim_fields_keys,
-                custom_vjp=None,
             )
 
             return traced_fields_vjp

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -1331,7 +1331,7 @@ def postprocess_adj(
     sim_data_orig: td.SimulationData,
     sim_data_fwd: td.SimulationData,
     sim_fields_keys: list[tuple],
-    custom_vjp: tuple[CustomVJPConfig, ...],
+    custom_vjp: Optional[tuple[CustomVJPConfig, ...]] = None,
 ) -> AutogradFieldMap:
     """Postprocess adjoint results into VJPs (delegated)."""
     return _postprocess_adj_impl(


### PR DESCRIPTION
Optional argument for when this is imported by the backend for the adjoint pipeline

updated emulated_run in unit test to catch a regression for this

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small signature change with a safe default; risk is limited to potential downstream callers that relied on the parameter being required.
> 
> **Overview**
> Allows backend integrations to call `postprocess_adj` without providing a `custom_vjp` hook by making the parameter optional (default `None`).
> 
> Updates the autograd emulation unit test to omit `custom_vjp=None`, ensuring the backward pass still succeeds when the argument is not supplied, and records the fix in the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d97fbd1e4cd488b6d004450898c24687f3b8f30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->