### PR TITLE
FXC-5773: detect Homebrew cask KLayout paths

### DIFF
--- a/changelog.d/3310.fixed.md
+++ b/changelog.d/3310.fixed.md
@@ -1,0 +1,1 @@
+Improved KLayout executable discovery on macOS for Homebrew cask app-suite installs under `/Applications/KLayout`.

--- a/tests/test_plugins/klayout/test_util.py
+++ b/tests/test_plugins/klayout/test_util.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -45,3 +46,25 @@ def test_check_installation_finds_known_location(monkeypatch, tmp_path):
     resolved = util.check_installation(raise_error=True)
     assert resolved == str(fake_binary)
     assert os.environ["PATH"] == ""
+
+
+def test_common_install_locations_include_homebrew_cask_app_suite(monkeypatch):
+    """Darwin candidates include Homebrew cask app-suite install locations."""
+
+    monkeypatch.setattr(f"{KLAYOUT_PLUGIN_PATH}.util.platform.system", lambda: "Darwin")
+    paths = util._common_install_locations()
+    assert Path("/Applications/KLayout/klayout.app/Contents/MacOS/klayout") in paths
+
+
+def test_brew_cask_klayout_binaries_detect_versioned_paths(monkeypatch, tmp_path):
+    """Discover binaries from versioned Homebrew cask directories."""
+
+    cask_root = tmp_path / "Caskroom" / "klayout"
+    binary = cask_root / "0.30.6" / "KLayout" / "klayout.app" / "Contents" / "MacOS" / "klayout"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/bin/sh\nexit 0\n")
+    binary.chmod(0o755)
+
+    monkeypatch.setattr(f"{KLAYOUT_PLUGIN_PATH}.util._MACOS_BREW_CASK_KLAYOUT_ROOTS", (cask_root,))
+    candidates = util._brew_cask_klayout_binaries()
+    assert binary in candidates

--- a/tidy3d/plugins/klayout/drc/README.md
+++ b/tidy3d/plugins/klayout/drc/README.md
@@ -35,6 +35,9 @@ export PATH="$PATH:/Applications/klayout.app/Contents/MacOS"
 ```
 Run `check_installation()` again to check if the application is found.
 
+On macOS, Homebrew cask app-suite installs such as
+`/Applications/KLayout/klayout.app/Contents/MacOS/klayout` are also discovered automatically.
+
 2. Provide a KLayout DRC runset script that defines the source (input gds) using `source($gdsfile)` and the report (output result file) using `report("DRC results", $resultsfile)`. Please refer to the [DRC Runset Formatting section below](#drc-runset-file-formatting).
 
 ## DRC Runset File Formatting

--- a/tidy3d/plugins/klayout/util.py
+++ b/tidy3d/plugins/klayout/util.py
@@ -11,6 +11,11 @@ import tidy3d as td
 if TYPE_CHECKING:
     from typing import Union
 
+_MACOS_BREW_CASK_KLAYOUT_ROOTS: tuple[Path, ...] = (
+    Path("/opt/homebrew/Caskroom/klayout"),
+    Path("/usr/local/Caskroom/klayout"),
+)
+
 
 def check_installation(raise_error: bool = False) -> Union[str, None]:
     """Return the path to the KLayout executable if it is installed.
@@ -68,13 +73,17 @@ def _common_install_locations() -> tuple[Path, ...]:
         apps = [
             Path("/Applications") / "KLayout.app" / "Contents" / "MacOS" / "klayout",
             Path("/Applications") / "klayout.app" / "Contents" / "MacOS" / "klayout",
+            Path("/Applications") / "KLayout" / "klayout.app" / "Contents" / "MacOS" / "klayout",
+            Path("/Applications") / "KLayout" / "KLayout.app" / "Contents" / "MacOS" / "klayout",
+            Path("/Applications") / "klayout" / "klayout.app" / "Contents" / "MacOS" / "klayout",
             home / "Applications" / "KLayout.app" / "Contents" / "MacOS" / "klayout",
+            home / "Applications" / "KLayout" / "klayout.app" / "Contents" / "MacOS" / "klayout",
         ]
         brew_bins = [
             Path("/opt/homebrew/bin/klayout"),
             Path("/usr/local/bin/klayout"),
         ]
-        paths.extend(apps + brew_bins)
+        paths.extend(apps + brew_bins + list(_brew_cask_klayout_binaries()))
     elif system == "windows":
         program_files = [
             Path(os.environ.get("ProgramFiles", r"C:\\Program Files")),
@@ -113,3 +122,24 @@ def _common_install_locations() -> tuple[Path, ...]:
             seen.add(path)
 
     return tuple(unique_paths)
+
+
+def _brew_cask_klayout_binaries() -> tuple[Path, ...]:
+    """Return likely KLayout binaries from Homebrew Cask installation roots on macOS."""
+
+    binaries: list[Path] = []
+    for cask_root in _MACOS_BREW_CASK_KLAYOUT_ROOTS:
+        if not cask_root.exists():
+            continue
+        for version_dir in cask_root.iterdir():
+            if not version_dir.is_dir():
+                continue
+            for app_dir_name in ("KLayout", "klayout"):
+                app_dir = version_dir / app_dir_name
+                binaries.extend(
+                    [
+                        app_dir / "klayout.app" / "Contents" / "MacOS" / "klayout",
+                        app_dir / "KLayout.app" / "Contents" / "MacOS" / "klayout",
+                    ]
+                )
+    return tuple(binaries)


### PR DESCRIPTION
## Summary
- extend macOS KLayout discovery to include Homebrew cask app-suite installs (for example `/Applications/KLayout/klayout.app/Contents/MacOS/klayout`)
- add discovery for versioned Homebrew cask roots under `/opt/homebrew/Caskroom/klayout` and `/usr/local/Caskroom/klayout`
- add regression tests for the new macOS candidates and cask-root detection
- document the Homebrew cask app-suite path support in the KLayout DRC README

## Testing
- `poetry run pytest -q tests/test_plugins/klayout/test_util.py`
- `poetry run ruff check tidy3d/plugins/klayout/util.py tests/test_plugins/klayout/test_util.py`
- `poetry run pre-commit run --files tidy3d/plugins/klayout/util.py tests/test_plugins/klayout/test_util.py tidy3d/plugins/klayout/drc/README.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Path discovery logic is extended but remains read-only filesystem probing; main risk is missing/incorrect path patterns or edge-case performance when iterating cask directories on macOS.
> 
> **Overview**
> Improves macOS KLayout executable discovery by expanding `_common_install_locations()` to include Homebrew cask *app-suite* locations under `/Applications/KLayout` and by scanning versioned Homebrew Caskroom roots (`/opt/homebrew/Caskroom/klayout`, `/usr/local/Caskroom/klayout`) via a new `_brew_cask_klayout_binaries()` helper.
> 
> Adds regression tests covering the new candidate paths and versioned cask detection, updates the KLayout DRC README to mention the automatically-discovered Homebrew app-suite path, and includes a changelog entry for the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee862b04d8ccb45366fe3e13f921861fb2d26188. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->