### PR TITLE
fix(tidy3d): suppress error logs during speculative model instantiation in repr

### DIFF
--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -372,3 +372,103 @@ def test_assert_log_level():
     # Test when log level is higher than expected
     with pytest.raises(AssertionError), AssertLogLevel("INFO"):
         td.log.warning("ABC")  # Should fail since WARNING > INFO
+
+
+def test_suppress_output():
+    """Test that suppress_output() context manager prevents log messages from being emitted."""
+    from ..utils import AssertLogLevelHandler
+
+    # Register a handler to capture log records
+    handler = AssertLogLevelHandler()
+    td.log.handlers["test_suppress"] = handler
+
+    try:
+        # Without suppression, messages should be captured
+        td.log.warning("visible warning")
+        td.log.error("visible error")
+        assert len(handler.records) == 2
+
+        # With suppression, messages should not be captured
+        with td.log.suppress_output():
+            td.log.warning("suppressed warning")
+            td.log.error("suppressed error")
+            td.log.info("suppressed info")
+
+        # Still only 2 records from before
+        assert len(handler.records) == 2
+
+        # After exiting context, messages should be captured again
+        td.log.warning("visible again")
+        assert len(handler.records) == 3
+
+        # Nested suppression should work correctly
+        with td.log.suppress_output():
+            td.log.warning("outer suppressed")
+            with td.log.suppress_output():
+                td.log.warning("inner suppressed")
+            td.log.warning("still outer suppressed")
+
+        # Still only 3 records
+        assert len(handler.records) == 3
+
+    finally:
+        del td.log.handlers["test_suppress"]
+
+
+def test_suppress_output_during_repr():
+    """Test that suppress_output prevents spurious errors during repr of models that can't be default-instantiated.
+
+    This tests the scenario where:
+    1. A model has optional fields with defaults (so Pydantic can attempt to instantiate it)
+    2. A validator raises SetupError when instantiated with defaults (which logs an error)
+    3. The repr optimization tries to create a default instance to compare against
+    4. Without suppress_output, the error would be logged even though it's caught
+
+    This mirrors what happens with CustomMedium (permittivity=None by default, but validator
+    requires either permittivity or eps_dataset to be provided).
+    """
+    from typing import Optional
+
+    from pydantic import model_validator
+
+    from tidy3d.components.base import Tidy3dBaseModel
+    from tidy3d.exceptions import SetupError
+
+    from ..utils import AssertLogLevelHandler
+
+    # Create a model that:
+    # - Has optional field with None default (so Pydantic can instantiate it)
+    # - Raises SetupError in validator when value is None (which logs an error before raising)
+    class _ModelRequiringValue(Tidy3dBaseModel):
+        value: Optional[float] = None
+
+        @model_validator(mode="after")
+        def _check_value(self):
+            if self.value is None:
+                raise SetupError("test error: value cannot be None")
+            return self
+
+    # Verify the model raises when instantiated with no args
+    # (SetupError is wrapped in Pydantic's ValidationError)
+    with pytest.raises(ValidationError, match="value cannot be None"):
+        _ModelRequiringValue()
+
+    # Register a handler to capture log records
+    handler = AssertLogLevelHandler()
+    td.log.handlers["test_repr"] = handler
+
+    try:
+        # Create a valid instance (with value provided)
+        model = _ModelRequiringValue(value=1.0)
+
+        # repr() internally tries to create _ModelRequiringValue() to compare defaults.
+        # This fails with SetupError, which logs an error before raising.
+        # The suppress_output context manager should prevent this error from appearing.
+        _ = repr(model)
+
+        # Check that no ERROR level messages were logged
+        error_records = [r for r in handler.records if r[0] >= _get_level_int("ERROR")]
+        assert len(error_records) == 0, f"Unexpected error logs during repr: {error_records}"
+
+    finally:
+        del td.log.handlers["test_repr"]

--- a/tidy3d/components/docstrings.py
+++ b/tidy3d/components/docstrings.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
 import numpy as np
 from pydantic import BaseModel, TypeAdapter
 
+from tidy3d.log import log
+
 if TYPE_CHECKING:
     from typing import Optional
 
@@ -108,7 +110,11 @@ def _format_model_default(model: BaseModel, *, show_default_args: bool) -> str:
 
     model_cls = model.__class__
     try:
-        default_model = model_cls()
+        # Suppress log output during speculative default model creation, as some models
+        # (e.g. CustomMedium, ParameterPerturbation) cannot be instantiated without
+        # required arguments and their validators log error messages before raising.
+        with log.suppress_output():
+            default_model = model_cls()
         current_dump = model.model_dump()
         default_dump = default_model.model_dump()
     except Exception:

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -139,6 +139,7 @@ class Logger:
         self._stack = None
         self._capture = False
         self._captured_warnings = []
+        self._suppress_all = False
 
     def set_capture(self, capture: bool) -> None:
         """Turn on/off tree-like capturing of log messages."""
@@ -178,6 +179,20 @@ class Logger:
                 self.log(max_level, "Suppressed " + ", ".join(counts) + noun)
                 self._stack = stack
         return False
+
+    @contextmanager
+    def suppress_output(self) -> Iterator[None]:
+        """Context manager to suppress all log output.
+
+        This is useful for speculative operations where validation failures are expected
+        and their error messages should not be shown to the user.
+        """
+        old_value = self._suppress_all
+        self._suppress_all = True
+        try:
+            yield
+        finally:
+            self._suppress_all = old_value
 
     def begin_capture(self) -> None:
         """Start capturing log stack for consolidated validation log.
@@ -279,6 +294,10 @@ class Logger:
         capture: bool = True,
     ) -> None:
         """Distribute log messages to all handlers"""
+
+        # Skip all output if suppression is active (for speculative operations)
+        if self._suppress_all:
+            return
 
         # Check global cache if requested or if warn_once is enabled for warnings
         # (before composing/capturing to avoid duplicates)


### PR DESCRIPTION
## Summary

- Add `suppress_output()` context manager to the Logger class
- Use it in `_format_model_default` when attempting to create default model instances for repr comparison

## Problem

Spurious ERROR messages were appearing in Jupyter notebooks when displaying perturbed simulations (e.g., `sim_zero_voltage` in the ChargeSolver notebook):

```
ERROR: Missing spatial profiles of 'permittivity' or 'eps_dataset'.
ERROR: Perturbation models 'heat' and 'charge' in 'ParameterPerturbation' cannot be simultaneously 'None'.
```

These errors occurred because `_format_model_default` (used by `__repr__`) tries to instantiate `model_cls()` with no arguments to compare against defaults and show only non-default fields. However, some models (`CustomMedium`, `ParameterPerturbation`) cannot be created without required arguments, and their validators log error messages **before** raising exceptions.

## Solution

Added a `suppress_output()` context manager to temporarily disable all log output during speculative operations where validation failures are expected. This prevents confusing error messages from appearing to users when the underlying operation (displaying the object) actually succeeds.

## Test plan

- [x] Verified ERROR messages no longer appear when calling `repr()` on perturbed simulations
- [x] Verified all pre-commit hooks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global logger behavior by adding a blanket suppression flag; incorrect scoping could hide real warnings/errors or interfere with log capture in edge cases.
> 
> **Overview**
> Prevents spurious ERROR logs during `repr()`/docstring rendering by suppressing logging while `_format_model_default` speculatively instantiates `model_cls()` to diff against defaults.
> 
> Adds `Logger.suppress_output()` (and a `_suppress_all` gate in `_log`) to temporarily silence all handler output, and introduces tests covering suppression behavior (including nesting) and ensuring no ERROR records are emitted during `repr()` of a model that fails default instantiation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ae646f421f693d837d092cad0fa0d5e6f3eb0b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->