### PR TITLE
fix(tidy3d): extras tests pydantic issues (FXC-5643)

### DIFF
--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -2703,7 +2703,7 @@ class DispersiveMedium(AbstractMedium, ABC):
     def _run_after_validators(self) -> Self:
         """Run post-init validations in an explicit, dependency-aware order."""
         super()._run_after_validators()
-        if "eps_inf" in self.model_fields:
+        if "eps_inf" in type(self).model_fields:
             call_wrapped_validator(DispersiveMedium._permittivity_modulation_validation, self)
         call_wrapped_validator(DispersiveMedium._conductivity_modulation_validation, self)
         return self


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to post-init validation gating; main risk is subtle behavior change in when the `eps_inf`-dependent validation triggers for subclasses.
> 
> **Overview**
> Fixes a Pydantic validator guard in `DispersiveMedium._run_after_validators` by checking `"eps_inf" in type(self).model_fields` instead of `self.model_fields`.
> 
> This ensures the permittivity modulation validation runs (or is skipped) based on the model’s declared fields in a way that’s compatible with newer Pydantic behavior and avoids erroneous validator execution/omission.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70b025a1f01bf7d1b3c997ac7f100b99de5dbd1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->