### PR TITLE
chore: clean up warning messages

### DIFF
--- a/tidy3d/components/tcad/monitors/abstract.py
+++ b/tidy3d/components/tcad/monitors/abstract.py
@@ -44,10 +44,7 @@ class HeatChargeMonitor(AbstractMonitor, ABC):
         """Warn if deprecated ``conformal`` field is provided."""
         # Note:  Only warn when the deprecated flag is actually enabled.
         if isinstance(values, dict) and values.get("conformal"):
-            log.warning(
-                "The `conformal` flag is deprecated and will be removed in version 2.12. "
-                "It has no effect when the simulation mesh is created with `remove_fragments=True`.",
-            )
+            log.warning("The 'conformal' flag is deprecated and will be removed in version 2.12.")
         return values
 
     def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -1085,7 +1085,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
         if nodes_estimate > max_nodes:
             log.warning(
-                "WARNING: It has been estimated the mesh to be bigger than the currently "
+                "It is estimated that the mesh will be larger than the currently "
                 "supported mesh size for Charge simulations. The simulation may be "
                 "submitted but if the maximum number of nodes is indeed exceeded "
                 "the pipeline will be stopped. If this happens the grid specification "


### PR DESCRIPTION
## Summary
- Simplify deprecated `conformal` flag message to just state deprecation without extra context
- Remove redundant "WARNING:" prefix from `log.warning()` call in heat charge simulation

## Test plan
- [x] Pre-commit hooks pass

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only changes to log warnings; no functional behavior or data flow is modified.
> 
> **Overview**
> **Cleans up TCAD warning output** by simplifying the deprecated `HeatChargeMonitor.conformal` warning to only state that the flag will be removed in v2.12.
> 
> Also rephrases the Charge mesh-size estimate warning in `HeatChargeSimulation._estimate_charge_mesh_size()` to remove the redundant `WARNING:` prefix and improve wording, without changing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbb8bf998aefa41f4f3f2af5a2b0368e0b76b85c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->