### PR TITLE
HeatBCTypes radiationBC inclusion

### DIFF
--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -65,6 +65,7 @@ from tidy3d.components.tcad.types import (
     HeatFromElectricSource,
     HeatSource,
     InsulatingBC,
+    RadiationBC,
     TemperatureBC,
     UniformHeatSource,
     VoltageBC,
@@ -73,6 +74,7 @@ from tidy3d.components.tcad.viz import (
     CHARGE_BC_INSULATOR,
     HEAT_BC_COLOR_CONVECTION,
     HEAT_BC_COLOR_FLUX,
+    HEAT_BC_COLOR_RADIATION,
     HEAT_BC_COLOR_TEMPERATURE,
     HEAT_SOURCE_CMAP,
     plot_params_heat_bc,
@@ -98,7 +100,7 @@ if TYPE_CHECKING:
 
 HEAT_CHARGE_BACK_STRUCTURE_STR = "<<<HEAT_CHARGE_BACKGROUND_STRUCTURE>>>"
 
-HeatBCTypes = (TemperatureBC, HeatFluxBC, ConvectionBC)
+HeatBCTypes = (TemperatureBC, HeatFluxBC, ConvectionBC, RadiationBC)
 HeatSourceTypes = (UniformHeatSource, HeatSource, HeatFromElectricSource)
 ChargeSourceTypes = ()
 ElectricBCTypes = (VoltageBC, CurrentBC, InsulatingBC)
@@ -1524,6 +1526,8 @@ class HeatChargeSimulation(AbstractSimulation):
             plot_params = plot_params.updated_copy(facecolor=HEAT_BC_COLOR_FLUX)
         elif isinstance(condition, ConvectionBC):
             plot_params = plot_params.updated_copy(facecolor=HEAT_BC_COLOR_CONVECTION)
+        elif isinstance(condition, RadiationBC):
+            plot_params = plot_params.updated_copy(facecolor=HEAT_BC_COLOR_RADIATION)
         elif isinstance(condition, InsulatingBC):
             plot_params = plot_params.updated_copy(facecolor=CHARGE_BC_INSULATOR)
 

--- a/tidy3d/components/tcad/viz.py
+++ b/tidy3d/components/tcad/viz.py
@@ -9,6 +9,7 @@ from tidy3d.components.viz import PlotParams
 HEAT_BC_COLOR_TEMPERATURE = "orange"
 HEAT_BC_COLOR_FLUX = "green"
 HEAT_BC_COLOR_CONVECTION = "brown"
+HEAT_BC_COLOR_RADIATION = "red"
 CHARGE_BC_INSULATOR = "black"
 HEAT_SOURCE_CMAP = "coolwarm"
 CHARGE_DIST_CMAP = "viridis"


### PR DESCRIPTION
Add `RadiationBC` to `HeatBCTypes` tuple and plotting logic to correctly identify and visualize heat simulations using it.

The `HeatBCTypes` tuple is crucial for classifying heat simulations and validating boundary conditions. Without `RadiationBC` in this tuple, simulations relying solely on `RadiationBC` would not trigger the heat equation solver or be correctly validated, leading to silent failures. This PR ensures `RadiationBC` is fully integrated into the heat simulation framework and properly plotted.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-39fce56c-c32d-4697-98be-7254f590e3fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39fce56c-c32d-4697-98be-7254f590e3fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to heat boundary-condition classification and visualization; low risk aside from potential behavior change where `RadiationBC`-only setups now correctly trigger heat solving/validation.
> 
> **Overview**
> `RadiationBC` is now treated as a first-class heat boundary condition in `HeatChargeSimulation` by adding it to `HeatBCTypes`, ensuring simulations that rely on radiation boundaries are classified/validated as heat simulations.
> 
> Plotting is updated to recognize `RadiationBC` and render it with a dedicated color (`HEAT_BC_COLOR_RADIATION`, added as `red`) so radiation boundaries are visually distinguishable in heat/charge plots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d9c20b26fdc665d2c7dab2064c962277bb9320e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->