### PR TITLE
fix order of execution test failure in test_viz for applying flex style

### DIFF
--- a/tests/test_components/test_viz.py
+++ b/tests/test_components/test_viz.py
@@ -8,8 +8,13 @@ import pytest
 from pydantic import ValidationError
 
 import tidy3d as td
+import tidy3d.components.viz as viz
 from tidy3d import Box, Medium, Simulation, Structure
-from tidy3d.components.viz import Polygon, restore_matplotlib_rcparams, set_default_labels_and_title
+from tidy3d.components.viz import (
+    Polygon,
+    flex_style,
+    set_default_labels_and_title,
+)
 from tidy3d.constants import inf
 from tidy3d.exceptions import Tidy3dKeyError
 
@@ -334,10 +339,25 @@ def test_sim_plot_structures_fill():
         assert patch.get_facecolor() != "none", "Face color should be set"
 
 
-def test_tidy3d_matplotlib_style_application_on_import():
-    """Test restore_matplotlib_rcparams() to reset the automatically applied matplotlib.rcParams"""
+def test_tidy3d_matplotlib_style_application_on_import(monkeypatch):
+    """Test that lazy application and manual restoration of rcParams works."""
+
+    # 1. Reset Matplotlib to factory defaults for this test
+    mpl.rcdefaults()
+
+    # 2. Monkeypatch the internal flags to simulate a 'never-applied' state
+    monkeypatch.setattr(viz, "_tidy3d_style_applied", False)
+    monkeypatch.setattr(flex_style, "_ORIGINAL_PARAMS", None)
+    # 3. Trigger the lazy application logic
+    viz._ensure_tidy3d_style()
+
+    # 4. Verify the style was applied
     assert mpl.rcParams.get("axes.prop_cycle").by_key()["color"][0] == "#176737"
-    restore_matplotlib_rcparams()
+
+    # 5. Test the restoration logic
+    viz.restore_matplotlib_rcparams()
+
+    # 6. Verify it's back to default
     assert (
         mpl.rcParams.get("axes.prop_cycle").by_key()["color"][0]
         == mpl.rcParamsDefault.get("axes.prop_cycle").by_key()["color"][0]


### PR DESCRIPTION
the test before was working if the lazy application of the matplotlib parameters was happening before this test ran

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adjusts setup/teardown around Matplotlib rcParams to remove ordering dependence; no production logic changes.
> 
> **Overview**
> Updates `test_tidy3d_matplotlib_style_application_on_import` to be order-independent by resetting Matplotlib defaults, forcing `tidy3d.components.viz` into a “style not yet applied” state via `monkeypatch`, explicitly invoking `viz._ensure_tidy3d_style()`, then validating both the applied palette and `viz.restore_matplotlib_rcparams()` reverting to defaults.
> 
> The test now imports `tidy3d.components.viz`/`flex_style` directly instead of relying on side effects from earlier imports, reducing flakiness from lazy style initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16d3618392a5ea5a436ebc30c3fa6636812c6ad4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->