### PR TITLE
fix(ci): ensure testmon promotion triggers for merge queue runs

### DIFF
--- a/.github/workflows/tidy3d-testmon-cache-promote.yml
+++ b/.github/workflows/tidy3d-testmon-cache-promote.yml
@@ -7,6 +7,7 @@ on: # zizmor: ignore[dangerous-triggers]
     types:
       - completed
     branches:
+      - develop
       - "gh-readonly-queue/develop/**"
   workflow_call:
     inputs:


### PR DESCRIPTION
## Summary
- broaden `workflow_run` branch filters in `tidy3d-testmon-cache-promote.yml` to include `develop` in addition to `gh-readonly-queue/develop/**`

## Why
The promotion workflow is intended to run after successful `merge_group` runs of `public/tidy3d/python-client-tests`, but the existing branch filter may be too restrictive depending on how GitHub resolves `workflow_run` branch matching for merge queue runs.

This keeps the no-rerun architecture and avoids adding any `push`-triggered test execution.

## Scope / Safety
- no changes to `tidy3d-python-client-tests.yml`
- no new test jobs, no duplicated CI test runs
- promotion workflow logic/jobs unchanged (only event branch matching expanded)

## Validation plan
1. Wait for next successful merge-group completion.
2. Confirm `public/tidy3d/promote-testmon-cache` creates a run.
3. Confirm `actions/caches?ref=refs/heads/develop` shows `testmon-*` entries.
