### PR TITLE
feat(geometry): add arc segment support to PolySlab with bulges

### DIFF
--- a/changelog.d/3288.added.md
+++ b/changelog.d/3288.added.md
@@ -1,0 +1,1 @@
+Added `bulges` parameter to `PolySlab` geometry for defining arc segments in 2D polygon cross-sections using the standard bulge convention (bulge = tan(theta/4)), enabling curved edges between vertices.

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -1765,6 +1765,23 @@
           ],
           "type": "integer"
         },
+        "bulges": {
+          "anyOf": [
+            {
+              "type": "ArrayLike",
+              "x-array-dtype": "<f8",
+              "x-array-forbid_nan": true,
+              "x-array-ndim": 1,
+              "x-array-scalar_to_1d": true,
+              "x-array-shape": null,
+              "x-array-strict": false
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "dilation": {
           "default": 0.0,
           "type": "number"
@@ -10272,6 +10289,23 @@
             2
           ],
           "type": "integer"
+        },
+        "bulges": {
+          "anyOf": [
+            {
+              "type": "ArrayLike",
+              "x-array-dtype": "<f8",
+              "x-array-forbid_nan": true,
+              "x-array-ndim": 1,
+              "x-array-scalar_to_1d": true,
+              "x-array-shape": null,
+              "x-array-strict": false
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "dilation": {
           "default": 0.0,

--- a/schemas/HeatChargeSimulation.json
+++ b/schemas/HeatChargeSimulation.json
@@ -1095,6 +1095,23 @@
           ],
           "type": "integer"
         },
+        "bulges": {
+          "anyOf": [
+            {
+              "type": "ArrayLike",
+              "x-array-dtype": "<f8",
+              "x-array-forbid_nan": true,
+              "x-array-ndim": 1,
+              "x-array-scalar_to_1d": true,
+              "x-array-shape": null,
+              "x-array-strict": false
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "dilation": {
           "default": 0.0,
           "type": "number"
@@ -7122,6 +7139,23 @@
             2
           ],
           "type": "integer"
+        },
+        "bulges": {
+          "anyOf": [
+            {
+              "type": "ArrayLike",
+              "x-array-dtype": "<f8",
+              "x-array-forbid_nan": true,
+              "x-array-ndim": 1,
+              "x-array-scalar_to_1d": true,
+              "x-array-shape": null,
+              "x-array-strict": false
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "dilation": {
           "default": 0.0,

--- a/schemas/HeatSimulation.json
+++ b/schemas/HeatSimulation.json
@@ -1095,6 +1095,23 @@
           ],
           "type": "integer"
         },
+        "bulges": {
+          "anyOf": [
+            {
+              "type": "ArrayLike",
+              "x-array-dtype": "<f8",
+              "x-array-forbid_nan": true,
+              "x-array-ndim": 1,
+              "x-array-scalar_to_1d": true,
+              "x-array-shape": null,
+              "x-array-strict": false
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "dilation": {
           "default": 0.0,
           "type": "number"
@@ -7122,6 +7139,23 @@
             2
           ],
           "type": "integer"
+        },
+        "bulges": {
+          "anyOf": [
+            {
+              "type": "ArrayLike",
+              "x-array-dtype": "<f8",
+              "x-array-forbid_nan": true,
+              "x-array-ndim": 1,
+              "x-array-scalar_to_1d": true,
+              "x-array-shape": null,
+              "x-array-strict": false
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "dilation": {
           "default": 0.0,

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -1967,6 +1967,23 @@
           ],
           "type": "integer"
         },
+        "bulges": {
+          "anyOf": [
+            {
+              "type": "ArrayLike",
+              "x-array-dtype": "<f8",
+              "x-array-forbid_nan": true,
+              "x-array-ndim": 1,
+              "x-array-scalar_to_1d": true,
+              "x-array-shape": null,
+              "x-array-strict": false
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "dilation": {
           "default": 0.0,
           "type": "number"
@@ -10039,6 +10056,23 @@
             2
           ],
           "type": "integer"
+        },
+        "bulges": {
+          "anyOf": [
+            {
+              "type": "ArrayLike",
+              "x-array-dtype": "<f8",
+              "x-array-forbid_nan": true,
+              "x-array-ndim": 1,
+              "x-array-scalar_to_1d": true,
+              "x-array-shape": null,
+              "x-array-strict": false
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "dilation": {
           "default": 0.0,

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -2407,6 +2407,23 @@
           ],
           "type": "integer"
         },
+        "bulges": {
+          "anyOf": [
+            {
+              "type": "ArrayLike",
+              "x-array-dtype": "<f8",
+              "x-array-forbid_nan": true,
+              "x-array-ndim": 1,
+              "x-array-scalar_to_1d": true,
+              "x-array-shape": null,
+              "x-array-strict": false
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "dilation": {
           "default": 0.0,
           "type": "number"
@@ -13484,6 +13501,23 @@
             2
           ],
           "type": "integer"
+        },
+        "bulges": {
+          "anyOf": [
+            {
+              "type": "ArrayLike",
+              "x-array-dtype": "<f8",
+              "x-array-forbid_nan": true,
+              "x-array-ndim": 1,
+              "x-array-scalar_to_1d": true,
+              "x-array-shape": null,
+              "x-array-strict": false
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "dilation": {
           "default": 0.0,

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -2497,6 +2497,23 @@
           ],
           "type": "integer"
         },
+        "bulges": {
+          "anyOf": [
+            {
+              "type": "ArrayLike",
+              "x-array-dtype": "<f8",
+              "x-array-forbid_nan": true,
+              "x-array-ndim": 1,
+              "x-array-scalar_to_1d": true,
+              "x-array-shape": null,
+              "x-array-strict": false
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "dilation": {
           "default": 0.0,
           "type": "number"
@@ -13794,6 +13811,23 @@
             2
           ],
           "type": "integer"
+        },
+        "bulges": {
+          "anyOf": [
+            {
+              "type": "ArrayLike",
+              "x-array-dtype": "<f8",
+              "x-array-forbid_nan": true,
+              "x-array-ndim": 1,
+              "x-array-scalar_to_1d": true,
+              "x-array-shape": null,
+              "x-array-strict": false
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "dilation": {
           "default": 0.0,

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -26,6 +26,7 @@ import tidy3d as td
 from tidy3d.compat import _package_is_older_than
 from tidy3d.components.geometry.base import cleanup_shapely_object
 from tidy3d.components.geometry.mesh import AREA_SIZE_THRESHOLD
+from tidy3d.components.geometry.polyslab import _PolyBulgeUtil
 from tidy3d.components.geometry.utils import (
     SnapBehavior,
     SnapLocation,
@@ -46,6 +47,12 @@ GEO_INF = td.Box(size=(1, 1, td.inf))
 BOX = td.Box(size=(1, 1, 1))
 BOX_2D = td.Box(size=(1, 0, 1))
 POLYSLAB = td.PolySlab(vertices=((0, 0), (1, 0), (1, 1), (0, 1)), slab_bounds=(-0.5, 0.5), axis=2)
+POLYSLAB_ARC = td.PolySlab(
+    vertices=((0, 0), (1, 0), (1, 1), (0, 1)),
+    bulges=[0.3, 0, -0.2, 0],
+    slab_bounds=(-0.5, 0.5),
+    axis=2,
+)
 SPHERE = td.Sphere(radius=1)
 CYLINDER = td.Cylinder(axis=2, length=1, radius=1)
 
@@ -91,6 +98,7 @@ GEO_TYPES = [
     CYLINDER,
     SPHERE,
     POLYSLAB,
+    POLYSLAB_ARC,
     UNION,
     INTERSECTION,
     DIFFERENCE,
@@ -414,6 +422,428 @@ def test_validate_polyslab_vertices_valid():
 def test_sidewall_failed_validation():
     with pytest.raises(pd.ValidationError):
         POLYSLAB.copy(update={"sidewall_angle": 1000})
+
+
+def test_bulge_size_validation():
+    size = POLYSLAB.vertices.shape[0]
+    with pytest.raises(pd.ValidationError):
+        POLYSLAB.updated_copy(bulges=[1, 2])
+    POLYSLAB.updated_copy(bulges=np.random.random(size))
+
+    assert len(POLYSLAB._bulges) == POLYSLAB.vertices.shape[0]
+    assert np.allclose(POLYSLAB._bulges, 0)
+
+
+def test_bulge_compatibility_validation():
+    polyslab = POLYSLAB.updated_copy(bulges=np.random.random(POLYSLAB.vertices.shape[0]))
+    POLYSLAB.updated_copy(dilation=0.01)
+    with pytest.raises(pd.ValidationError):
+        polyslab.updated_copy(dilation=0.01)
+    POLYSLAB.updated_copy(sidewall_angle=0.01)
+    with pytest.raises(pd.ValidationError):
+        polyslab.updated_copy(sidewall_angle=0.01)
+
+
+def test_arc_geometry_helpers():
+    """Test arc geometry helper functions."""
+    # All tests use chord from (0,0) to (2,0), chord_length = 2.
+    edge_start = np.array([[0.0, 0.0]])
+    edge_end = np.array([[2.0, 0.0]])
+
+    # --- Semicircle: bulge = tan(45°) = 1.0, included angle = 180° ---
+    # Positive bulge → CCW arc bulging downward (perpendicular to chord).
+    # radius = chord / (2 sin(90°)) = 1
+    # center = midpoint + 0 * perp = (1, 0)  (midpoint_to_center_dist = 0)
+    arc = _PolyBulgeUtil._arcs_from_bulges(edge_start, edge_end, np.array([1.0]))
+    assert np.isclose(arc["included_angles"][0], np.pi)
+    assert np.isclose(arc["radii"][0], 1.0)
+    assert np.allclose(arc["centers"][0], [1.0, 0.0])
+    assert np.isclose(arc["start_angles"][0], np.pi)  # atan2(0, -1)
+    assert np.isclose(arc["end_angles"][0], 0.0)  # atan2(0, 1)
+
+    # --- Quarter-circle: bulge = tan(22.5°), included angle = 90° ---
+    # radius = chord / (2 sin(45°)) = 2 / √2 = √2
+    # midpoint_to_center_dist = √2 - tan(22.5°) = 1.0
+    # center = (1, 0) + 1 * (0, 1) = (1, 1)
+    quarter_bulge = np.tan(np.pi / 8)  # tan(22.5°)
+    arc = _PolyBulgeUtil._arcs_from_bulges(edge_start, edge_end, np.array([quarter_bulge]))
+    assert np.isclose(arc["included_angles"][0], np.pi / 2)
+    assert np.isclose(arc["radii"][0], np.sqrt(2))
+    assert np.allclose(arc["centers"][0], [1.0, 1.0])
+    assert np.isclose(arc["start_angles"][0], -3 * np.pi / 4)  # atan2(-1, -1)
+    assert np.isclose(arc["end_angles"][0], -np.pi / 4)  # atan2(-1, 1)
+
+    # --- Negative quarter-circle: bulge = -tan(22.5°), included angle = -90° ---
+    # radius = √2 (same magnitude)
+    # center = (1, 0) + (-1) * 1 * (0, 1) = (1, -1)
+    arc = _PolyBulgeUtil._arcs_from_bulges(edge_start, edge_end, np.array([-quarter_bulge]))
+    assert np.isclose(arc["included_angles"][0], -np.pi / 2)
+    assert np.isclose(arc["radii"][0], np.sqrt(2))
+    assert np.allclose(arc["centers"][0], [1.0, -1.0])
+    assert np.isclose(arc["start_angles"][0], 3 * np.pi / 4)  # atan2(1, -1)
+    assert np.isclose(arc["end_angles"][0], np.pi / 4)  # atan2(1, 1)
+
+    # --- Batch: semicircle + negative quarter-circle in one call ---
+    edge_starts = np.array([[0.0, 0.0], [0.0, 0.0]])
+    edge_ends = np.array([[2.0, 0.0], [2.0, 0.0]])
+    bulges = np.array([1.0, -quarter_bulge])
+    arcs = _PolyBulgeUtil._arcs_from_bulges(edge_starts, edge_ends, bulges)
+    assert np.isclose(arcs["radii"][0], 1.0)
+    assert np.isclose(arcs["radii"][1], np.sqrt(2))
+    assert np.allclose(arcs["centers"][0], [1.0, 0.0])
+    assert np.allclose(arcs["centers"][1], [1.0, -1.0])
+    assert arcs["included_angles"][0] > 0  # positive bulge → CCW sweep
+    assert arcs["included_angles"][1] < 0  # negative bulge → CW sweep
+
+    # --- Verify endpoints lie on the arc (distance to center == radius) ---
+    for bulge_val in [1.0, quarter_bulge, -quarter_bulge]:
+        arc = _PolyBulgeUtil._arcs_from_bulges(edge_start, edge_end, np.array([bulge_val]))
+        center = arc["centers"][0]
+        radius = arc["radii"][0]
+        dist_start = np.linalg.norm(edge_start[0] - center)
+        dist_end = np.linalg.norm(edge_end[0] - center)
+        assert np.isclose(dist_start, radius)
+        assert np.isclose(dist_end, radius)
+
+    # --- _polygon_arcs_bounds ---
+    # Arc that stays below the chord (positive bulge)
+    bounds_verts = np.array([[0.0, 0.0], [2.0, 0.0]])
+    bulge_data = _PolyBulgeUtil._compute_bulge_data(bounds_verts, np.array([0.5, 0.0]))
+    min_c, max_c = _PolyBulgeUtil._polygon_arcs_bounds(bounds_verts, bulge_data)
+    assert min_c[0, 0] <= 0 and max_c[0, 0] >= 2.0
+    assert min_c[0, 1] <= 0  # arc bulges downward for positive bulge
+
+    # Arc that stays above the chord (negative bulge)
+    bulge_data = _PolyBulgeUtil._compute_bulge_data(bounds_verts, np.array([-0.5, 0.0]))
+    min_c, max_c = _PolyBulgeUtil._polygon_arcs_bounds(bounds_verts, bulge_data)
+    assert max_c[0, 1] >= 0  # arc bulges upward for negative bulge
+
+    # --- _arcs_from_bulges: zero bulge must raise ValueError ---
+    with pytest.raises(ValueError, match="non-zero"):
+        _PolyBulgeUtil._arcs_from_bulges(edge_start, edge_end, np.array([0.0]))
+
+    # --- _polygon_discretize: no-arc early return ---
+    tri_verts = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]])
+    bd_zero = _PolyBulgeUtil._compute_bulge_data(tri_verts, np.array([0.0, 0.0, 0.0]))
+    disc_zero = _PolyBulgeUtil._polygon_discretize(tri_verts, bd_zero)
+    np.testing.assert_array_equal(disc_zero, tri_verts)
+
+    # --- _polygon_discretize: explicit num_points_per_arc ---
+    sq_verts = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    bd_one_arc = _PolyBulgeUtil._compute_bulge_data(sq_verts, np.array([0.3, 0.0, 0.0, 0.0]))
+    disc_explicit = _PolyBulgeUtil._polygon_discretize(sq_verts, bd_one_arc, num_points_per_arc=10)
+    assert len(disc_explicit) == 4 + 10  # 4 original vertices + 10 arc points
+
+
+def test_polyslab_with_arcs_basic():
+    """Test basic PolySlab creation with arc segments."""
+    vertices = [(0, 0), (1, 0), (1, 1), (0, 1)]
+
+    # Create with small bulge on first edge
+    polyslab = td.PolySlab(
+        vertices=vertices,
+        bulges=[0.2, 0, 0, 0],
+        axis=2,
+        slab_bounds=(-0.5, 0.5),
+    )
+
+    assert polyslab._has_arc_segments is True
+    assert len(polyslab._bulges) == 4
+    assert np.isclose(polyslab._bulges[0], 0.2)
+
+    # Discretized polygon should have more points
+    disc_verts = polyslab._discretized_reference_polygon
+    assert len(disc_verts) > len(vertices)
+
+    # JSON serialization should preserve geometry
+    json_str = polyslab.json()
+    polyslab_loaded = td.PolySlab.parse_raw(json_str)
+    assert np.allclose(polyslab_loaded.bulges, polyslab.bulges)
+    assert polyslab_loaded._has_arc_segments
+    np.testing.assert_allclose(
+        polyslab_loaded._discretized_reference_polygon,
+        polyslab._discretized_reference_polygon,
+    )
+    assert np.allclose(polyslab_loaded.bounds, polyslab.bounds)
+
+    # Trimesh via tilted-plane intersection should produce valid geometry
+    # (exercises _do_intersections_tilted_plane with arc-discretized polygon)
+    tilted_shapes = polyslab.intersections_plane(x=0.5)
+    assert len(tilted_shapes) >= 1
+    for shape in tilted_shapes:
+        assert shape.is_valid
+
+    # Non-axis-aligned (diagonal) edges with arcs
+    tri_verts = [(0, 0), (2, 0), (1, 2)]
+    tri_ps = td.PolySlab(vertices=tri_verts, bulges=[0.3, 0.2, 0], axis=2, slab_bounds=(-0.5, 0.5))
+    assert tri_ps._has_arc_segments
+    assert len(tri_ps._discretized_reference_polygon) > 3
+
+
+def test_polyslab_arc_self_intersection_validation():
+    """Test that self-intersecting arc polygons raise error."""
+    # Narrow rectangle where inward bulges cross in the middle
+    vertices = [(0, 0), (2, 0), (2, 0.3), (0, 0.3)]
+
+    # Large inward bulges that cross each other
+    with pytest.raises(pd.ValidationError):
+        td.PolySlab(
+            vertices=vertices,
+            bulges=[-1.5, 0, 1.5, 0],  # both bulge toward center, causing intersection
+            axis=2,
+            slab_bounds=(-0.5, 0.5),
+        )
+
+
+def test_polyslab_arc_area_perimeter():
+    """Test area and perimeter calculations with arc segments."""
+    # Unit square
+    vertices = np.array([(0, 0), (1, 0), (1, 1), (0, 1)])
+
+    # Without arcs: area = 1, perimeter = 4
+    area_no_arc = td.PolySlab._area(vertices)
+    perim_no_arc = td.PolySlab._perimeter(vertices)
+    assert np.isclose(abs(area_no_arc), 1.0)
+    assert np.isclose(perim_no_arc, 4.0)
+
+    # With semicircular bulge on one edge (bulge=1 on bottom edge)
+    # The semicircle adds area = pi*r^2/2 = pi*0.5^2/2 = pi/8
+    bulges = np.array([1.0, 0, 0, 0])
+    bulge_data = _PolyBulgeUtil._compute_bulge_data(vertices, bulges)
+    area_with_arc = td.PolySlab._area(vertices) + _PolyBulgeUtil._arc_segment_area(bulge_data)
+    # For a unit chord with bulge=1: radius=0.5, segment area = r^2*(pi - sin(pi))/2 = 0.5^2*pi/2
+    expected_segment_area = 0.25 * np.pi / 2
+    assert np.isclose(abs(area_with_arc), 1.0 + expected_segment_area, rtol=0.01)
+
+    # Perimeter with arc: replaces chord=1 with arc=pi*0.5=pi/2
+    perim_with_arc = _PolyBulgeUtil._polygon_perimeter(vertices, bulge_data)
+    assert np.isclose(perim_with_arc, 3 + np.pi / 2, rtol=0.01)
+
+
+def test_polyslab_arc_bounds():
+    """Test that bounds properly account for arc extents."""
+    # Square from (0,0) to (1,1)
+    vertices = [(0, 0), (1, 0), (1, 1), (0, 1)]
+
+    # No arcs: bounds should be exactly the vertices
+    polyslab_no_arc = td.PolySlab(
+        vertices=vertices,
+        axis=2,
+        slab_bounds=(-0.5, 0.5),
+    )
+    bounds = polyslab_no_arc.bounds
+    assert np.isclose(bounds[0][0], 0)  # xmin
+    assert np.isclose(bounds[1][0], 1)  # xmax
+    assert np.isclose(bounds[0][1], 0)  # ymin
+    assert np.isclose(bounds[1][1], 1)  # ymax
+
+    # With outward bulge on bottom edge: y should extend below 0
+    polyslab_arc = td.PolySlab(
+        vertices=vertices,
+        bulges=[0.5, 0, 0, 0],  # bulge outward on bottom edge
+        axis=2,
+        slab_bounds=(-0.5, 0.5),
+    )
+    bounds_arc = polyslab_arc.bounds
+    assert bounds_arc[0][1] < 0  # ymin should be negative (arc extends below)
+
+    # Multiple arcs (outward bottom + inward right + outward top)
+    polyslab_multi = td.PolySlab(
+        vertices=vertices,
+        bulges=[0.5, -0.3, 0.5, 0],
+        axis=2,
+        slab_bounds=(-0.5, 0.5),
+    )
+    bounds_multi = polyslab_multi.bounds
+    assert bounds_multi[0][1] < 0  # bottom outward arc extends below
+    assert bounds_multi[1][1] > 1  # top outward arc extends above
+    # z bounds unchanged by arcs
+    assert np.isclose(bounds_multi[0][2], -0.5)
+    assert np.isclose(bounds_multi[1][2], 0.5)
+
+
+def test_polyslab_arc_inside():
+    """Test point containment with arc segments."""
+    # Square with outward bulge on bottom
+    vertices = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    polyslab = td.PolySlab(
+        vertices=vertices,
+        bulges=[0.5, 0, 0, 0],
+        axis=2,
+        slab_bounds=(-0.5, 0.5),
+    )
+
+    # Point inside the square part
+    x = np.array([0.5])
+    y = np.array([0.5])
+    z = np.array([0.0])
+    assert polyslab.inside(x, y, z)[0]
+
+    # Point in the arc bulge region (below y=0 but within arc)
+    x_arc = np.array([0.5])
+    y_arc = np.array([-0.05])  # slightly below y=0
+    z_arc = np.array([0.0])
+    assert polyslab.inside(x_arc, y_arc, z_arc)[0]
+
+    # Point outside the arc bulge region
+    x_out = np.array([0.5])
+    y_out = np.array([-0.5])  # far below y=0
+    z_out = np.array([0.0])
+    assert not polyslab.inside(x_out, y_out, z_out)[0]
+
+    # Negative bulge (inward arc) on right edge
+    polyslab_neg = td.PolySlab(
+        vertices=vertices,
+        bulges=[0, -0.5, 0, 0],  # inward arc on right edge (1,0)->(1,1)
+        axis=2,
+        slab_bounds=(-0.5, 0.5),
+    )
+    # Point at the edge midpoint should be outside (arc bows inward)
+    assert not polyslab_neg.inside(np.array([1.0]), np.array([0.5]), np.array([0.0]))[0]
+    # Point well inside should still be inside
+    assert polyslab_neg.inside(np.array([0.3]), np.array([0.5]), np.array([0.0]))[0]
+
+
+def test_polyslab_arc_intersections():
+    """Test cross-section intersections with arc segments."""
+    vertices = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    polyslab = td.PolySlab(
+        vertices=vertices,
+        bulges=[0.3, 0, 0, 0],
+        axis=2,
+        slab_bounds=(-0.5, 0.5),
+    )
+
+    # Get intersection at z=0 (normal to axis)
+    shapes = polyslab._intersections_normal(z=0.0)
+    assert len(shapes) == 1
+
+    # The intersection polygon should have more than 4 vertices (due to arc discretization)
+    poly = shapes[0]
+    assert len(poly.exterior.coords) > 5
+
+    # Side intersection (plane orthogonal to slab, cutting through arc region).
+    # The arc on edge (0,0)→(1,0) with bulge=0.3 extends below y=0,
+    # so y=-0.01 only intersects the polyslab if arc discretization is used.
+    shapes_x = polyslab.intersections_plane(x=0.5)
+    assert len(shapes_x) >= 1
+    shapes_y = polyslab.intersections_plane(y=-0.01)
+    assert len(shapes_y) >= 1
+
+    # interior_angle is not implemented for arc segments
+    with pytest.raises(NotImplementedError):
+        polyslab.interior_angle
+
+
+def test_polyslab_arc_inside_scalar():
+    """Scalar and ndarray inside() must agree for a point in the arc bulge region."""
+    vertices = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    polyslab = td.PolySlab(
+        vertices=vertices,
+        bulges=[0.5, 0, 0, 0],
+        axis=2,
+        slab_bounds=(-0.5, 0.5),
+    )
+
+    # Point in the arc bulge region (below y=0 but within arc)
+    x_val, y_val, z_val = 0.5, -0.05, 0.0
+
+    # ndarray path
+    inside_array = polyslab.inside(np.array([x_val]), np.array([y_val]), np.array([z_val]))[0]
+
+    # scalar path
+    inside_scalar = polyslab.inside(x_val, y_val, z_val)
+
+    assert inside_array == inside_scalar, (
+        f"Scalar ({inside_scalar}) and ndarray ({inside_array}) inside() disagree "
+        f"for point in arc bulge region"
+    )
+    # Both should be True — the point is inside the arc
+    assert inside_scalar
+
+
+def test_polyslab_arc_tilted_plane_intersection():
+    """Tilted-plane intersection trimesh must include arc bulge geometry."""
+    vertices = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    polyslab = td.PolySlab(
+        vertices=vertices,
+        bulges=[0.5, 0, 0, 0],
+        axis=2,
+        slab_bounds=(-0.5, 0.5),
+    )
+
+    # Intersect with the y=-0.01 plane (cuts through the arc bulge region only)
+    shapes = polyslab.intersections_plane(y=-0.01)
+    assert len(shapes) >= 1, "Tilted-plane intersection missed the arc bulge region"
+
+
+def test_bulge_finite_validation():
+    """Inf and NaN bulge values must raise ValidationError."""
+    size = POLYSLAB.vertices.shape[0]
+    with pytest.raises(pd.ValidationError):
+        POLYSLAB.updated_copy(bulges=[np.inf, 0, 0, 0])
+    with pytest.raises(pd.ValidationError):
+        POLYSLAB.updated_copy(bulges=[0, -np.inf, 0, 0])
+    with pytest.raises(pd.ValidationError):
+        POLYSLAB.updated_copy(bulges=[0, 0, np.nan, 0])
+
+
+def test_zero_length_edge_nonzero_bulge():
+    """Duplicate vertex with non-zero bulge must raise an error."""
+    # Two identical vertices at (0,0) with a non-zero bulge on that zero-length edge
+    vertices = [(0, 0), (0, 0), (1, 0), (1, 1)]
+    with pytest.raises(pd.ValidationError):
+        td.PolySlab(
+            vertices=vertices,
+            bulges=[0.5, 0, 0, 0],
+            axis=2,
+            slab_bounds=(-0.5, 0.5),
+        )
+
+
+def test_zero_length_edge_zero_bulge_dropped():
+    """Duplicate vertex with zero bulge should be silently dropped."""
+    # (0,0) appears twice; the zero-length edge has bulge=0, should be dropped
+    vertices = [(0, 0), (0, 0), (1, 0), (1, 1)]
+    polyslab = td.PolySlab(
+        vertices=vertices,
+        bulges=[0, 0, 0, 0],
+        axis=2,
+        slab_bounds=(-0.5, 0.5),
+    )
+    canon_verts, canon_bulges = polyslab._canonical_vertices_and_bulges
+    # After dropping the duplicate, should have 3 vertices
+    assert len(canon_verts) == 3
+    assert len(canon_bulges) == 3
+
+
+def test_winding_reversal_adjusts_bulges():
+    """CW input should get reversed to CCW with bulges permuted and sign-flipped."""
+    # CW-ordered square: (0,0) -> (0,1) -> (1,1) -> (1,0)
+    vertices_cw = np.array([(0, 0), (0, 1), (1, 1), (1, 0)], dtype=float)
+    bulges_cw = np.array([0.2, 0.0, -0.3, 0.0])
+
+    canon_verts, canon_bulges = td.PolySlab._canonicalize_vertices_and_bulges(
+        vertices_cw, bulges_cw
+    )
+    # After canonicalization, should be CCW
+    assert td.PolySlab._area(canon_verts) > 0
+    # Bulge signs should be flipped and permuted
+    # For reversal: bulges_new = -np.roll(bulges[::-1], -1)
+    expected_bulges = -np.roll(bulges_cw[::-1], -1)
+    np.testing.assert_allclose(canon_bulges, expected_bulges)
+
+
+def test_adjoint_error_with_bulges():
+    """_compute_derivatives must raise NotImplementedError for non-zero bulges."""
+    polyslab = td.PolySlab(
+        vertices=[(0, 0), (1, 0), (1, 1), (0, 1)],
+        bulges=[0.2, 0, 0, 0],
+        axis=2,
+        slab_bounds=(-0.5, 0.5),
+    )
+    with pytest.raises(NotImplementedError, match="Adjoint derivatives are not supported"):
+        polyslab._compute_derivatives(derivative_info=None)
 
 
 def test_surfaces():

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -18,6 +18,7 @@ from tidy3d.components.autograd.types import TracedFloat
 from tidy3d.components.autograd.utils import hasbox
 from tidy3d.components.base import cached_property
 from tidy3d.components.transformation import ReflectionFromPlane, RotationAroundAxis
+from tidy3d.components.types import ArrayFloat1D
 from tidy3d.config import config
 from tidy3d.constants import LARGE_NUMBER, MICROMETER, fp_eps
 from tidy3d.exceptions import SetupError, Tidy3dImportError, ValidationError
@@ -37,7 +38,6 @@ if TYPE_CHECKING:
     from tidy3d.components.autograd import AutogradFieldMap
     from tidy3d.components.autograd.derivative_utils import DerivativeInfo
     from tidy3d.components.types import (
-        ArrayFloat1D,
         ArrayFloat2D,
         ArrayLike,
         Axis,
@@ -62,6 +62,12 @@ _MAX_POLYSLAB_VERTICES_FOR_TRIANGULATION = 500
 
 _MIN_POLYGON_AREA = fp_eps
 
+# Angular resolution for arc discretization (approximately 1 degrees)
+_ARC_DISCRETIZATION_ANGULAR_STEP = np.pi / 180
+
+# Minimum number of intermediate points per arc segment for discretization
+_MIN_POINTS_PER_ARC = 5
+
 
 @lru_cache(maxsize=128)
 def leggauss(n: int) -> tuple[NDArray, NDArray]:
@@ -72,13 +78,385 @@ def leggauss(n: int) -> tuple[NDArray, NDArray]:
     )
 
 
+class _PolyBulgeUtil:
+    """Pure-geometry utility methods for arc/bulge computations on polygons for internal use.
+    All methods in this class are static methods.
+    """
+
+    @staticmethod
+    def _arcs_from_bulges(
+        arc_starts: ArrayFloat2D,
+        arc_ends: ArrayFloat2D,
+        bulges: ArrayFloat1D,
+    ) -> dict:
+        """Compute arc geometry for multiple arcs at once (vectorized).
+
+        Parameters
+        ----------
+        arc_starts : ArrayFloat2D
+            Shape (N, 2) start points of each arc.
+        arc_ends : ArrayFloat2D
+            Shape (N, 2) end points of each arc.
+        bulges : ArrayFloat1D
+            Shape (N,) bulge values. Must all be non-zero; an error is raised if any are ≈ 0.
+
+        Returns
+        -------
+        dict
+            Dictionary with arrays of shape (N,) or (N, 2):
+            'centers', 'radii', 'start_angles', 'end_angles',
+            'included_angles'.
+        """
+
+        arc_starts = np.asarray(arc_starts, dtype=float)
+        arc_ends = np.asarray(arc_ends, dtype=float)
+        bulges = np.asarray(bulges, dtype=float)
+
+        # Validate that no bulges are close to 0
+        if np.any(np.isclose(bulges, 0)):
+            raise ValueError(
+                "All bulges must be non-zero. Edges with bulge ≈ 0 should be filtered out "
+                "before calling this method, as they represent straight line segments."
+            )
+
+        chord_vecs = arc_ends - arc_starts  # (N, 2)
+        chord_lengths = np.linalg.norm(chord_vecs, axis=1)  # (N,)
+
+        abs_bulges = np.abs(bulges)
+        included_angles = 4.0 * np.arctan(bulges)  # (N,)
+
+        # Sagitta: s = (chord/2) * |bulge|
+        sagittas = (chord_lengths / 2.0) * abs_bulges  # (N,)
+
+        # Radius: r = ((chord/2)^2 + s^2) / (2*s)
+        half_chords = chord_lengths / 2.0
+        radii = (half_chords**2 + sagittas**2) / (2.0 * sagittas)  # (N,)
+
+        # Midpoints of each chord
+        chord_midpoints = (arc_starts + arc_ends) / 2.0  # (N, 2)
+
+        # Perpendicular unit vectors (rotate chord by 90 degrees CCW)
+        chord_perpendiculars = (
+            np.column_stack([-chord_vecs[:, 1], chord_vecs[:, 0]]) / chord_lengths[:, np.newaxis]
+        )  # (N, 2)
+
+        # Distance from midpoint to center
+        midpoint_to_center_dist = radii - sagittas  # (N,)
+
+        # Center: positive bulge -> center at mid + d*perp, negative -> mid - d*perp
+        bulge_signs = np.sign(bulges)  # (N,)
+        centers = (
+            chord_midpoints
+            + (bulge_signs * midpoint_to_center_dist)[:, np.newaxis] * chord_perpendiculars
+        )  # (N, 2)
+
+        # Start and end angles
+        start_angles = np.arctan2(
+            arc_starts[:, 1] - centers[:, 1], arc_starts[:, 0] - centers[:, 0]
+        )  # (N,)
+        end_angles = np.arctan2(
+            arc_ends[:, 1] - centers[:, 1], arc_ends[:, 0] - centers[:, 0]
+        )  # (N,)
+
+        return {
+            "centers": centers,
+            "radii": radii,
+            "start_angles": start_angles,
+            "end_angles": end_angles,
+            "included_angles": included_angles,
+        }
+
+    @staticmethod
+    def _compute_bulge_data(vertices: ArrayFloat2D, bulges: ArrayFloat1D) -> dict:
+        """Precompute arc geometry from vertices and bulges, e.g. encoding which edges are arcs.
+
+        Parameters
+        ----------
+        vertices : ArrayFloat2D
+            Shape (N, 2) polygon vertices.
+        bulges : ArrayFloat1D
+            Shape (N,) bulge values for each edge.
+
+        Returns
+        -------
+        dict
+            Always contains 'arc_mask' that encodes which edges are arcs. When arcs exist, also contains
+            'centers', 'radii', 'start_angles', 'end_angles', 'included_angles'.
+        """
+        bulges = np.asarray(bulges)
+        arc_mask = ~np.isclose(bulges, 0)
+
+        if not np.any(arc_mask):
+            return {"arc_mask": arc_mask}
+
+        edge_starts = np.asarray(vertices)
+        edge_ends = np.roll(edge_starts, -1, axis=0)
+        arc_data = _PolyBulgeUtil._arcs_from_bulges(
+            edge_starts[arc_mask], edge_ends[arc_mask], bulges[arc_mask]
+        )
+        return {"arc_mask": arc_mask, **arc_data}
+
+    @staticmethod
+    def _polygon_arcs_bounds(
+        vertices: ArrayFloat2D,
+        bulge_data: dict,
+    ) -> tuple[ArrayFloat2D, ArrayFloat2D]:
+        """Compute analytical bounding boxes for arc segments in a polygon.
+
+        An arc's bounding box is determined by its endpoints plus any cardinal
+        extrema (rightmost, topmost, leftmost, bottommost points of the underlying
+        circle) that the arc actually passes through. The method:
+
+        1. Initializes bounds from the two endpoints of each arc.
+        2. Checks which of the 4 cardinal angles (0, pi/2, pi, 3pi/2) fall within
+           each arc's angular sweep, accounting for sweep direction (CCW vs CW)
+           and wraparound at 0/2pi.
+        3. For each cardinal angle the arc passes through, expands the bounding box
+           to include the corresponding extremal point (center +/- radius).
+
+        Parameters
+        ----------
+        vertices : ArrayFloat2D
+            Shape (N, 2) polygon vertices.
+        bulge_data : dict
+            Precomputed arc data from ``_compute_bulge_data``.
+
+        Returns
+        -------
+        tuple[ArrayFloat2D, ArrayFloat2D]
+            (min_coords, max_coords) each of shape (N, 2) where N is the number of arc segments.
+
+        Raises
+        ------
+        KeyError
+            If ``bulge_data`` contains no arcs (all bulges are zero).
+        """
+        arc_mask = bulge_data["arc_mask"]
+        edge_starts = np.asarray(vertices)
+        edge_ends = np.roll(edge_starts, -1, axis=0)
+        arc_starts = edge_starts[arc_mask]
+        arc_ends = edge_ends[arc_mask]
+
+        # Initialize bounds from endpoints
+        min_coords = np.minimum(arc_starts, arc_ends)  # (N, 2)
+        max_coords = np.maximum(arc_starts, arc_ends)  # (N, 2)
+
+        # The 4 cardinal angles correspond to the extremal points of the circle:
+        #     pi/2 (top: max y)
+        #       |
+        #  pi (left: min x) ---+--- 0 (right: max x)
+        #       |
+        #   3pi/2 (bottom: min y)
+        cardinal_angles = np.array([0.0, np.pi / 2, np.pi, 3 * np.pi / 2])  # (4,)
+
+        # Normalize from arctan2's [-pi, pi] to [0, 2*pi) so the wraparound
+        # logic below can use a single consistent range.
+        start_angles_norm = bulge_data["start_angles"] % (2 * np.pi)  # (N,)
+        end_angles_norm = bulge_data["end_angles"] % (2 * np.pi)  # (N,)
+
+        # For each arc, check which cardinal angles lie within its angular sweep.
+        # Broadcast: (N, 1) vs (1, 4) -> (N, 4) boolean matrix
+        start_angles_norm_col = start_angles_norm[:, np.newaxis]  # (N, 1)
+        end_angles_norm_col = end_angles_norm[:, np.newaxis]  # (N, 1)
+        cardinal_row = cardinal_angles[np.newaxis, :]  # (1, 4)
+        sweeps_ccw_col = (bulge_data["included_angles"] > 0)[:, np.newaxis]  # (N, 1)
+
+        # CCW: angles increase from start to end.
+        #   No wrap (end > start): cardinal in [start, end]
+        #   Wrap    (end <= start): cardinal in [start, 2*pi) or [0, end]
+        ccw_simple = (cardinal_row >= start_angles_norm_col) & (cardinal_row <= end_angles_norm_col)
+        ccw_wrapped = (end_angles_norm_col <= start_angles_norm_col) & (
+            (cardinal_row >= start_angles_norm_col) | (cardinal_row <= end_angles_norm_col)
+        )
+        ccw_hits_cardinal = ccw_simple | ccw_wrapped
+
+        # CW: angles decrease from start to end.
+        #   No wrap (end < start): cardinal in [end, start]
+        #   Wrap    (end >= start): cardinal in [0, start] or [end, 2*pi)
+        cw_simple = (cardinal_row <= start_angles_norm_col) & (cardinal_row >= end_angles_norm_col)
+        cw_wrapped = (end_angles_norm_col >= start_angles_norm_col) & (
+            (cardinal_row <= start_angles_norm_col) | (cardinal_row >= end_angles_norm_col)
+        )
+        cw_hits_cardinal = cw_simple | cw_wrapped
+
+        arc_hits_cardinal = np.where(sweeps_ccw_col, ccw_hits_cardinal, cw_hits_cardinal)  # (N, 4)
+
+        # Expand bounds for each cardinal the arc passes through.
+        # Cardinal directions: 0=right(0°), 1=top(90°), 2=left(180°), 3=bottom(270°)
+        for n, _ in enumerate(cardinal_angles):
+            coord_idx = n % 2  # Alternates x(0), y(1), x(0), y(1)
+            sign = (-1) ** (n // 2)  # Pattern: +1, +1, -1, -1
+            bounds = max_coords if n < 2 else min_coords  # max for 0,1; min for 2,3
+            op_func = np.maximum if n < 2 else np.minimum
+
+            hit = arc_hits_cardinal[:, n]
+            extremal_values = bulge_data["centers"][:, coord_idx] + sign * bulge_data["radii"]
+            bounds[:, coord_idx] = np.where(
+                hit, op_func(bounds[:, coord_idx], extremal_values), bounds[:, coord_idx]
+            )
+
+        return min_coords, max_coords
+
+    @staticmethod
+    def _polygon_discretize(
+        vertices: ArrayFloat2D, bulge_data: dict, num_points_per_arc: int | None = None
+    ) -> ArrayFloat2D:
+        """Discretize a polygon with arc segments into a pure polyline.
+
+        This method converts arc edges (defined by bulge factors) into straight line segments,
+        producing a polyline approximation. It is used for:
+
+        - Validation: checking for self-intersection
+        - Geometric queries: inside point testing, plane intersections
+        - Visualization: rendering polygons with arcs as polylines
+
+        Parameters
+        ----------
+        vertices : ArrayFloat2D
+            Shape (N, 2) defining polygon vertices.
+        bulge_data : dict
+            Precomputed arc data from ``_compute_bulge_data``.
+        num_points_per_arc : int, optional
+            Number of intermediate points per arc segment. If None, the number of points
+            is automatically determined based on the arc's included angle, using approximately
+            one point per degree and a minimum of 5 points per arc.
+
+        Returns
+        -------
+        ArrayFloat2D
+            Discretized vertices with arcs converted to polylines.
+        """
+        vertices = np.asarray(vertices)
+        arc_mask = bulge_data["arc_mask"]
+        num_vertices = len(vertices)
+
+        if not np.any(arc_mask):
+            return vertices.copy()
+
+        arc_indices = np.where(arc_mask)[0]
+
+        # Compute number of points per arc (vectorized)
+        if num_points_per_arc is not None:
+            points_per_arc = np.full(len(arc_indices), num_points_per_arc, dtype=int)
+        else:
+            abs_angles = np.abs(bulge_data["included_angles"])
+            points_per_arc = np.maximum(
+                _MIN_POINTS_PER_ARC, np.ceil(abs_angles / _ARC_DISCRETIZATION_ANGULAR_STEP)
+            ).astype(int)
+
+        # Build a lookup: edge index -> position in arc arrays
+        edge_to_arc_idx = dict(zip(arc_indices, range(len(arc_indices))))
+
+        # Loop to assemble variable-length per-arc points
+        all_points = []
+        for vertex_idx in range(num_vertices):
+            all_points.append(vertices[vertex_idx])
+
+            if vertex_idx in edge_to_arc_idx:
+                arc_pos = edge_to_arc_idx[vertex_idx]
+                center = bulge_data["centers"][arc_pos]
+                radius = bulge_data["radii"][arc_pos]
+                start_angle = bulge_data["start_angles"][arc_pos]
+                end_angle = bulge_data["end_angles"][arc_pos]
+
+                # Generate angles
+                if bulge_data["included_angles"][arc_pos] > 0:
+                    if end_angle < start_angle:
+                        end_angle += 2 * np.pi
+                else:
+                    if end_angle > start_angle:
+                        end_angle -= 2 * np.pi
+                angles = np.linspace(start_angle, end_angle, points_per_arc[arc_pos] + 2)
+                # Skip first (edge_start) and last (edge_end) — last will be added as next vertex
+                angles = angles[1:-1]
+
+                if len(angles) > 0:
+                    arc_points = np.column_stack(
+                        [center[0] + radius * np.cos(angles), center[1] + radius * np.sin(angles)]
+                    )
+                    all_points.extend(arc_points)
+
+        return np.array(all_points)
+
+    @staticmethod
+    def _arc_segment_area(bulge_data: dict) -> float:
+        """Compute the signed total area of circular segments from arc edges.
+
+        Each arc edge contributes a circular segment (the region between the
+        arc and its chord). This correction is meant to be added to the
+        shoelace (chord-based) polygon area.
+
+        Parameters
+        ----------
+        bulge_data : dict
+            Precomputed arc data from ``_compute_bulge_data``.
+
+        Returns
+        -------
+        float
+            Signed sum of circular segment areas.
+
+        Raises
+        ------
+        KeyError
+            If ``bulge_data`` contains no arcs (all bulges are zero).
+        """
+        radii = bulge_data["radii"]
+        theta = np.abs(bulge_data["included_angles"])
+
+        # Circular segment area: A = r² * (θ - sin(θ)) / 2
+        segment_areas = (radii**2) * (theta - np.sin(theta)) / 2.0
+
+        # Sign: positive included_angle → outward bulge → adds area (for CCW polygon)
+        bulge_signs = np.sign(bulge_data["included_angles"])
+        return float(np.sum(bulge_signs * segment_areas))
+
+    @staticmethod
+    def _polygon_perimeter(vertices: ArrayFloat2D, bulge_data: dict) -> float:
+        """Compute the polygon perimeter using arc lengths for curved segments.
+
+        Parameters
+        ----------
+        vertices : ArrayFloat2D
+            Shape (N, 2) defining the polygon vertices in the xy-plane.
+        bulge_data : dict
+            Precomputed arc data from ``_compute_bulge_data``.
+
+        Returns
+        -------
+        float
+            Total perimeter including arc lengths.
+        """
+        next_vertices = np.roll(vertices, shift=-1, axis=0)
+        edge_lengths = np.linalg.norm(next_vertices - vertices, axis=1)  # (N,)
+
+        arc_mask = bulge_data["arc_mask"]
+        if not np.any(arc_mask):
+            return float(np.sum(edge_lengths))
+
+        # For arc edges: replace chord lengths with arc lengths
+        radii = bulge_data["radii"]
+        edge_lengths[arc_mask] = radii * np.abs(bulge_data["included_angles"])
+
+        return float(np.sum(edge_lengths))
+
+
 class PolySlab(base.Planar):
     """Polygon extruded with optional sidewall angle along axis direction.
+
+    Polygon edges may optionally be circular arcs via the ``bulges`` parameter, which
+    follows the convention: ``bulge = tan(θ/4)`` where ``θ`` is the
+    included angle of the arc. For CCW polygon, a positive bulge produces an arc that bulges outward
+    ; a negative bulge bulges inward; and zero means a straight edge.
 
     Example
     -------
     >>> vertices = np.array([(0,0), (1,0), (1,1)])
     >>> p = PolySlab(vertices=vertices, axis=2, slab_bounds=(-1, 1))
+    >>> # With arc segments (a rounded edge from vertex 1 to vertex 2):
+    >>> p_arc = PolySlab(
+    ...     vertices=vertices, axis=2, slab_bounds=(-1, 1), bulges=[0, 0.5, 0]
+    ... )
     """
 
     slab_bounds: tuple[TracedFloat, TracedFloat] = Field(
@@ -102,6 +480,23 @@ class PolySlab(base.Planar):
         "The index of dimension should be in the ascending order: e.g. if "
         "the slab normal axis is ``axis=y``, the coordinate of the vertices will be in (x, z)",
         json_schema_extra={"units": MICROMETER},
+    )
+
+    bulges: ArrayFloat1D | None = Field(
+        None,
+        title="Bulges In Segments",
+        description="List of values describing the bulge of each edge, following the typical convention: "
+        "``bulge = tan(θ/4)`` where θ is the included angle of the arc. "
+        "When ``bulges=None``, all segments are straight lines; otherwise, the number of bulge values "
+        "must equal the number of vertices. ``bulges[i]`` defines the arc on the edge from vertex ``i`` "
+        "to vertex ``(i+1) mod N``. "
+        "Sign convention: ``bulge=0`` means straight line; ``bulge>0`` bulges outward "
+        "(for CCW polygons); ``bulge<0`` bulges inward. "
+        "All values must be finite. "
+        "Canonicalization: bulges are kept synchronized with vertices during internal canonicalization. "
+        "When winding order is reversed to CCW (i.e., when the input polygon is CW), bulges are permuted to match the reversed edges and "
+        "their signs are flipped. When duplicate adjacent vertices are removed, the corresponding "
+        "zero-bulge entry is dropped; a zero-length edge with non-zero bulge raises ``SetupError``.",
     )
 
     @staticmethod
@@ -145,6 +540,99 @@ class PolySlab(base.Planar):
                 "in future releases."
             )
         return val
+
+    @model_validator(mode="after")
+    def _validate_bulge_array_length(self: Self) -> Self:
+        """When ``bulges`` is not None, its length must match ``vertices``."""
+        if self.bulges is None:
+            return self
+        if len(self.bulges) != self.vertices.shape[0]:
+            raise SetupError(
+                "The number of bulge values in 'bulges' must match the number of 'vertices'. "
+                f"However, this polyslab contains {self.vertices.shape[0]} vertices, but {len(self.bulges)} "
+                "bulge values."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_bulges_are_finite(self: Self) -> Self:
+        """All bulge values must be finite (no inf or nan)."""
+        if self.bulges is None:
+            return self
+        if not np.all(np.isfinite(self.bulges)):
+            raise SetupError(
+                "All 'bulges' values must be finite. Infinite or NaN bulge values are not allowed."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_no_bulge_on_zero_length_edges(self: Self) -> Self:
+        """Zero-length edges cannot have non-zero bulge values."""
+        if self.bulges is None:
+            return self
+
+        # Detect zero-length edges
+        vertices = np.array(self.vertices)
+        bulges = np.array(self.bulges)
+        vertices_next = np.roll(vertices, shift=-1, axis=0)
+        edge_lengths = np.linalg.norm(vertices - vertices_next, axis=1)
+        is_zero_length = np.isclose(edge_lengths, 0, rtol=_IS_CLOSE_RTOL)
+
+        # Check for zero-length edges with non-zero bulge
+        has_nonzero_bulge = ~np.isclose(bulges, 0)
+        invalid_edges = is_zero_length & has_nonzero_bulge
+        if np.any(invalid_edges):
+            invalid_idx = np.where(invalid_edges)[0][0]  # Report first invalid edge
+            raise SetupError(
+                f"Zero-length edge at vertex index {invalid_idx} has a non-zero bulge value "
+                f"({bulges[invalid_idx]}). A zero-length edge cannot define an arc segment."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _vertical_sidewall_no_dilation_with_arc(self: Self) -> Self:
+        """In the presence of arc segments, for now sidwall is limited to vertical, and no dilation allowed."""
+        if self.bulges is None:
+            return self
+        if not np.allclose(self.bulges, 0):
+            if not math.isclose(self.sidewall_angle, 0):
+                raise SetupError(
+                    "Arc segments are present in the polygon. 'sidewall_angle' must be 0. "
+                    "A general treatment for slanted polyslab containing arc segments "
+                    "will be available in future releases."
+                )
+            if not math.isclose(self.dilation, 0):
+                raise SetupError(
+                    "Arc segments are present in the polygon. 'dilation' value must be 0. "
+                    "A general treatment will be available in future releases."
+                )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_no_self_intersection_with_arcs(self: Self) -> Self:
+        """Ensure polygon with arc segments is not self-intersecting."""
+        if self.bulges is None:
+            return self
+        if np.allclose(self.bulges, 0):
+            return self  # No arcs, defer to existing vertex-based validation
+
+        # Use canonical (deduplicated, CCW) vertices and bulges
+        canon_verts, canon_bulges = PolySlab._canonicalize_vertices_and_bulges(
+            self.vertices, self.bulges
+        )
+
+        # Discretize the polygon with arc segments
+        bulge_data = _PolyBulgeUtil._compute_bulge_data(canon_verts, canon_bulges)
+        discretized = _PolyBulgeUtil._polygon_discretize(canon_verts, bulge_data)
+
+        # Check if the resulting polygon is valid
+        poly = shapely.Polygon(discretized)
+        if not poly.is_valid or not poly.is_simple:
+            raise SetupError(
+                "Polygon with arc segments is self-intersecting. "
+                "Please adjust the bulge values to avoid self-intersection."
+            )
+        return self
 
     @model_validator(mode="after")
     def no_complex_self_intersecting_polygon_at_reference_plane(self: Self) -> Self:
@@ -427,7 +915,7 @@ class PolySlab(base.Planar):
         ArrayLike[float, float]
             The vertices of the polygon at the reference plane.
         """
-        vertices = self._proper_vertices(self.vertices)
+        vertices = self._canonical_vertices_and_bulges[0]
         if math.isclose(self.dilation, 0):
             return vertices
         offset_vertices = self._shift_vertices(vertices, self.dilation)[0]
@@ -496,6 +984,88 @@ class PolySlab(base.Planar):
             )
         return self.updated_copy(slab_bounds=tuple(bounds))
 
+    @staticmethod
+    def _canonicalize_vertices_and_bulges(
+        vertices: ArrayFloat2D, bulges: ArrayFloat1D
+    ) -> tuple[ArrayFloat2D, ArrayFloat1D]:
+        """Canonicalize vertices and bulges together: remove zero-length edges,
+        enforce CCW winding, and synchronize bulge array.
+
+        Parameters
+        ----------
+        vertices : ArrayFloat2D
+            Shape (N, 2) polygon vertices.
+        bulges : ArrayFloat1D
+            Shape (N,) bulge values for each edge.
+
+        Returns
+        -------
+        tuple[ArrayFloat2D, ArrayFloat1D]
+            (canonical_vertices, canonical_bulges) both in CCW order
+            with zero-length edges removed.
+        """
+        vertices = np.array(vertices)
+        bulges = np.array(bulges)
+
+        # Detect and remove zero-length edges
+        next_vertices = np.roll(vertices, shift=-1, axis=0)
+        edge_lengths = np.linalg.norm(vertices - next_vertices, axis=1)
+        is_zero_length = np.isclose(edge_lengths, 0, rtol=_IS_CLOSE_RTOL)
+
+        if np.any(is_zero_length):
+            # Drop zero-length edges (both vertex and bulge)
+            # Note: validation for non-zero bulges on zero-length edges
+            # is handled by _validate_no_bulge_on_zero_length_edges validator
+            has_nonzero_length = ~is_zero_length
+            vertices = vertices[has_nonzero_length]
+            bulges = bulges[has_nonzero_length]
+
+        # Check winding and reverse if CW
+        if PolySlab._area(vertices) < 0:
+            vertices = vertices[::-1]
+            bulges = -np.roll(bulges[::-1], -1)
+
+        return vertices, bulges
+
+    @cached_property
+    def _canonical_vertices_and_bulges(self) -> tuple[ArrayFloat2D, ArrayFloat1D]:
+        """Canonical (CCW, deduplicated) vertices and bulges as a synchronized pair."""
+        if self.bulges is None:
+            proper = self._proper_vertices(self.vertices)
+            return proper, np.zeros(proper.shape[0])
+        return self._canonicalize_vertices_and_bulges(self.vertices, self.bulges)
+
+    @property
+    def _bulges(self) -> ArrayFloat1D:
+        """Postprocessed bulge values."""
+        return self._canonical_vertices_and_bulges[1]
+
+    @cached_property
+    def _has_arc_segments(self) -> bool:
+        """Whether this PolySlab has any non-zero bulge (arc) segments."""
+        return not np.allclose(self._bulges, 0)
+
+    @cached_property
+    def _bulge_data(self) -> dict:
+        """Precomputed arc geometry data from bulges and reference polygon.
+
+        Note: currently assumes all polygon cross-sections are identical
+        (sidewall_angle must be 0 when bulges are present). This will need
+        per-polygon bulge_data when nonzero sidewall angle is supported with bulges.
+        """
+        return _PolyBulgeUtil._compute_bulge_data(self.reference_polygon, self._bulges)
+
+    @cached_property
+    def _discretized_reference_polygon(self) -> ArrayFloat2D:
+        """Reference polygon with arc segments discretized to polylines.
+
+        For polygons without arc segments, returns the regular reference_polygon.
+        For polygons with arcs, returns a higher-resolution polyline approximation.
+        """
+        if not self._has_arc_segments:
+            return self.reference_polygon
+        return _PolyBulgeUtil._polygon_discretize(self.reference_polygon, self._bulge_data)
+
     @cached_property
     def is_ccw(self) -> bool:
         """Is this ``PolySlab`` CCW-oriented?"""
@@ -548,7 +1118,9 @@ class PolySlab(base.Planar):
 
             # vertical sidewall
             if math.isclose(self.sidewall_angle, 0):
-                face_polygon = shapely.Polygon(self.reference_polygon).buffer(fp_eps)
+                # Use discretized polygon for arc segments
+                poly_vertices = self._discretized_reference_polygon
+                face_polygon = shapely.Polygon(poly_vertices).buffer(fp_eps)
                 shapely.prepare(face_polygon)
                 inside_polygon_slab = shapely.contains_xy(face_polygon, x=xs_slab, y=ys_slab)
                 inside_polygon[inside_height] = inside_polygon_slab
@@ -579,8 +1151,11 @@ class PolySlab(base.Planar):
                     inside_polygon_axis[:, :, z_i] = inside_polygon_slab.reshape(x_axis.shape[:2])
                 inside_polygon = _move_axis_reverse(inside_polygon_axis)
         else:
-            vertices_z = self._shift_vertices(self.middle_polygon, dist)[0]
-            face_polygon = self.make_shapely_polygon(vertices_z).buffer(fp_eps)
+            if math.isclose(self.sidewall_angle, 0):
+                poly_vertices = self._discretized_reference_polygon
+            else:
+                poly_vertices = self._shift_vertices(self.middle_polygon, dist)[0]
+            face_polygon = self.make_shapely_polygon(poly_vertices).buffer(fp_eps)
             point = shapely.Point(x, y)
             inside_polygon = face_polygon.covers(point)
         return inside_height * inside_polygon
@@ -615,19 +1190,26 @@ class PolySlab(base.Planar):
         """
         import trimesh
 
-        if len(self.base_polygon) > _MAX_POLYSLAB_VERTICES_FOR_TRIANGULATION:
+        if math.isclose(self.sidewall_angle, 0):
+            base_poly = self._discretized_reference_polygon
+            top_poly = base_poly
+        else:
+            base_poly = self.base_polygon
+            top_poly = self.top_polygon
+
+        if len(base_poly) > _MAX_POLYSLAB_VERTICES_FOR_TRIANGULATION:
             log.warning(
                 f"Processing PolySlabs with over {_MAX_POLYSLAB_VERTICES_FOR_TRIANGULATION} vertices can be slow.",
                 log_once=True,
             )
-        base_triangles = triangulation.triangulate(self.base_polygon)
+        base_triangles = triangulation.triangulate(base_poly)
         top_triangles = (
             base_triangles
             if math.isclose(self.sidewall_angle, 0)
-            else triangulation.triangulate(self.top_polygon)
+            else triangulation.triangulate(top_poly)
         )
 
-        n = len(self.base_polygon)
+        n = len(base_poly)
         faces = (
             [[a, b, c] for c, b, a in base_triangles]
             + [[n + a, n + b, n + c] for a, b, c in top_triangles]
@@ -635,8 +1217,8 @@ class PolySlab(base.Planar):
             + [((i + 1) % n, n + ((i + 1) % n), n + i) for i in range(n)]
         )
 
-        x = np.hstack((self.base_polygon[:, 0], self.top_polygon[:, 0]))
-        y = np.hstack((self.base_polygon[:, 1], self.top_polygon[:, 1]))
+        x = np.hstack((base_poly[:, 0], top_poly[:, 0]))
+        y = np.hstack((base_poly[:, 1], top_poly[:, 1]))
         z = np.hstack((np.full(n, self.slab_bounds[0]), np.full(n, self.slab_bounds[1])))
         vertices = np.vstack(self.unpop_axis(z, (x, y), self.axis)).T
         mesh = trimesh.Trimesh(vertices, faces)
@@ -663,7 +1245,9 @@ class PolySlab(base.Planar):
             `Shapely's Documentation <https://shapely.readthedocs.io/en/stable/project.html>`_.
         """
         if math.isclose(self.sidewall_angle, 0):
-            return [self.make_shapely_polygon(self.reference_polygon)]
+            # Use discretized polygon for arc segments
+            poly_vertices = self._discretized_reference_polygon
+            return [self.make_shapely_polygon(poly_vertices)]
 
         z0 = self.center_axis
         z_local = z - z0  # distance to the middle
@@ -727,9 +1311,15 @@ class PolySlab(base.Planar):
             # for vertical sidewall, no need for complications
             if math.isclose(self.sidewall_angle, 0):
                 ints_y, ints_angle = self._find_intersecting_ys_angle_vertical(
-                    self.reference_polygon, position, axis_ordered
+                    self._discretized_reference_polygon, position, axis_ordered
                 )
             else:
+                if self._has_arc_segments:
+                    raise NotImplementedError(
+                        "Arc segments are not supported with slanted sidewalls in "
+                        "_intersections_side. Update _shift_vertices and this method to handle "
+                        "arc geometry before lifting the sidewall_angle restriction."
+                    )
                 # for slanted sidewall, move up by `fp_eps` in case vertices are degenerate at the base.
                 dist = -(h_base - self.finite_length_axis / 2 + fp_eps) * self._tanq
                 vertices = self._shift_vertices(self.middle_polygon, dist)[0]
@@ -796,6 +1386,13 @@ class PolySlab(base.Planar):
         """
         if math.isclose(self.sidewall_angle, 0):
             return np.array([])
+
+        if self._has_arc_segments:
+            raise NotImplementedError(
+                "Arc segments are not supported with slanted sidewalls in "
+                "_find_intersecting_height. Update this method to use discretized "
+                "arc geometry before lifting the sidewall_angle restriction."
+            )
 
         # shift rate
         dist = 1.0
@@ -939,6 +1536,13 @@ class PolySlab(base.Planar):
             List of angles between plane and edges.
         """
 
+        if self._has_arc_segments:
+            raise NotImplementedError(
+                "Arc segments are not supported with slanted sidewalls in "
+                "_find_intersecting_ys_angle_slant. Update this method to use "
+                "discretized arc geometry before lifting the sidewall_angle restriction."
+            )
+
         vertices_axis = vertices.copy()
         # flip vertices x,y for axis = y
         if axis == 1:
@@ -1055,6 +1659,15 @@ class PolySlab(base.Planar):
             # otherwise, bounds are directly based on the supplied vertices
             xmin, ymin = np.amin(self.vertices, axis=0)
             xmax, ymax = np.amax(self.vertices, axis=0)
+
+        # Account for arc segments extending beyond chord endpoints
+        if self._has_arc_segments:
+            vertices = self._canonical_vertices_and_bulges[0]
+            arc_mins, arc_maxs = _PolyBulgeUtil._polygon_arcs_bounds(vertices, self._bulge_data)
+            xmin = min(xmin, np.min(arc_mins[:, 0]))
+            ymin = min(ymin, np.min(arc_mins[:, 1]))
+            xmax = max(xmax, np.max(arc_maxs[:, 0]))
+            ymax = max(ymax, np.max(arc_maxs[:, 1]))
 
         # get bounds in (local) z
         zmin, zmax = self.slab_bounds
@@ -1273,6 +1886,13 @@ class PolySlab(base.Planar):
     def interior_angle(self) -> ArrayFloat1D:
         """Angle formed inside polygon by two adjacent edges."""
 
+        if self._has_arc_segments:
+            raise NotImplementedError(
+                "interior_angle does not account for arc segment geometry. "
+                "The angle at each vertex depends on the arc tangent directions, "
+                "not the chord directions."
+            )
+
         def normalize(v: NDArray) -> NDArray:
             return v / np.linalg.norm(v, axis=0)
 
@@ -1424,8 +2044,14 @@ class PolySlab(base.Planar):
 
         length = z_max - z_min
 
-        top_area = abs(self._area(self.top_polygon))
-        base_area = abs(self._area(self.base_polygon))
+        # Use arc-aware area calculation when arc segments present
+        if self._has_arc_segments:
+            arc_correction = _PolyBulgeUtil._arc_segment_area(self._bulge_data)
+            top_area = abs(self._area(self.top_polygon) + arc_correction)
+            base_area = abs(self._area(self.base_polygon) + arc_correction)
+        else:
+            top_area = abs(self._area(self.top_polygon))
+            base_area = abs(self._area(self.base_polygon))
 
         # https://mathworld.wolfram.com/PyramidalFrustum.html
         return 1.0 / 3.0 * length * (top_area + base_area + np.sqrt(top_area * base_area))
@@ -1438,11 +2064,18 @@ class PolySlab(base.Planar):
         top_polygon = self.top_polygon
         base_polygon = self.base_polygon
 
-        top_area = abs(self._area(top_polygon))
-        base_area = abs(self._area(base_polygon))
-
-        top_perim = self._perimeter(top_polygon)
-        base_perim = self._perimeter(base_polygon)
+        # Use arc-aware calculations when arc segments present
+        if self._has_arc_segments:
+            arc_correction = _PolyBulgeUtil._arc_segment_area(self._bulge_data)
+            top_area = abs(self._area(top_polygon) + arc_correction)
+            base_area = abs(self._area(base_polygon) + arc_correction)
+            top_perim = _PolyBulgeUtil._polygon_perimeter(top_polygon, self._bulge_data)
+            base_perim = _PolyBulgeUtil._polygon_perimeter(base_polygon, self._bulge_data)
+        else:
+            top_area = abs(self._area(top_polygon))
+            base_area = abs(self._area(base_polygon))
+            top_perim = self._perimeter(top_polygon)
+            base_perim = self._perimeter(base_polygon)
 
         z_min, z_max = self.slab_bounds
 
@@ -1474,6 +2107,13 @@ class PolySlab(base.Planar):
           gradients; this includes the +/- inf cases.
         - A 2d simulation collapses the surface integral to a line integral
         """
+        if self._has_arc_segments:
+            raise NotImplementedError(
+                "Adjoint derivatives are not supported for 'PolySlab' with non-zero "
+                "bulge (arc segment) values. Please use straight-edged polyslabs for "
+                "inverse design optimization."
+            )
+
         vjps: AutogradFieldMap = {}
 
         intersect_min, intersect_max = map(np.asarray, derivative_info.bounds_intersect)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core geometry computations (bounds, intersections, area/perimeter, containment) and introduces discretization-based behavior that could affect downstream meshing/queries, though guarded by strict validation and feature gating (no dilation/sidewall/adjoint).
> 
> **Overview**
> Adds arc-edge support to `PolySlab` via a new optional `bulges` array (bulge = tan(θ/4)) and propagates it through JSON schemas/changelog.
> 
> Implements arc geometry utilities, canonicalizes vertices+bulges together, and updates bounds/area/perimeter, `inside()`, and plane intersection logic to use an arc-discretized polygon when bulges are present, while enforcing new validations (length/finite values/no arc on zero-length edges/no self-intersecting arcs) and explicitly disallowing arcs with `dilation`, nonzero `sidewall_angle`, `interior_angle`, and adjoint derivatives. Extensive tests cover helper math, serialization, intersections, containment, and validation edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40fccbfd828c2c3ab9c3276b5a6b8d85aecfab29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->