### PR TITLE
fix(web): include workflow_type in local cache key to prevent cross-type collisions

### DIFF
--- a/tests/test_web/test_local_cache.py
+++ b/tests/test_web/test_local_cache.py
@@ -1073,3 +1073,123 @@ def test_cache_cli_commands(monkeypatch, tmp_path_factory, basic_simulation, tmp
     list_after = runner.invoke(tidy3d_cli, ["cache", "list"])
     assert list_after.exit_code == 0
     assert "Cache is empty." in list_after.output
+
+
+def test_cache_key_includes_workflow_type():
+    """build_cache_key must produce different keys for different workflow types
+    even when the simulation hash and version are identical.
+
+    Regression test for a bug where a VolumeMesher result could be returned
+    when a HeatChargeSimulation was run because both shared the same inner
+    simulation hash and workflow_type was not part of the cache key.
+    """
+    from tidy3d.web.cache import build_cache_key
+
+    common_hash = "abc123"
+    version = "1.0"
+
+    key_heat = build_cache_key(
+        simulation_hash=common_hash, version=version, workflow_type="HEAT_CHARGE"
+    )
+    key_mesh = build_cache_key(
+        simulation_hash=common_hash, version=version, workflow_type="VOLUME_MESH"
+    )
+    key_fdtd = build_cache_key(simulation_hash=common_hash, version=version, workflow_type="FDTD")
+
+    assert key_heat != key_mesh, "HEAT_CHARGE and VOLUME_MESH must produce different cache keys"
+    assert key_heat != key_fdtd, "HEAT_CHARGE and FDTD must produce different cache keys"
+    assert key_mesh != key_fdtd, "VOLUME_MESH and FDTD must produce different cache keys"
+
+    # Same inputs must be deterministic
+    key_heat2 = build_cache_key(
+        simulation_hash=common_hash, version=version, workflow_type="HEAT_CHARGE"
+    )
+    assert key_heat == key_heat2
+
+
+def test_volume_mesh_cache_no_collision_with_heat(tmp_path_factory):
+    """Storing a VOLUME_MESH result must not be returned when fetching a
+    HeatChargeSimulation that shares the same inner simulation.
+
+    Reproduces the notebook bug where web.run(sim, parent_tasks=[mesh_job.task_id])
+    returned VolumeMesherData instead of running the heat solver.
+    """
+    heat_sim = td.HeatChargeSimulation(
+        size=(3.0, 3.0, 3.0),
+        medium=td.Medium(permittivity=1.0, heat_spec=td.FluidSpec()),
+        structures=[
+            td.Structure(
+                geometry=td.Box(size=(1, 1, 1), center=(0, 0, 0)),
+                medium=td.Medium(
+                    permittivity=2.0,
+                    heat_spec=td.SolidSpec(conductivity=1, capacity=1),
+                ),
+                name="box",
+            ),
+        ],
+        grid_spec=td.UniformUnstructuredGrid(dl=0.5),
+        sources=[td.HeatSource(rate=1, structures=["box"])],
+        boundary_spec=[
+            td.HeatChargeBoundarySpec(
+                placement=td.StructureBoundary(structure="box"),
+                condition=td.TemperatureBC(temperature=300),
+            )
+        ],
+        monitors=[
+            td.TemperatureMonitor(center=(0, 0, 0), size=(1, 1, 0), name="temp", unstructured=True),
+        ],
+    )
+
+    mesher = td.VolumeMesher(
+        simulation=heat_sim,
+        monitors=[
+            td.VolumeMeshMonitor(center=(0, 0, 0), size=(1, 1, 0), name="mesh"),
+        ],
+    )
+
+    cache = resolve_local_cache(use_cache=True)
+    cache.clear()
+
+    # Store a fake result keyed as if it came from a VOLUME_MESH task.
+    # Use simulation=None so store_result extracts stub_data.simulation (the HeatChargeSimulation).
+    artifact = tmp_path_factory.mktemp("mesh_art") / CACHE_ARTIFACT_NAME
+    artifact.write_text("mesh-payload")
+
+    class _FakeVolumeMesherData:
+        """Minimal stand-in for VolumeMesherData with .simulation = HeatChargeSimulation."""
+
+        def __init__(self, sim):
+            self.simulation = sim
+
+    cache.store_result(
+        stub_data=_FakeVolumeMesherData(heat_sim),
+        task_id="vom-fake-id",
+        path=str(artifact),
+        workflow_type="VOLUME_MESH",
+    )
+    assert len(cache) == 1
+
+    # try_fetch for the HeatChargeSimulation must NOT return the VOLUME_MESH entry
+    entry = cache.try_fetch(heat_sim)
+    assert entry is None, (
+        "Cache returned a VOLUME_MESH entry for a HeatChargeSimulation lookup; "
+        "workflow_type must be part of the cache key to prevent this collision."
+    )
+
+    # try_fetch for the VolumeMesher itself must also NOT match (different sim hash)
+    entry_mesher = cache.try_fetch(mesher)
+    assert entry_mesher is None
+
+    # Storing a HEAT_CHARGE result should then be fetchable
+    heat_artifact = tmp_path_factory.mktemp("heat_art") / CACHE_ARTIFACT_NAME
+    heat_artifact.write_text("heat-payload")
+    cache.store_result(
+        stub_data=_FakeVolumeMesherData(heat_sim),
+        task_id="hcs-fake-id",
+        path=str(heat_artifact),
+        workflow_type="HEAT_CHARGE",
+    )
+    assert len(cache) == 2
+
+    entry_heat = cache.try_fetch(heat_sim)
+    assert entry_heat is not None, "HEAT_CHARGE entry should be fetchable for HeatChargeSimulation"

--- a/tidy3d/web/cache.py
+++ b/tidy3d/web/cache.py
@@ -625,6 +625,7 @@ class LocalCache:
             cache_key = build_cache_key(
                 simulation_hash=simulation_hash,
                 version=versions,
+                workflow_type=workflow_type,
             )
 
             entry = self._fetch(cache_key)
@@ -678,14 +679,18 @@ class LocalCache:
         Legacy task ID mappings are recorded to support backward lookup compatibility.
         """
         try:
+            workflow_name = (
+                workflow_type.value if isinstance(workflow_type, TaskType) else workflow_type
+            )
+
+            if not workflow_name:
+                log.debug("Failed storing local cache entry: workflow_type is not set.")
+                return False
+
             if simulation is not None:
                 simulation_obj = simulation
             else:
-                workflow_name = (
-                    workflow_type.value if isinstance(workflow_type, TaskType) else workflow_type
-                )
                 if workflow_name in {TaskType.MODAL_CM.value, TaskType.TERMINAL_CM.value}:
-                    # ComponentModelerData types use 'modeler' instead of 'simulation'
                     simulation_obj = getattr(stub_data, "modeler", None)
                 else:
                     simulation_obj = getattr(stub_data, "simulation", None)
@@ -704,6 +709,7 @@ class LocalCache:
             cache_key = build_cache_key(
                 simulation_hash=simulation_hash,
                 version=version,
+                workflow_type=workflow_name,
             )
 
             metadata = build_entry_metadata(
@@ -843,12 +849,19 @@ def build_cache_key(
     *,
     simulation_hash: str,
     version: str,
+    workflow_type: str,
 ) -> str:
-    """Construct a deterministic cache key."""
+    """Construct a deterministic cache key.
+
+    ``workflow_type`` is included so that different task types sharing the same
+    underlying simulation (e.g. ``VolumeMesher`` vs ``HeatChargeSimulation``)
+    never collide.
+    """
 
     payload = {
         "simulation_hash": simulation_hash,
         "versions": _canonicalize(version),
+        "workflow_type": workflow_type,
     }
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()


### PR DESCRIPTION
## Summary

- Fixes a bug where the local simulation cache returned `VolumeMesherData` when a `HeatChargeSimulation` was run, because both produced the same cache key.
- Adds `workflow_type` to the `build_cache_key` payload so that different task types (e.g. `VOLUME_MESH` vs `HEAT_CHARGE`) always produce distinct cache keys, even when the underlying simulation hash is identical.

## Context

`VolumeMesherData` subclasses `AbstractHeatChargeSimulationData`, so its `.simulation` field is the inner `HeatChargeSimulation` rather than the original `VolumeMesher`. This design choice was made so `VolumeMesherData` can share internal data-manipulation and plotting methods with `HeatChargeSimulationData`, but it breaks the typical pattern where `Data.simulation` is the original workflow object. This should be revisited in a future refactor.

When `store_result` fell back to `getattr(stub_data, "simulation")`, the cache key was computed from the `HeatChargeSimulation` hash. A subsequent `web.run(sim)` for the same `HeatChargeSimulation` then matched that key and erroneously returned the `VolumeMesherData`.

Existing cache entries become unreachable after this change and will be evicted naturally by the LRU policy.

## Test plan

- [x] `test_cache_key_includes_workflow_type` — unit test: same sim hash + different workflow types produce different cache keys
- [x] `test_volume_mesh_cache_no_collision_with_heat` — integration test: storing a `VOLUME_MESH` result then fetching for `HeatChargeSimulation` must not return it
- [x] All 21 cache tests pass (`pytest tests/test_web/test_local_cache.py`)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the cache key format, making existing cache entries unreachable until naturally evicted and potentially altering cache hit rates; otherwise logic is small and covered by targeted tests.
> 
> **Overview**
> Fixes local-cache collisions by including `workflow_type` in `build_cache_key`, and wires this through both cache lookups (`LocalCache.try_fetch`) and writes (`LocalCache.store_result`).
> 
> Adds regression tests ensuring different workflow types with the same underlying simulation hash cannot hit the same cache entry, including a reproduction where a stored `VOLUME_MESH` result must not be returned for a `HeatChargeSimulation` fetch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d207aab0e718d605126730fe15f7717aa30c6c17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->