### PR TITLE
fix(ci): promote testmon cache with runner-compatible saves

### DIFF
--- a/.github/workflows/tidy3d-testmon-cache-promote.yml
+++ b/.github/workflows/tidy3d-testmon-cache-promote.yml
@@ -119,11 +119,49 @@ jobs:
           for metadata_file in "${metadata_files[@]}"; do
             artifact_name=$(basename "$(dirname "$metadata_file")")
             cache_key=$(jq -r '.cache_key // empty' "$metadata_file")
+            job_class=$(jq -r '.job_class // empty' "$metadata_file")
+            runner_os=$(jq -r '.runner_os // empty' "$metadata_file")
+            platform=$(jq -r '.platform // empty' "$metadata_file")
             if [[ -z "$cache_key" ]]; then
               echo "::warning::Skipping ${artifact_name}; metadata missing cache_key."
               continue
             fi
-            candidate_rows+=("$(jq -cn --arg artifact_name "$artifact_name" --arg cache_key "$cache_key" '{artifact_name: $artifact_name, cache_key: $cache_key}')")
+
+            runner_spec_json=""
+            runner_family=""
+            case "$job_class" in
+              local)
+                if [[ "$runner_os" != "Linux" ]]; then
+                  echo "::warning::Skipping ${artifact_name}; unsupported local runner_os '$runner_os'."
+                  continue
+                fi
+                runner_spec_json='["slurm-runner","4xcpu","container=ghcr.io/astral-sh/uv:debian"]'
+                runner_family="local-self-hosted-linux"
+                ;;
+              remote)
+                case "$platform" in
+                  ubuntu-latest|macos-latest|windows-latest)
+                    runner_spec_json=$(jq -cn --arg platform "$platform" '$platform')
+                    runner_family="$platform"
+                    ;;
+                  *)
+                    echo "::warning::Skipping ${artifact_name}; unsupported remote platform '$platform'."
+                    continue
+                    ;;
+                esac
+                ;;
+              *)
+                echo "::warning::Skipping ${artifact_name}; unsupported job_class '$job_class'."
+                continue
+                ;;
+            esac
+
+            candidate_rows+=("$(jq -cn \
+              --arg artifact_name "$artifact_name" \
+              --arg cache_key "$cache_key" \
+              --arg runner_spec_json "$runner_spec_json" \
+              --arg runner_family "$runner_family" \
+              '{artifact_name: $artifact_name, cache_key: $cache_key, runner_spec_json: $runner_spec_json, runner_family: $runner_family}')")
           done
 
           if [[ "${#candidate_rows[@]}" -eq 0 ]]; then
@@ -143,7 +181,7 @@ jobs:
   promote-testmon-cache:
     needs: discover-cache-candidates
     if: needs.discover-cache-candidates.result == 'success' && needs.discover-cache-candidates.outputs.candidates != '' && needs.discover-cache-candidates.outputs.candidates != '[]'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJson(matrix.candidate.runner_spec_json) }}
     permissions:
       contents: read
       actions: write
@@ -181,12 +219,18 @@ jobs:
             exit 1
           fi
 
-      - name: stage-testmon-cache
+      - name: stage-testmon-cache-unix
+        if: runner.os != 'Windows'
         run: cp cache-candidate/.testmondata .testmondata
+
+      - name: stage-testmon-cache-windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Copy-Item -Path "cache-candidate/.testmondata" -Destination ".testmondata" -Force
 
       - name: lookup-existing-cache
         id: cache-lookup
-        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: .testmondata
           key: ${{ matrix.candidate.cache_key }}
@@ -194,7 +238,7 @@ jobs:
 
       - name: save-promoted-testmon-cache
         if: steps.cache-lookup.outputs.cache-hit != 'true'
-        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: .testmondata
           key: ${{ matrix.candidate.cache_key }}
@@ -204,3 +248,25 @@ jobs:
         env:
           CACHE_KEY: ${{ matrix.candidate.cache_key }}
         run: echo "Cache already present for key '$CACHE_KEY'; skipping save."
+
+      - name: verify-promoted-cache-lookup
+        id: verify-cache-lookup
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: .testmondata
+          key: ${{ matrix.candidate.cache_key }}
+          lookup-only: true
+
+      - name: enforce-promoted-cache-availability
+        if: steps.verify-cache-lookup.outputs.cache-hit != 'true'
+        env:
+          CACHE_KEY: ${{ matrix.candidate.cache_key }}
+          RUNNER_FAMILY: ${{ matrix.candidate.runner_family }}
+          CACHE_HIT: ${{ steps.verify-cache-lookup.outputs.cache-hit }}
+          CACHE_MATCHED_KEY: ${{ steps.verify-cache-lookup.outputs.cache-matched-key }}
+        run: |
+          echo "::error::Promoted cache is not restorable on runner family '$RUNNER_FAMILY'."
+          echo "::error::cache_key=$CACHE_KEY"
+          echo "::error::cache_hit=$CACHE_HIT"
+          echo "::error::cache_matched_key=$CACHE_MATCHED_KEY"
+          exit 1

--- a/.github/workflows/tidy3d-testmon-cache-promote.yml
+++ b/.github/workflows/tidy3d-testmon-cache-promote.yml
@@ -200,6 +200,7 @@ jobs:
           path: cache-candidate
 
       - name: validate-cache-candidate
+        shell: bash
         env:
           EXPECTED_CACHE_KEY: ${{ matrix.candidate.cache_key }}
           ARTIFACT_NAME: ${{ matrix.candidate.artifact_name }}
@@ -259,6 +260,7 @@ jobs:
 
       - name: enforce-promoted-cache-availability
         if: steps.verify-cache-lookup.outputs.cache-hit != 'true'
+        shell: bash
         env:
           CACHE_KEY: ${{ matrix.candidate.cache_key }}
           RUNNER_FAMILY: ${{ matrix.candidate.runner_family }}


### PR DESCRIPTION
## Summary
- make cache promotion runner-compatible by selecting promotion runner family from candidate metadata
- align promotion cache action pins with test workflow (`actions/cache` v5)
- keep promoted cache path at `.testmondata`
- add post-promotion restore lookup gate to fail if promoted cache is not immediately restorable on that runner family

## Why
We observed repeated cache misses with matching keys because promoted entries had incompatible cache `version` values versus source merge-group caches.

The mismatch was systemic across runner families (local self-hosted, remote ubuntu/macos/windows), not self-hosted-only.

## Changes
In `.github/workflows/tidy3d-testmon-cache-promote.yml`:
- enrich candidate matrix rows with:
  - `runner_spec_json`
  - `runner_family`
- run each `promote-testmon-cache` matrix job on its compatible runner:
  - local candidates -> `['slurm-runner','4xcpu','container=ghcr.io/astral-sh/uv:debian']`
  - remote candidates -> `${platform}` (`ubuntu-latest`, `macos-latest`, `windows-latest`)
- use `actions/cache/restore` and `actions/cache/save` v5 pins (same as python-client-tests)
- add `verify-promoted-cache-lookup` + `enforce-promoted-cache-availability` gate
- force bash shell for bash-scripted validation/enforcement steps to avoid Windows shell parsing issues

## Pre-merge validation path
Use workflow dispatch on this branch with a known successful merge-group source run:

- Workflow: `public/tidy3d/promote-testmon-cache`
- Inputs:
  - `source_event=merge_group`
  - `source_run_id=<merge_group_run_id>`

The run should only pass when each promoted candidate is restorable on its own runner family.

## Validation done
- `git diff --check`
- YAML parse check via Ruby `YAML.load_file`
- Manual dispatch run on this branch:
  - `21955062404` (cancelled intentionally due unavailable self-hosted capacity)
  - all remote promotion jobs succeeded (ubuntu/macos/windows)
  - local self-hosted jobs remained queued (capacity), so full local-path validation remains pending runner availability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only change but it alters cache promotion/restore behavior across multiple runner platforms and can introduce new workflow failures if runner metadata is missing or mismatched.
> 
> **Overview**
> Makes Testmon cache promotion *runner-family aware* by enriching discovered cache candidates with runner metadata and running each promotion job on a compatible `runs-on` spec (local self-hosted Linux vs `ubuntu/macos/windows-latest`).
> 
> Upgrades promotion to `actions/cache` v5 pins, adds OS-specific staging for `.testmondata` (Windows vs Unix), forces `bash` for scripted validation, and adds a post-save restore lookup gate that fails the workflow if the promoted cache cannot be restored on that runner family.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bd2ec159d55bef534dd4c3f82e042557566a161. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->