### PR TITLE
fix(ci): make promoted testmon caches restorable by test jobs

### DIFF
--- a/.github/workflows/tidy3d-testmon-cache-promote.yml
+++ b/.github/workflows/tidy3d-testmon-cache-promote.yml
@@ -181,11 +181,14 @@ jobs:
             exit 1
           fi
 
+      - name: stage-testmon-cache
+        run: cp cache-candidate/.testmondata .testmondata
+
       - name: lookup-existing-cache
         id: cache-lookup
         uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
-          path: cache-candidate/.testmondata
+          path: .testmondata
           key: ${{ matrix.candidate.cache_key }}
           lookup-only: true
 
@@ -193,7 +196,7 @@ jobs:
         if: steps.cache-lookup.outputs.cache-hit != 'true'
         uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
-          path: cache-candidate/.testmondata
+          path: .testmondata
           key: ${{ matrix.candidate.cache_key }}
 
       - name: report-existing-cache


### PR DESCRIPTION
## Summary
- fix a cache-version mismatch between `python-client-tests` and `promote-testmon-cache`
- keep candidate artifact handling unchanged (`cache-candidate/.testmondata`)
- stage candidate cache into repo-root `.testmondata` before cache restore/save
- use `.testmondata` as the `actions/cache` path in promotion workflow

## Why
`python-client-tests` restores/saves testmon cache at `.testmondata`, but promotion was restoring/saving at `cache-candidate/.testmondata`.

For `actions/cache`, path contributes to cache versioning. Same key with different path can still be non-restorable by consumers that use a different path.

Observed symptoms after successful promotions:
- develop cache entries existed and were actively accessed
- PR runs still reported telemetry misses (`exact=0`, `fallback=0`)

Relevant runs:
- Promotion success: https://github.com/flexcompute/tidy3d/actions/runs/21940929984
- Post-promotion PR misses: https://github.com/flexcompute/tidy3d/actions/runs/21943020494 and https://github.com/flexcompute/tidy3d/actions/runs/21943599827

## Scope
- only `.github/workflows/tidy3d-testmon-cache-promote.yml`
- no trigger changes
- no added/removed test jobs

## Validation
- `git diff --check`
- actionlint unavailable in local shell

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only workflow change that adjusts cache file paths; main risk is reduced cache hits if the staging step or path assumptions are wrong.
> 
> **Overview**
> Fixes a cache-version mismatch in `tidy3d-testmon-cache-promote.yml` by staging the candidate artifact’s `cache-candidate/.testmondata` into repo-root `.testmondata` and using that path for `actions/cache` lookup/save.
> 
> This keeps artifact validation/download unchanged while ensuring promoted caches match the path used by the test workflows, avoiding promotions that can’t be restored despite identical keys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d725049e44b8972eb6a359dd6aeaf40a53d7ff5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->