### PR TITLE
chore: add changelog for field decay check update

### DIFF
--- a/changelog.d/3290.changed.md
+++ b/changelog.d/3290.changed.md
@@ -1,0 +1,1 @@
+Changed field decay checking from percentage-based intervals to a fixed number of time steps (default 400), enabling quicker automatic shutoff in long-running simulations.

--- a/changelog.d/3290.fixed.md
+++ b/changelog.d/3290.fixed.md
@@ -1,0 +1,1 @@
+Fixed premature simulation shutoff when sources have a delayed peak (e.g. large GaussianPulse offset), where zero field energy before the source activates was incorrectly interpreted as full decay.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changelog entries; no runtime behavior or APIs are modified in this PR.
> 
> **Overview**
> Adds changelog entries documenting a change to field decay checking (switching from percentage-based intervals to a fixed timestep count, default `400`) and a fix for premature simulation shutoff when sources have delayed peaks (e.g., large `GaussianPulse` offsets).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db2590dd08501d5b968639f41dc7ae1811e084df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->