### PR TITLE
fix(adjoint): optional argument for postprocess_adj for backend

### DIFF
--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -283,7 +283,6 @@ def use_emulated_run(monkeypatch):
                 sim_data_orig=sim_data_orig,
                 sim_data_fwd=sim_data_fwd,
                 sim_fields_keys=sim_fields_keys,
-                custom_vjp=None,
             )
 
             return traced_fields_vjp

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -869,7 +869,7 @@ def _run_primitive(
     aux_data: dict,
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
-    custom_vjp: Optional[Union[CustomVJPConfig, tuple[CustomVJPConfig, ...]]] = None,
+    custom_vjp: Optional[tuple[CustomVJPConfig, ...]],
     **run_kwargs: Any,
 ) -> AutogradFieldMap:
     """Autograd-traced 'run()' function: runs simulation, strips tracer data, caches fwd data."""
@@ -938,7 +938,7 @@ def _run_async_primitive(
     aux_data_dict: dict[str, dict[str, Any]],
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
-    custom_vjp: Optional[dict[str, Sequence[CustomVJPConfig]]] = None,
+    custom_vjp: Optional[dict[str, Sequence[CustomVJPConfig]]],
     **run_async_kwargs: Any,
 ) -> dict[str, AutogradFieldMap]:
     task_names = sim_fields_dict.keys()
@@ -1044,7 +1044,7 @@ def _run_bwd(
     aux_data: dict,
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
-    custom_vjp: tuple[CustomVJPConfig, ...],
+    custom_vjp: Optional[tuple[CustomVJPConfig, ...]],
     **run_kwargs: Any,
 ) -> Callable[[AutogradFieldMap], AutogradFieldMap]:
     """VJP-maker for ``_run_primitive()``. Constructs and runs adjoint simulations, computes grad."""
@@ -1171,7 +1171,7 @@ def _run_async_bwd(
     aux_data_dict: dict[str, dict[str, Any]],
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
-    custom_vjp: Optional[dict[str, Sequence[CustomVJPConfig]]] = None,
+    custom_vjp: Optional[dict[str, Sequence[CustomVJPConfig]]],
     **run_async_kwargs: Any,
 ) -> Callable[[dict[str, AutogradFieldMap]], dict[str, AutogradFieldMap]]:
     """VJP-maker for ``_run_primitive()``. Constructs and runs adjoint simulation, computes grad."""
@@ -1331,7 +1331,7 @@ def postprocess_adj(
     sim_data_orig: td.SimulationData,
     sim_data_fwd: td.SimulationData,
     sim_fields_keys: list[tuple],
-    custom_vjp: tuple[CustomVJPConfig, ...],
+    custom_vjp: Optional[tuple[CustomVJPConfig, ...]] = None,
 ) -> AutogradFieldMap:
     """Postprocess adjoint results into VJPs (delegated)."""
     return _postprocess_adj_impl(


### PR DESCRIPTION
Optional argument for when this is imported by the backend for the adjoint pipeline

updated emulated_run in unit test to catch a regression for this

(reposting because of error in branch name for jira)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type/signature and default-argument adjustments in adjoint postprocessing with a targeted regression test; no algorithmic changes to gradient computation.
> 
> **Overview**
> Makes `custom_vjp` optional throughout the autograd adjoint pipeline so `postprocess_adj()` can be called without explicitly passing a value (defaulting to no custom VJP overrides).
> 
> Updates autograd primitive/backward function type signatures accordingly, and tightens the emulated autograd unit test to cover the regression by calling `postprocess_adj` without `custom_vjp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b646e734d4ee3a7e4b040800bcb1fa3a4bf8f13e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->