### PR TITLE
refactor: simplify get_dls for 2D material volumetric equivalents

### DIFF
--- a/tidy3d/components/geometry/utils_2d.py
+++ b/tidy3d/components/geometry/utils_2d.py
@@ -38,14 +38,6 @@ def get_bounds(geom: Geometry, axis: Axis) -> tuple[float, float]:
     return (geom.bounds[0][axis], geom.bounds[1][axis])
 
 
-def get_thickened_geom(geom: Geometry, axis: Axis) -> Geometry:
-    """Helper to return a slightly thickened version of a planar geometry."""
-    center = get_bounds(geom, axis)[0]
-    neg_thickness = increment_float(center, -1.0)
-    pos_thickness = increment_float(center, 1.0)
-    return geom._update_from_bounds(bounds=(neg_thickness, pos_thickness), axis=axis)
-
-
 def get_neighbors(
     geom: Geometry,
     axis: Axis,

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -58,7 +58,7 @@ from .frequency_extrapolation import LowFrequencySmoothingSpec
 from .geometry.base import Box, Geometry, GeometryGroup
 from .geometry.mesh import TriangleMesh
 from .geometry.utils import _shift_object, flatten_groups, traverse_geometries
-from .geometry.utils_2d import get_bounds, get_thickened_geom, snap_coordinate_to_grid, subdivide
+from .geometry.utils_2d import get_bounds, snap_coordinate_to_grid, subdivide
 from .grid.grid import Coords, Grid
 from .grid.grid_spec import AutoGrid, GridSpec, UniformGrid
 from .lumped_element import LumpedElementType
@@ -1871,26 +1871,28 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         if not self._contains_converted_volumetric_structures:
             return self.scene.sorted_structures
 
-        def get_dls(geom: Geometry, axis: Axis, num_dls: int) -> list[float]:
-            """Get grid size around the 2D material."""
-            dls = self._discretize_grid(Box.from_bounds(*geom.bounds), grid=grid).sizes.to_list[
-                axis
-            ]
-            # When 1 dl is requested it is assumed that only an approximate value is needed
-            # before the 2D material has been snapped to the grid
-            if num_dls == 1:
-                return [np.mean(dls)]
+        def get_dls(snapped_center: float, axis: Axis) -> list[float]:
+            """Get grid sizes adjacent to a 2D material.
 
-            # When 2 dls are requested the 2D geometry should have been snapped to grid,
-            # so this represents the exact adjacent grid spacing
-            if len(dls) != num_dls:
+            Finds the boundary closest to the snapped center and returns the
+            cell sizes on either side.
+            """
+            boundaries = np.array(grid.boundaries.to_list[axis])
+
+            # Find the boundary index closest to the snapped center
+            idx = np.argmin(np.abs(boundaries - snapped_center))
+
+            # If at first or last boundary, we can't get cells on both sides
+            if idx == 0 or idx == len(boundaries) - 1:
                 raise Tidy3dError(
                     "Failed to detect grid size around the 2D material. "
                     "Can't generate volumetric equivalent for this simulation. "
                     "If you received this error, please create an issue in the Tidy3D "
                     "github repository."
                 )
-            return dls
+
+            # Return cell sizes: one before the boundary, one after
+            return [boundaries[idx] - boundaries[idx - 1], boundaries[idx + 1] - boundaries[idx]]
 
         def snap_to_grid(geom: Geometry, axis: Axis) -> Geometry:
             """Snap a 2D material to the Yee grid."""
@@ -1943,7 +1945,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
                 # Snap to the grid and create volumetric equivalent
                 snapped_geometry = snap_to_grid(subdivided_geometry[0], axis)
                 snapped_center = get_bounds(snapped_geometry, axis)[0]
-                dls = get_dls(get_thickened_geom(snapped_geometry, axis), axis, 2)
+                dls = get_dls(snapped_center, axis)
                 adjacent_media = [subdivided_geometry[1].medium, subdivided_geometry[2].medium]
 
                 # Create the new volumetric medium


### PR DESCRIPTION
## Summary
- Replaces the indirect `get_dls` approach (thicken geometry → discretize grid → extract cell sizes) with a direct boundary lookup: find the nearest grid boundary to the snapped 2D material center and compute adjacent cell sizes from the boundary array.
- Removes the unused `get_thickened_geom` import and the `num_dls` parameter that was always called with `2`.
- No behavioral change — produces the same two cell sizes for the volumetric equivalent calculation.

## Test plan
- [x] Existing 2D material tests pass (no new tests needed — pure refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor confined to 2D-material volumetric equivalent setup; main risk is subtle off-by-one/edge-boundary behavior if snapping picks the first/last grid boundary.
> 
> **Overview**
> Simplifies how volumetric equivalents for `Medium2D` compute adjacent grid cell sizes (`dls`) by directly looking up the nearest grid boundary to the snapped 2D material center and taking the two neighboring cell widths.
> 
> Removes the now-unneeded `get_thickened_geom` helper from `utils_2d.py` and stops importing/using it in `Simulation._volumetric_structures_grid`, eliminating the prior “thicken geometry → discretize → extract sizes” path and tightening error handling when the snapped center is at the grid edge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a05d23d393f8e609155e31cd82c8bf405cf95464. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->