### PR TITLE
chore: fix formatting and clarity in charge docs

### DIFF
--- a/changelog.d/3285.changed.md
+++ b/changelog.d/3285.changed.md
@@ -1,0 +1,1 @@
+Improved charge simulation documentation: clarified 2D vs 3D output units, added unit metadata to monitor data fields, and fixed docstring formatting and formula inaccuracies across TCAD components.

--- a/docs/api/charge/index.rst
+++ b/docs/api/charge/index.rst
@@ -8,7 +8,6 @@ Charge |:zap:|
     mediums
     boundary_conditions
     source
-    discretization
     monitor
     output_data
 
@@ -17,6 +16,5 @@ Charge |:zap:|
 .. include:: /api/charge/mediums.rst
 .. include:: /api/charge/boundary_conditions.rst
 .. include:: /api/charge/source.rst
-.. include:: /api/charge/discretization.rst
 .. include:: /api/charge/monitor.rst
 .. include:: /api/charge/output_data.rst

--- a/docs/api/charge/mediums.rst
+++ b/docs/api/charge/mediums.rst
@@ -60,7 +60,7 @@ Bandgap
 
 
 Effective Density Of States (DOS)
-^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autosummary::
    :toctree: ../_autosummary/
@@ -72,7 +72,7 @@ Effective Density Of States (DOS)
    tidy3d.DualValleyEffectiveDOS
 
 Energy Bandgap
-^^^^^^^^
+^^^^^^^^^^^^^^
 
 .. autosummary::
    :toctree: ../_autosummary/

--- a/docs/api/charge/output_data.rst
+++ b/docs/api/charge/output_data.rst
@@ -3,6 +3,25 @@
 Output Data
 -------------
 
+.. important::
+   **2D vs 3D simulations and units.**
+   Charge simulations can be 2D (one ``size`` component is 0) or 3D.
+   In 2D mode, the solver treats the geometry as a cross-section with
+   infinite extrusion depth. Extensive output quantities (current,
+   capacitance, resistance) are therefore reported **per unit length**
+   (:math:`\mu\text{m}`). For example:
+
+   - Current: :math:`\text{A}` (3D) :math:`\rightarrow` :math:`\text{A}/\mu\text{m}` (2D)
+   - Capacitance: :math:`\text{fF}` (3D) :math:`\rightarrow` :math:`\text{fF}/\mu\text{m}` (2D)
+   - Resistance: :math:`\Omega` (3D) :math:`\rightarrow` :math:`\Omega \cdot \mu\text{m}` (2D)
+
+   Intensive quantities (potential, carrier concentration, electric
+   field, energy bands) keep the same units regardless of
+   dimensionality.
+
+   To convert a 2D result to a total device quantity, multiply by
+   the physical device depth in micrometers.
+
 
 Simulation Data
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/api/charge/source.rst
+++ b/docs/api/charge/source.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: tidy3d
 
-Thermal Sources
------------------
+Charge-Heat Coupled Sources
+-----------------------------
 
 .. autosummary::
    :toctree: ../_autosummary/

--- a/tidy3d/components/material/tcad/charge.py
+++ b/tidy3d/components/material/tcad/charge.py
@@ -120,8 +120,9 @@ class SemiconductorMedium(AbstractChargeMedium):
             q \\frac{\\partial p}{\\partial t} = -\\nabla \\cdot \\mathbf{J_p} - qR
         \\end{equation}
 
-    As well as iso-thermal, the system is considered to be at :math:`T=300`. This restriction will
-    be removed in future releases.
+    The system defaults to isothermal conditions at :math:`T=300 \\text{K}`.
+    Non-isothermal (self-heating) simulations can be enabled via appropriate
+    analysis specifications (e.g., ``SteadyChargeDCAnalysis``).
 
     The above system requires the definition of the flux functions (free carrier current density), :math:`\\mathbf{J_n}` and
     :math:`\\mathbf{J_p}`. We consider the usual form
@@ -246,9 +247,9 @@ class SemiconductorMedium(AbstractChargeMedium):
     -------
         Current limitations of the formulation include:
 
-        - Boltzmann statistics are supported
-        - Iso-thermal equations with :math:`T=300K`
-        - Steady state only
+        - Boltzmann statistics by default; Fermi-Dirac statistics available
+        - Isothermal by default at T=300K; self-heating available through analysis spec
+        - Steady-state DC and small-signal AC analyses supported
         - Dopants are considered to be fully ionized
 
     Note

--- a/tidy3d/components/tcad/bandgap.py
+++ b/tidy3d/components/tcad/bandgap.py
@@ -25,17 +25,18 @@ class SlotboomBandGapNarrowing(Tidy3dBaseModel):
 
         Note that :math:`N_{tot}` is the total doping as defined within a :class:`SemiconductorMedium`.
 
-        Example
-        -------
-            >>> import tidy3d as td
-            >>> default_Si = td.SlotboomBandGapNarrowing(
-            ...    v1=6.92 * 1e-3,
-            ...    n2=1.3e17,
-            ...    c2=0.5,
-            ...    min_N=1e15,
-            ... )
+        .. [1] 'UNIFIED APPARENT BANDGAP NARROWING IN n- AND p-TYPE SILICON' Solid-State Electronics Vol. 35, No. 2, pp. 125-129, 1992
 
-        .. [1] 'UNIFIED APPARENT BANDGAP NARROWING IN n- AND p-TYPE SILICON' Solid-State Electronics Vol. 35, No. 2, pp. 125-129, 1992"""
+    Example
+    -------
+        >>> import tidy3d as td
+        >>> default_Si = td.SlotboomBandGapNarrowing(
+        ...    v1=6.92 * 1e-3,
+        ...    n2=1.3e17,
+        ...    c2=0.5,
+        ...    min_N=1e15,
+        ... )
+    """
 
     v1: PositiveFloat = Field(
         title=":math:`V_{1,bgn}` parameter",

--- a/tidy3d/components/tcad/bandgap_energy.py
+++ b/tidy3d/components/tcad/bandgap_energy.py
@@ -39,9 +39,9 @@ class VarshniEnergyBandGap(Tidy3dBaseModel):
     ... )
 
     References
-    -------
+    ----------
 
-        Varshni, Y. P. (1967). Temperature dependence of the energy gap in semiconductors. Physica, 34(1), 149-154.
+        .. [1] Varshni, Y. P. (1967). Temperature dependence of the energy gap in semiconductors. Physica, 34(1), 149-154.
 
     """
 

--- a/tidy3d/components/tcad/boundary/charge.py
+++ b/tidy3d/components/tcad/boundary/charge.py
@@ -62,7 +62,7 @@ class InsulatingBC(HeatChargeBC):
 
         Ensures the electric potential to the normal :math:`\\nabla \\psi \\cdot \\mathbf{n}  = 0` as well as the
         surface recombination current density :math:`J_s = \\mathbf{J} \\cdot \\mathbf{n} = 0` are set to zero where
-        the current density is :math:`\\mathbf{J_n}` and the normal vector is :math:`\\mathbf{n}`
+        the current density is :math:`\\mathbf{J}` and the normal vector is :math:`\\mathbf{n}`
 
     Example
     -------

--- a/tidy3d/components/tcad/data/monitor_data/charge.py
+++ b/tidy3d/components/tcad/data/monitor_data/charge.py
@@ -53,6 +53,7 @@ class SteadyPotentialData(HeatChargeMonitorData):
         None,
         title="Electric potential series",
         description="Contains the electric potential series.",
+        json_schema_extra={"units": "V"},
     )
 
     @property
@@ -81,6 +82,7 @@ class SteadyFreeCarrierData(HeatChargeMonitorData):
         None,
         title="Electrons series",
         description=r"Contains the computed electrons concentration :math:`n`.",
+        json_schema_extra={"units": "1/cm^3"},
     )
     # n = electrons
 
@@ -88,6 +90,7 @@ class SteadyFreeCarrierData(HeatChargeMonitorData):
         None,
         title="Holes series",
         description=r"Contains the computed holes concentration :math:`p`.",
+        json_schema_extra={"units": "1/cm^3"},
     )
     # p = holes
 
@@ -154,30 +157,35 @@ class SteadyEnergyBandData(HeatChargeMonitorData):
         None,
         title="Conduction band series",
         description="Contains the computed energy of the bottom of the conduction band :math:`E_c`.",
+        json_schema_extra={"units": "eV"},
     )
 
     Ev: Optional[UnstructuredFieldType] = Field(
         None,
         title="Valence band series",
         description="Contains the computed energy of the top of the valence band :math:`E_v`.",
+        json_schema_extra={"units": "eV"},
     )
 
     Ei: Optional[UnstructuredFieldType] = Field(
         None,
         title="Intrinsic Fermi level series",
         description="Contains the computed intrinsic Fermi level for the material :math:`E_i`.",
+        json_schema_extra={"units": "eV"},
     )
 
     Efn: Optional[UnstructuredFieldType] = Field(
         None,
         title="Electron's quasi-Fermi level series",
         description="Contains the computed quasi-Fermi level for electrons :math:`E_{fn}`.",
+        json_schema_extra={"units": "eV"},
     )
 
     Efp: Optional[UnstructuredFieldType] = Field(
         None,
         title="Hole's quasi-Fermi level series",
         description="Contains the computed quasi-Fermi level for holes :math:`E_{fp}`.",
+        json_schema_extra={"units": "eV"},
     )
 
     @property
@@ -305,14 +313,18 @@ class SteadyCapacitanceData(HeatChargeMonitorData):
     hole_capacitance: Optional[SteadyVoltageDataArray] = Field(
         None,
         title="Hole capacitance",
-        description="Small signal capacitance :math:`(\\frac{dQ_p}{dV})` associated to the monitor.",
+        description="Small signal capacitance :math:`(\\frac{dQ_p}{dV})` associated to the monitor. "
+        "Units: fF (3D) or fF/μm (2D, per unit length).",
+        json_schema_extra={"units": "fF"},
     )
     # C_p = hole_capacitance
 
     electron_capacitance: Optional[SteadyVoltageDataArray] = Field(
         None,
         title="Electron capacitance",
-        description="Small signal capacitance :math:`(\\frac{dQn}{dV})` associated to the monitor.",
+        description="Small signal capacitance :math:`(\\frac{dQn}{dV})` associated to the monitor. "
+        "Units: fF (3D) or fF/μm (2D, per unit length).",
+        json_schema_extra={"units": "fF"},
     )
     # C_n = electron_capacitance
 
@@ -393,8 +405,8 @@ class SteadyElectricFieldData(HeatChargeMonitorData):
 
 class SteadyCurrentDensityData(HeatChargeMonitorData):
     """
-    Stores current density :math:`\\vec{J}` from a Charge/Conduction simulation. It is given in
-    units of :math:`A/\\mu m^2`
+    Stores current density :math:`\\vec{J}` from a Charge/Conduction simulation.
+    Units: :math:`A/\\mu m^2` (3D) or :math:`A/\\mu m` (2D, per unit length).
     """
 
     monitor: SteadyCurrentDensityMonitor = Field(

--- a/tidy3d/components/tcad/data/sim_data.py
+++ b/tidy3d/components/tcad/data/sim_data.py
@@ -108,20 +108,29 @@ class DeviceCharacteristics(Tidy3dBaseModel):
         None,
         title="Steady DC hole capacitance",
         description="Device steady DC capacitance data based on holes. If the simulation "
-        "has converged, these result should be close to that of electrons.",
+        "has converged, these result should be close to that of electrons. "
+        "Units: fF (3D) or fF/μm (2D). For 2D simulations, multiply by the device depth "
+        "to obtain the total capacitance.",
+        json_schema_extra={"units": "fF"},
     )
 
     steady_dc_electron_capacitance: Optional[SteadyVoltageDataArray] = Field(
         None,
         title="Steady DC electron capacitance",
         description="Device steady DC capacitance data based on electrons. If the simulation "
-        "has converged, these result should be close to that of holes.",
+        "has converged, these result should be close to that of holes. "
+        "Units: fF (3D) or fF/μm (2D). For 2D simulations, multiply by the device depth "
+        "to obtain the total capacitance.",
+        json_schema_extra={"units": "fF"},
     )
 
     steady_dc_current_voltage: Optional[SteadyVoltageDataArray] = Field(
         None,
         title="Steady DC current-voltage",
-        description="Device steady DC current-voltage relation for the device.",
+        description="Device steady DC current-voltage relation for the device. "
+        "Units: A (3D) or A/μm (2D). For 2D simulations, multiply by the device depth "
+        "to obtain the total current.",
+        json_schema_extra={"units": "A"},
     )
 
     steady_dc_resistance_voltage: Optional[SteadyVoltageDataArray] = Field(
@@ -129,7 +138,9 @@ class DeviceCharacteristics(Tidy3dBaseModel):
         title="Small signal resistance",
         description="Steady DC computation of the small signal resistance. This is computed "
         "as the derivative of the current-voltage relation :math:`\\frac{\\Delta V}{\\Delta I}`, and the result "
-        "is given in Ohms. Note that in 2D the resistance is given in :math:`\\Omega \\mu`.",
+        "is given in Ohms. In 2D the resistance is given in :math:`\\Omega \\cdot \\mu\\text{m}`. "
+        "For 2D simulations, multiply by the device depth (in μm) to obtain the resistance in Ω.",
+        json_schema_extra={"units": "Ω"},
     )
 
     ac_current_voltage: Optional[FreqVoltageDataArray] = Field(
@@ -138,7 +149,9 @@ class DeviceCharacteristics(Tidy3dBaseModel):
         description="Small-signal AC current as a function of DC bias voltage and frequency. "
         "This complex-valued data :math:`I(v, f)` is computed from small-signal analysis and "
         "can be used to determine frequency-dependent device parameters like admittance. "
-        "For 2D simulations, the units are :math:`A/{\\mu m}`, so scale by device width.",
+        "Units: A (3D) or A/μm (2D). For 2D simulations, multiply by the device depth "
+        "(extrusion length) to obtain the total current.",
+        json_schema_extra={"units": "A"},
     )
 
 

--- a/tidy3d/components/tcad/effective_DOS.py
+++ b/tidy3d/components/tcad/effective_DOS.py
@@ -51,7 +51,7 @@ class IsotropicEffectiveDOS(EffectiveDOS):
 
     .. math::
 
-        \\mathbf{N_eff} = 2 * (\\frac{m_eff * m_e * k_B T}{2 \\pi \\hbar^2})^(3/2)
+        N_{\\text{eff}} = 2 \\left( \\frac{m_{\\text{eff}} \\cdot m_e \\cdot k_B T}{2 \\pi \\hbar^2} \\right)^{3/2}
 
     """
 

--- a/tidy3d/components/tcad/generation_recombination.py
+++ b/tidy3d/components/tcad/generation_recombination.py
@@ -134,7 +134,7 @@ class RadiativeRecombination(Tidy3dBaseModel):
 
         .. math::
 
-            R_{\\text{rad}} = C \\left( np - n_0 p_0 \\right)
+            R_{\\text{rad}} = C \\cdot n \\cdot p
 
     Example
     -------
@@ -221,7 +221,7 @@ class DistributedGeneration(Tidy3dBaseModel):
     rate: SpatialDataArray = Field(
         title="Generation rate",
         description="Spatially varying generation rate.",
-        json_schema_extra={"units": "1/(cm^3 s^1)"},
+        json_schema_extra={"units": "1/(cm^3 s)"},
     )
 
     @classmethod

--- a/tidy3d/components/tcad/mobility.py
+++ b/tidy3d/components/tcad/mobility.py
@@ -62,7 +62,7 @@ class CaugheyThomasMobility(Tidy3dBaseModel):
          - ``mu_min``
          - Minimum low-field mobility for :math:`n` and :math:`p`
        * - :math:`\\mu_{max}`
-         - ``mu_n``
+         - ``mu``
          - Maximum low-field mobility for :math:`n` and :math:`p`
        * - :math:`\\alpha_1`
          - ``exp_1``
@@ -73,6 +73,9 @@ class CaugheyThomasMobility(Tidy3dBaseModel):
        * - :math:`\\alpha_N`
          - ``exp_N``
          - Exponent for doping dependence.
+       * - :math:`\\alpha_3`
+         - ``exp_3``
+         - Exponent for the temperature dependence of the reference doping
        * - :math:`\\alpha_4`
          - ``exp_4``
          - Exponent for the temperature dependence of the exponent :math:`\\alpha_N`

--- a/tidy3d/components/tcad/monitors/charge.py
+++ b/tidy3d/components/tcad/monitors/charge.py
@@ -44,8 +44,8 @@ class SteadyFreeCarrierMonitor(HeatChargeMonitor):
     Example
     -------
     >>> import tidy3d as td
-    >>> voltage_monitor_z0 = td.SteadyFreeCarrierMonitor(
-    ... center=(0, 0.14, 0), size=(0.6, 0.3, 0), name="voltage_z0", unstructured=True,
+    >>> carrier_monitor_z0 = td.SteadyFreeCarrierMonitor(
+    ... center=(0, 0.14, 0), size=(0.6, 0.3, 0), name="carrier_z0", unstructured=True,
     ... )
     """
 

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -213,16 +213,16 @@ class HeatChargeSimulation(AbstractSimulation):
     Currently, this solver supports steady-state heat conduction where :math:`q` is the heat flux, :math:`k`
     is the thermal conductivity, and :math:`T` is the temperature.
 
-         .. math::
+    .. math::
 
-            -\\nabla \\cdot (-k \\nabla T) = q
+        -\\nabla \\cdot (-k \\nabla T) = q
 
     It is also possible to run transient heat simulations by specifying ``analysis_spec=UnsteadyHeatAnalysis(...)``. This adds
     the temporal terms to the above equations:
 
-        .. math::
+    .. math::
 
-            \\frac{\\partial \\rho c_p T}{\\partial t} -\\nabla \\cdot (k \\nabla(T)) = q
+        \\frac{\\partial \\rho c_p T}{\\partial t} -\\nabla \\cdot (k \\nabla(T)) = q
 
     where :math:`\\rho` is the density and :math:`c_p` is the specific heat capacity of the medium.
 
@@ -231,9 +231,9 @@ class HeatChargeSimulation(AbstractSimulation):
     medium, and the electric field (:math:`\\mathbf{E} = -\\nabla(\\psi)`) derived from electrical potential (:math:`\\psi`).
     Currently, in this type of simulation, no current sources or sinks are supported.
 
-        .. math::
+    .. math::
 
-            \\text{div}(\\sigma \\cdot \\nabla(\\psi)) = 0
+        \\text{div}(\\sigma \\cdot \\nabla(\\psi)) = 0
 
 
     For further details on what equations are solved in ``Charge`` simulations, refer to the :class:`SemiconductorMedium`.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily documentation and schema metadata changes; minimal behavioral risk aside from potential downstream consumers relying on `json_schema_extra` or docstring-rendered content.
> 
> **Overview**
> **Improves Charge/TCAD documentation clarity and unit reporting.** The charge API docs now explicitly document 2D vs 3D output units (per-unit-length scaling in 2D) and remove the unused `discretization` page from the charge docs index.
> 
> Docstrings across TCAD components were cleaned up (headings/formatting, corrected formulas, updated examples/limitations text), and several monitor/simulation data fields now include `json_schema_extra` unit metadata plus clearer unit descriptions for capacitance/current/resistance and carrier/band quantities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f48ea6c905419bf8a1dbf2e706da56976df89b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->