### PR TITLE
[FXC-5512] port outer_dot kernel from #3258 onto #3279

### DIFF
--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import tracemalloc
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -24,6 +26,7 @@ from tidy3d.components.data.monitor_data import (
     ModeSolverData,
     PermittivityData,
 )
+from tidy3d.components.data.utils import _dot_numpy, _outer_dot_numpy
 from tidy3d.components.data.zbf import ZBFData
 from tidy3d.components.mode.mode_solver import ModeSolver
 from tidy3d.constants import UnitScaling
@@ -1575,6 +1578,70 @@ def test_dot_outer_dot_consistency(conjugate, sim_2d):
             d = A_i.dot(B_j, conjugate=conjugate)
             od_val = od.sel(mode_index_0=i, mode_index_1=j).values
             np.testing.assert_allclose(od_val, d.values.squeeze(), rtol=1e-12)
+
+
+def test_outer_dot_numpy_memory_regression():
+    """Ensure blocked outer-dot kernel lowers peak allocation versus naive mode loop."""
+
+    def _outer_dot_numpy_naive(
+        E1: tuple[np.ndarray, np.ndarray],
+        H1: tuple[np.ndarray, np.ndarray],
+        E2: tuple[np.ndarray, np.ndarray],
+        H2: tuple[np.ndarray, np.ndarray],
+        dS: tuple[np.ndarray, np.ndarray],
+        conjugate: bool,
+    ) -> np.ndarray:
+        E1u, E1v = E1
+        H1u, H1v = H1
+        E2u, E2v = E2
+        H2u, H2v = H2
+
+        if conjugate:
+            E1u, E1v = np.conj(E1u), np.conj(E1v)
+            H1u, H1v = np.conj(H1u), np.conj(H1v)
+
+        n_modes_1 = E1u.shape[-3]
+        n_modes_2 = E2u.shape[-3]
+        result = np.zeros((*E1u.shape[:-3], n_modes_1, n_modes_2), dtype=np.result_type(E1u, E2u))
+
+        for i in range(n_modes_1):
+            E1_i = (E1u[..., i : i + 1, :, :], E1v[..., i : i + 1, :, :])
+            H1_i = (H1u[..., i : i + 1, :, :], H1v[..., i : i + 1, :, :])
+            result[..., i, :] = _dot_numpy(E1_i, H1_i, (E2u, E2v), (H2u, H2v), dS, conjugate=False)
+
+        return result
+
+    def _run_with_peak_bytes(fn):
+        tracemalloc.start()
+        try:
+            out = fn()
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        return out, peak
+
+    # n_modes=40 and spatial grid 300x400 are large enough to expose mode-loop temporaries
+    # while keeping this regression test fast enough for CI.
+    rng = np.random.default_rng(0)
+    shape = (1, 40, 300, 400)
+    left = rng.standard_normal(shape).astype(np.complex128)
+    right = rng.standard_normal(shape).astype(np.complex128)
+    dS = (np.ones(shape[-2:], dtype=np.float64), np.ones(shape[-2:], dtype=np.float64))
+
+    E1 = (left, left)
+    H1 = (left, left)
+    E2 = (right, right)
+    H2 = (right, right)
+
+    naive_result, naive_peak = _run_with_peak_bytes(
+        lambda: _outer_dot_numpy_naive(E1, H1, E2, H2, dS, conjugate=True)
+    )
+    blocked_result, blocked_peak = _run_with_peak_bytes(
+        lambda: _outer_dot_numpy(E1, H1, E2, H2, dS, conjugate=True)
+    )
+
+    np.testing.assert_allclose(blocked_result, naive_result, rtol=1e-12, atol=1e-12)
+    assert blocked_peak < naive_peak * 0.85
 
 
 # ---------------------------------------------------------------------------

--- a/tidy3d/components/data/utils.py
+++ b/tidy3d/components/data/utils.py
@@ -27,6 +27,10 @@ CustomSpatialDataTypeAnnotated = Union[
     SpatialDataArray,
 ]
 
+OUTER_DOT_BLOCK_TARGET_BYTES = 64 * 1024**2
+OUTER_DOT_BLOCK_MIN_SIZE = 8
+OUTER_DOT_BLOCK_MAX_SIZE = 64
+
 
 def _instantaneous_power_flow_numpy(
     E: tuple[np.ndarray, np.ndarray],
@@ -276,27 +280,94 @@ def _outer_dot_numpy(
     assert E2u.shape == H2v.shape
     assert E2v.shape == H2u.shape
 
+    dS_EuHv, dS_EvHu = dS
+
     # Get number of modes and broadcast shape
     n_modes_1 = E1u.shape[-3]
     n_modes_2 = E2u.shape[-3]
     broadcast_shape = E1u.shape[:-3]
-    dtype = E1u.dtype
+    num_grid_points = E1u.shape[-2] * E1u.shape[-1]
+    dtype = np.result_type(
+        E1u.dtype,
+        E1v.dtype,
+        H1u.dtype,
+        H1v.dtype,
+        E2u.dtype,
+        E2v.dtype,
+        H2u.dtype,
+        H2v.dtype,
+        np.asarray(dS_EuHv).dtype,
+        np.asarray(dS_EvHu).dtype,
+    )
 
     # Initialize output matrix
     S = np.zeros((*broadcast_shape, n_modes_1, n_modes_2), dtype=dtype)
+
+    if n_modes_1 == 0 or n_modes_2 == 0:
+        return S
 
     # Conjugate outside loop to avoid copies
     if conjugate:
         E1u, E1v = np.conj(E1u), np.conj(E1v)
         H1u, H1v = np.conj(H1u), np.conj(H1v)
 
-    # Compute all elements of the overlap matrix
-    # Use slices instead of fancy indexing for E2/H2 to avoid copies
-    for i in range(n_modes_1):
-        E1_i = (E1u[..., i : i + 1, :, :], E1v[..., i : i + 1, :, :])
-        H1_i = (H1u[..., i : i + 1, :, :], H1v[..., i : i + 1, :, :])
-        # E2/H2 use all modes, so just pass them directly (no indexing needed)
-        S[..., i, :] = _dot_numpy(E1_i, H1_i, E2, H2, dS, False, bidirectional)
+    # Heuristic: choose mode block size targeting bounded temporary allocations.
+    itemsize = np.dtype(dtype).itemsize
+    if num_grid_points == 0:
+        block_size = OUTER_DOT_BLOCK_MAX_SIZE
+    else:
+        block_size = int(OUTER_DOT_BLOCK_TARGET_BYTES // (num_grid_points * itemsize))
+        block_size = max(OUTER_DOT_BLOCK_MIN_SIZE, block_size)
+        block_size = min(OUTER_DOT_BLOCK_MAX_SIZE, block_size)
+
+    block_size_left = min(n_modes_1, block_size)
+    block_size_right = min(n_modes_2, block_size)
+
+    dS_EuHv_flat = np.asarray(dS_EuHv).reshape(-1)
+    dS_EvHu_flat = np.asarray(dS_EvHu).reshape(-1)
+    if dS_EuHv_flat.size != num_grid_points or dS_EvHu_flat.size != num_grid_points:
+        raise ValueError("Tangential area shape mismatch in blocked outer_dot kernel.")
+
+    num_batches = int(np.prod(broadcast_shape, dtype=int)) if broadcast_shape else 1
+    out_flat = S.reshape(num_batches, n_modes_1, n_modes_2)
+
+    if bidirectional:
+        term_specs = (
+            (0.25, E1u, H2v, dS_EuHv_flat),
+            (0.25, H1v, E2u, dS_EuHv_flat),
+            (-0.25, E1v, H2u, dS_EvHu_flat),
+            (-0.25, H1u, E2v, dS_EvHu_flat),
+        )
+    else:
+        term_specs = (
+            (0.5, E1u, H2v, dS_EuHv_flat),
+            (-0.5, E1v, H2u, dS_EvHu_flat),
+        )
+
+    # Flatten once outside loops so each block only performs views + BLAS matmul.
+    flattened_terms = tuple(
+        (
+            coeff,
+            left.reshape(num_batches, n_modes_1, num_grid_points),
+            right.reshape(num_batches, n_modes_2, num_grid_points),
+            d_area,
+        )
+        for coeff, left, right, d_area in term_specs
+    )
+
+    for batch_idx in range(num_batches):
+        out_batch = out_flat[batch_idx]
+        for coeff, left_term, right_term, d_area in flattened_terms:
+            left_batch = left_term[batch_idx]
+            right_batch = right_term[batch_idx]
+            for i0 in range(0, n_modes_1, block_size_left):
+                i0_end = min(i0 + block_size_left, n_modes_1)
+                left_block = left_batch[i0:i0_end]
+                for i1 in range(0, n_modes_2, block_size_right):
+                    i1_end = min(i1 + block_size_right, n_modes_2)
+                    right_block = right_batch[i1:i1_end]
+                    weighted_right = right_block * d_area
+                    out_batch[i0:i0_end, i1:i1_end] += coeff * (left_block @ weighted_right.T)
 
     return S
 


### PR DESCRIPTION
## Summary
- port the blocked/streaming `outer_dot` optimization from #3258 onto #3279's non-colocated overlap stack
- move the optimization into `tidy3d/components/data/utils.py::_outer_dot_numpy` (the new hot path used by #3279)
- preserve #3279 behavior for dual Yee-area weighting (`dS_EuHv` / `dS_EvHu`) and mode/frequency output semantics

## Why
- #3258 and #3279 conflict heavily at the old `monitor_data.py` call-site level
- #3279 now routes overlap math through `utils.py`, so the clean port point is `_outer_dot_numpy`
- this addresses Casey's memory concern by doing term-by-term accumulation + double-sided mode blocking, plus a regression test

## What Changed
- `tidy3d/components/data/utils.py`
  - replace per-mode outer loop with blocked matrix accumulation
  - process cross-product terms one at a time (avoid holding all weighted temporaries)
  - add adaptive block-size heuristic constants
- `tests/test_data/test_monitor_data.py`
  - add `test_outer_dot_numpy_memory_regression` with `tracemalloc`
  - assert numerical parity vs naive implementation and lower peak memory

## Explicit Non-Goals (left to #3279 owner)
- source-side `colocate` API discussion
- changelog scope decisions for #3279
- assert-vs-check policy cleanup in unrelated #3279 codepaths

## Validation
- `poetry run pre-commit run --files tidy3d/components/data/utils.py tests/test_data/test_monitor_data.py`
- `poetry run pytest -q --no-cov -W ignore tests/test_data/test_monitor_data.py -k "outer_dot_numpy_memory_regression or dot_outer_dot_consistency or outer_dot_broadcasting_combinations"`
- `poetry run pytest -q --no-cov -W ignore tests/test_plugins/test_mode_solver.py -k "high_order_mode_normalization or translated_dot or degenerate_mode_processing"`

## References
- base implementation PR: #3279
- source optimization PR: #3258
- related merged typing-only PR context: #3278

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a performance-critical numerical kernel used for mode overlap matrices; while output parity is tested, the new blocked matmul path could introduce subtle shape/dtype or performance edge cases across inputs.
> 
> **Overview**
> **Reduces peak memory usage in modal overlap outer-products** by rewriting `utils.py::_outer_dot_numpy` to compute overlaps via term-by-term accumulation with adaptive mode blocking (targeting a bounded temporary size) instead of a per-mode loop.
> 
> Adds a `tracemalloc` regression test (`test_outer_dot_numpy_memory_regression`) that compares against a naive implementation for numerical equivalence and asserts a meaningful drop in peak allocations, and introduces tuning constants (`OUTER_DOT_BLOCK_*`) for the blocking heuristic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf62a76b54f580b80a17d755480991406b5b5b44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->