### PR TITLE
fix(web): add clear Batch key validation after pydantic v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added baseband source time classes (`BasebandStep`, `BasebandGaussianPulse`, `BasebandRectangularPulse`, `BasebandCustomSourceTime`) for transient RF simulations with real-valued time signals.
 
 ### Breaking Changes
+- `web.Batch(simulations=...)` now requires string task names when simulations are passed as a dictionary. Numeric keys (for example `0`, `1`) are no longer converted automatically; convert them to strings first (for example `"0"`, `"1"`).
 - Added optional automatic extrusion of structures at the simulation boundaries into/through PML/Absorber layers via `extrude_structures` field in class `AbsorberSpec`.
 - Added `structure_priority_mode` for `TerminalComponentModeler` and default to `"conductor"` to ensure metal structures override dielectrics regardless of structure order, preventing order-dependent results in RF simulations.
 - 1D lumped elements (with zero lateral extent) are no longer allowed. Use a small finite lateral extent (e.g., `1e-6`) instead.

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 import responses
 from _pytest import monkeypatch
+from pydantic import ValidationError
 from responses import matchers
 
 import tidy3d as td
@@ -709,6 +710,31 @@ def test_batch(mock_webapi, mock_job_status, mock_load, tmp_path, task_name):
     b2.run(path_dir=str(tmp_path))
     _ = b2.get_info()
     assert b2.real_cost() == FLEX_UNIT * len(sims)
+
+
+def test_batch_accepts_string_simulation_keys():
+    sims = {"0": make_sim(), "1": make_sim()}
+
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME)
+
+    assert tuple(batch.simulations.keys()) == ("0", "1")
+
+
+def test_batch_rejects_numeric_simulation_keys_with_clear_message():
+    sims = {0: make_sim()}
+
+    with pytest.raises(
+        ValidationError,
+        match="Batch simulations keys must be strings \\(task names\\)",
+    ):
+        Batch(simulations=sims, folder_name=PROJECT_NAME)
+
+
+def test_batch_rejects_non_string_non_numeric_simulation_keys():
+    sims = {("task",): make_sim()}
+
+    with pytest.raises(ValidationError, match="Use explicit string keys"):
+        Batch(simulations=sims, folder_name=PROJECT_NAME)
 
 
 @responses.activate

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -15,7 +15,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
-from pydantic import Field, PositiveInt, PrivateAttr, model_validator
+from pydantic import Field, PositiveInt, PrivateAttr, field_validator, model_validator
 from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeElapsedColumn
 
 from tidy3d._runtime import WASM_BUILD
@@ -855,6 +855,23 @@ class Batch(WebContainer):
     )
 
     _job_type: type = PrivateAttr(Job)
+
+    @field_validator("simulations", mode="before")
+    @classmethod
+    def _validate_simulation_keys_are_task_names(cls, simulations: Any) -> Any:
+        """Ensure mapping keys are task-name strings with a concise error message."""
+        if not isinstance(simulations, Mapping):
+            return simulations
+
+        for task_name in simulations:
+            if not isinstance(task_name, str):
+                raise ValueError(
+                    "Batch simulations keys must be strings (task names). "
+                    f"Got key {task_name!r} of type {type(task_name).__name__!r}. "
+                    "Use explicit string keys, for example: simulations[str(i)] = simulation."
+                )
+
+        return simulations
 
     def run(
         self,


### PR DESCRIPTION
## Summary
- keep strict `Batch(simulations=...)` task-name behavior: keys must be `str`
- add a focused pre-validation on `Batch.simulations` that raises a concise actionable error when keys are non-string
- add tests for accepted string keys and rejected non-string keys
- document this in `CHANGELOG.md` under **Breaking Changes**

## Why
Pydantic v2 narrowed implicit coercion, so non-string dict keys now surface as hard validation failures. This change preserves strict task-name semantics and improves the error quality for users.

## Validation
- `poetry run pytest -q tests/test_web/test_webapi.py -k "batch_accepts_string_simulation_keys or batch_rejects_numeric_simulation_keys_with_clear_message or batch_rejects_non_string_non_numeric_simulation_keys"`
- `poetry run ruff check tidy3d/web/api/container.py tests/test_web/test_webapi.py`

Refs: FXC-5671

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tightens client-side validation for `web.Batch(simulations=...)` dict inputs and updates tests/docs; main risk is breaking existing user code relying on implicit numeric-key coercion.
> 
> **Overview**
> `web.Batch(simulations=...)` now *explicitly requires* dictionary keys to be string task names, with a new pre-validation (`field_validator` on `Batch.simulations`) that raises a clear, actionable error when keys are non-strings.
> 
> Adds focused tests covering accepted string keys and rejection of numeric/other non-string keys (surfacing `pydantic.ValidationError`), and documents the behavior as a **Breaking Change** in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ce701924342378ce1e00065cdf6e704f8b2aed0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->