### PR TITLE
fix(tidy3d): FXC-5644-prevent-jupyter-output-leakage-on-tidy-3-d-import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `ModeSolver.validate_pre_upload` not validating `MicrowaveModeSpec` with `AutoImpedanceSpec`, causing cryptic server-side errors for invalid conductor geometries.
 - Fixed local cache not storing results for `ModalComponentModeler` (and `TerminalComponentModeler`) runs, causing cache misses on repeated `web.run()` calls.
 - Fixed spurious `ModeSimulation` error logs during deserialization of `SimulationDataMap` by adding discriminators to `SimulationType` and `SimulationDataType` unions.
+- Fixed unintended model output in Jupyter notebooks during `import tidy3d` by preventing `Tidy3dBaseModel.__str__` from triggering notebook display side effects.
 
 ## [2.10.2] - 2026-01-21
 

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -1856,7 +1856,7 @@ class Tidy3dBaseModel(BaseModel):
         from rich.console import Console
 
         sio = StringIO()
-        console = Console(file=sio)
+        console = Console(file=sio, force_jupyter=False)
         console.print(self)
         output = sio.getvalue()
         return output.rstrip("\n")


### PR DESCRIPTION
### Summary
This PR fixes unintended model output in Jupyter notebooks during `import tidy3d`.

### Problem
In a fresh notebook kernel, importing `tidy3d` could print large model representations (for example `ModeSpec(...)`) even though import should be silent.

### Root Cause
`Tidy3dBaseModel.__str__` uses Rich rendering, and the console behavior could trigger notebook display side effects while building string output.

### Changes
- Updated `Tidy3dBaseModel.__str__` in `tidy3d/components/base.py` to use a console configuration that prevents notebook side display and keeps output as captured string content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to string formatting behavior; low risk aside from minor differences in Rich rendering in notebook contexts.
> 
> **Overview**
> Prevents unintended model rendering/output in Jupyter notebooks during `import tidy3d` by changing `Tidy3dBaseModel.__str__` to construct a Rich `Console` with `force_jupyter=False`, ensuring `str(model)` is captured purely as text and doesn’t trigger notebook display side effects.
> 
> Updates the unreleased changelog to document the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e42e22cee3bfd94d44c1be82515f0905f85b9ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->