### PR TITLE
Seed develop-scoped testmon caches on push

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -2,7 +2,11 @@ name: "public/tidy3d/python-client-tests"
 
 on:
   merge_group:
-  
+
+  push:
+    branches:
+      - develop
+
   workflow_dispatch:
     inputs:
       remote_tests:
@@ -211,6 +215,13 @@ jobs:
               local_tests=true
               code_quality_tests=true
               pr_review_tests=true
+              test_selection="testmon"
+          fi
+
+          # Seed develop-scoped caches post-merge without extra quality gates.
+          if [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/develop" ]]; then
+              local_tests=true
+              remote_tests=true
               test_selection="testmon"
           fi
 
@@ -840,7 +851,11 @@ jobs:
         retention-days: 1
 
     - name: save-testmon-cache
-      if: success() && github.event_name == 'merge_group' && steps.testmon-cache-restore.outputs.cache-hit != 'true' && hashFiles('.testmondata') != ''
+      if: >-
+        success() &&
+        (github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/develop')) &&
+        steps.testmon-cache-restore.outputs.cache-hit != 'true' &&
+        hashFiles('.testmondata') != ''
       uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: .testmondata
@@ -1139,7 +1154,11 @@ jobs:
         retention-days: 1
 
     - name: save-testmon-cache
-      if: success() && github.event_name == 'merge_group' && steps.testmon-cache-restore.outputs.cache-hit != 'true' && hashFiles('.testmondata') != ''
+      if: >-
+        success() &&
+        (github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/develop')) &&
+        steps.testmon-cache-restore.outputs.cache-hit != 'true' &&
+        hashFiles('.testmondata') != ''
       uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: .testmondata


### PR DESCRIPTION
## Summary
- add a `push` trigger on `develop` in `tidy3d-python-client-tests.yml`
- in `determine-test-scope`, enable `local_tests` and `remote_tests` with `test_selection=testmon` for `push` on `refs/heads/develop`
- allow `save-testmon-cache` to run on `push` to `develop` in both local and remote test jobs (in addition to `merge_group`)

## Why
PR and merge-queue runs were restoring keys that target `develop`, but cache inventory showed testmon caches being written on queue refs, not `refs/heads/develop`. This change seeds develop-scoped caches after merges so future PR restores can hit branch-allowed cache scope.

## Validation
- reviewed workflow diff for trigger + conditions
- `git diff --check` passed
- `actionlint` unavailable in local shell (`actionlint not installed`)

## Follow-up checks after merge
- confirm `repos/{owner}/{repo}/actions/caches?ref=refs/heads/develop` returns testmon cache entries
- confirm next PR `pull_request` run reports non-miss cache telemetry
