### PR TITLE
fix: autograd notebook variable update (FXC-5098)

### DIFF
--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -787,9 +787,10 @@ def test_mode_data_with_fields_sort(conjugated_dot_product):
     unsorting = np.arange(num_modes) * np.ones((num_freqs, num_modes))
     unsorting = unsorting.astype(int)
     # we keep first, central, and last sorted
+    rng = np.random.default_rng(12345)
     for freq_id in range(1, num_freqs - 1):
         if freq_id != num_freqs // 2:
-            unsorting[freq_id, :] = np.random.permutation(unsorting[freq_id, :])
+            unsorting[freq_id, :] = rng.permutation(unsorting[freq_id, :])
 
     # unsort using sorting tool
     data_unsorted = data._apply_mode_reorder(unsorting)

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -1154,7 +1154,7 @@ def _run_bwd(
                     if isinstance(val, (list, tuple)) and isinstance(v, (list, tuple)):
                         vjp_traced_fields[k] = type(val)(x + y for x, y in zip(val, v))
                     else:
-                        vjp_traced_fields[k] += v
+                        vjp_traced_fields[k] = vjp_traced_fields[k] + v
                 else:
                     vjp_traced_fields[k] = v
 
@@ -1302,7 +1302,7 @@ def _run_async_bwd(
                     if isinstance(val, (list, tuple)) and isinstance(v, (list, tuple)):
                         sim_fields_vjp_dict[task_name][k] = type(val)(x + y for x, y in zip(val, v))
                     else:
-                        sim_fields_vjp_dict[task_name][k] += v
+                        sim_fields_vjp_dict[task_name][k] = sim_fields_vjp_dict[task_name][k] + v
                 else:
                     sim_fields_vjp_dict[task_name][k] = v
 


### PR DESCRIPTION
> GitHub Actions run #22105130616 revealed 72 notebook failures. After triaging, one tidy3d client code bug was identified: the autograd backward pass crashes with ValueError: output array is read-only
>      when accumulating VJP contributions from multiple adjoint simulations.
> 
>      Root cause: _coerce() in tidy3d/components/types/base.py:137 sets arr.flags.writeable = False on all Pydantic model arrays. When the autograd code uses += (in-place addition) on arrays that originated
>      from Pydantic fields, NumPy raises a read-only error.
> 
>      Change
> 
>      File: tidy3d/web/api/autograd/autograd.py
> 
>      Two locations use += on potentially read-only arrays:
> 
>      Line 1157 (in _run_bwd VJP)
> 
>      # Before:
>      vjp_traced_fields[k] += v
> 
>      # After:
>      vjp_traced_fields[k] = vjp_traced_fields[k] + v
> 
>      Line 1305 (in _run_async_bwd VJP)
> 
>      # Before:
>      sim_fields_vjp_dict[task_name][k] += v
> 
>      # After:
>      sim_fields_vjp_dict[task_name][k] = sim_fields_vjp_dict[task_name][k] + v
> 
>      Using = ... + v creates a new (writable) array instead of trying to mutate in-place.
> 
> 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches gradient accumulation in autograd backward passes; while the change is small, it affects correctness/performance of adjoint gradient computation and should be validated against existing gradient workflows.
> 
> **Overview**
> Fixes autograd VJP accumulation when combining contributions from multiple adjoint simulations by avoiding in-place `+=` on potentially read-only NumPy arrays (switches to `x = x + v` in both sync and async backward passes).
> 
> Makes the `test_mode_data_with_fields_sort` permutation deterministic by using a seeded `np.random.default_rng` instead of the global `np.random.permutation`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6b6e47464b9a5ee9b1f662dfef7240c7eb07359. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->