### PR TITLE
fix(adjoint): update EpsType typing in DerivativInfo

### DIFF
--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import numpy as np
 from numpy.typing import NDArray
 
-from tidy3d.components.data.data_array import FreqDataArray, ScalarFieldDataArray
+from tidy3d.components.data.data_array import ScalarFieldDataArray
 from tidy3d.components.data.utils import _zeros_like
 from tidy3d.components.types import ArrayLike, Bound
 from tidy3d.config import config
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 FieldDataDict = dict[str, ScalarFieldDataArray]
 PermittivityData = dict[str, ScalarFieldDataArray]
-EpsType = FreqDataArray
+EpsType = ScalarFieldDataArray
 ArrayFloat = NDArray[np.floating]
 ArrayComplex = NDArray[np.complexfloating]
 


### PR DESCRIPTION
thanks @marcorudolphflex for catching this mismatch! 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-alias/import change only; no runtime logic or numerical behavior is modified.
> 
> **Overview**
> Updates `DerivativeInfo` permittivity typing by removing `FreqDataArray` usage and redefining `EpsType` to `ScalarFieldDataArray`, aligning `eps_in`/`eps_out` annotations with the actual data structures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d4ac2e9d9a8ccda9c1ccdd07e8f188dc9b167d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->