### PR TITLE
fix(FXC-9999): make testmon cache keys reflect tested commit

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -710,9 +710,18 @@ jobs:
           } | sha256sum | awk '{print $1}'
         )
 
+        cache_layout="v2"
+        if [[ "${GITHUB_EVENT_NAME}" == "merge_group" ]]; then
+          cache_sha="${GITHUB_SHA}"
+        else
+          cache_sha="${default_branch_sha}"
+        fi
+
         echo "default_branch=$default_branch" >> "$GITHUB_OUTPUT"
         echo "default_branch_sha=$default_branch_sha" >> "$GITHUB_OUTPUT"
         echo "dep_hash=$dep_hash" >> "$GITHUB_OUTPUT"
+        echo "cache_layout=$cache_layout" >> "$GITHUB_OUTPUT"
+        echo "cache_sha=$cache_sha" >> "$GITHUB_OUTPUT"
 
     - name: restore-testmon-cache
       id: testmon-cache-restore
@@ -720,11 +729,9 @@ jobs:
       uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: .testmondata
-        key: testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
+        key: testmon-local-${{ steps.testmon-cache-key.outputs.cache_layout }}-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.cache_sha }}
         restore-keys: |
-          testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-
-          testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-
-          testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-
+          testmon-local-${{ steps.testmon-cache-key.outputs.cache_layout }}-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-
 
     - name: telemetry-cache-exact-hit
       if: >-
@@ -814,7 +821,7 @@ jobs:
     - name: stage-testmon-cache-candidate
       if: success() && github.event_name == 'merge_group' && hashFiles('.testmondata') != ''
       env:
-        CACHE_KEY: testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
+        CACHE_KEY: testmon-local-${{ steps.testmon-cache-key.outputs.cache_layout }}-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.cache_sha }}
       run: |
         set -euo pipefail
         candidate_dir="$RUNNER_TEMP/testmon-cache-candidate-local-py${{ matrix.python-version }}"
@@ -844,7 +851,7 @@ jobs:
       uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: .testmondata
-        key: testmon-local-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
+        key: testmon-local-${{ steps.testmon-cache-key.outputs.cache_layout }}-${{ runner.os }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.cache_sha }}
 
     - name: diff-coverage-report
       if: >- 
@@ -964,9 +971,18 @@ jobs:
           } | sha256sum | awk '{print $1}'
         )
 
+        cache_layout="v2"
+        if [[ "${GITHUB_EVENT_NAME}" == "merge_group" ]]; then
+          cache_sha="${GITHUB_SHA}"
+        else
+          cache_sha="${default_branch_sha}"
+        fi
+
         echo "default_branch=$default_branch" >> "$GITHUB_OUTPUT"
         echo "default_branch_sha=$default_branch_sha" >> "$GITHUB_OUTPUT"
         echo "dep_hash=$dep_hash" >> "$GITHUB_OUTPUT"
+        echo "cache_layout=$cache_layout" >> "$GITHUB_OUTPUT"
+        echo "cache_sha=$cache_sha" >> "$GITHUB_OUTPUT"
 
     - name: restore-testmon-cache
       id: testmon-cache-restore
@@ -974,11 +990,9 @@ jobs:
       uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: .testmondata
-        key: testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
+        key: testmon-remote-${{ steps.testmon-cache-key.outputs.cache_layout }}-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.cache_sha }}
         restore-keys: |
-          testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-
-          testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-
-          testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-
+          testmon-remote-${{ steps.testmon-cache-key.outputs.cache_layout }}-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-
 
     - name: telemetry-cache-exact-hit
       if: >-
@@ -1113,7 +1127,7 @@ jobs:
     - name: stage-testmon-cache-candidate
       if: success() && github.event_name == 'merge_group' && hashFiles('.testmondata') != ''
       env:
-        CACHE_KEY: testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
+        CACHE_KEY: testmon-remote-${{ steps.testmon-cache-key.outputs.cache_layout }}-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.cache_sha }}
       run: |
         set -euo pipefail
         candidate_dir="$RUNNER_TEMP/testmon-cache-candidate-remote-${{ matrix.platform }}-py${{ matrix.python-version }}"
@@ -1143,7 +1157,7 @@ jobs:
       uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: .testmondata
-        key: testmon-remote-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.default_branch_sha }}
+        key: testmon-remote-${{ steps.testmon-cache-key.outputs.cache_layout }}-${{ matrix.platform }}-py${{ matrix.python-version }}-${{ steps.testmon-cache-key.outputs.default_branch }}-${{ steps.testmon-cache-key.outputs.dep_hash }}-${{ steps.testmon-cache-key.outputs.cache_sha }}
 
     - name: create-badge
       if: ${{ github.ref == 'refs/heads/develop' }}


### PR DESCRIPTION
## Summary
- switch testmon cache keys to a versioned `v2` layout for clean migration
- set cache SHA from `GITHUB_SHA` on `merge_group` runs so promoted cache content matches the tested tree
- keep PR restores keyed to current default-branch SHA and narrow fallback to dep-hash-only within the same `v2` namespace

## Why
Recent PR runs showed exact cache-key hits while testmon still reported broad file churn and selected ~full suites. This change aligns key provenance with the commit that produced the cache payload and avoids reusing stale broad fallbacks.

## Validation
- workflow YAML diff reviewed for both local and remote test jobs
- no non-testmon workflow steps were added or removed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change limited to cache key computation and restore/save behavior; risk is mainly CI cache misses or reduced cache reuse increasing test times.
> 
> **Overview**
> **Fixes testmon cache-key provenance in CI.** The workflow now uses a versioned `v2` testmon cache key layout and switches the key’s SHA component to `GITHUB_SHA` for `merge_group` runs so saved/promoted `.testmondata` matches the commit that was actually tested.
> 
> For PR runs, cache keys remain tied to the current default-branch SHA, and fallback restores are narrowed to *dep-hash-only* within the new `v2` namespace (removing broader restore prefixes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 042f0c390bb9dca009c755e3eeb191e670804a43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->