### PR TITLE
FXC-5803: Fix VTU planar slice detection for large-coordinate jitter

### DIFF
--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -7,6 +7,8 @@ import os
 import pytest
 
 from tidy3d.config.__init__ import get_manager, reload_config
+from tidy3d.config.registry import attach_manager
+from tidy3d.config.registry import get_manager as get_registry_manager
 
 _ENV_VARS_TO_CLEAR = {
     "TIDY3D_PROFILE",
@@ -19,6 +21,15 @@ _ENV_VARS_TO_CLEAR = {
     "TIDY3D_WEB__APIKEY",
     "TIDY3D_BASE_DIR",
 }
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry_manager():
+    """Prevent ConfigManager instances created during a test from leaking
+    into subsequent tests via the global ``_MANAGER`` in the registry."""
+    original = get_registry_manager()
+    yield
+    attach_manager(original)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_data/test_datasets.py
+++ b/tests/test_data/test_datasets.py
@@ -779,6 +779,105 @@ def test_from_vtk():
         _ = td.TriangularGridDataset.from_vtk("tests/data/gmsh_2d.vtk")
 
 
+def test_triangular_from_vtu_near_planar_large_coordinates(tmp_path):
+    """Regression for large-coordinate planar slices with small normal-axis jitter."""
+    pytest.importorskip("vtk")
+    import vtk
+
+    import tidy3d as td
+
+    tri_grid = td.TriangularGridDataset(
+        normal_axis=1,
+        normal_pos=0.0,
+        points=td.PointDataArray(
+            [
+                [100000.0, 0.0],
+                [101000.0, 0.0],
+                [100000.0, 690.0],
+                [101000.0, 690.0],
+            ],
+            dims=("index", "axis"),
+        ),
+        cells=td.CellDataArray([[0, 1, 2], [1, 2, 3]], dims=("cell_index", "vertex_index")),
+        values=td.IndexedDataArray(
+            [1.0, 2.0, 3.0, 4.0], coords={"index": np.arange(4)}, name="temp"
+        ),
+    )
+
+    vtu_path = tmp_path / "near_planar_large_coords.vtu"
+    tri_grid.to_vtu(vtu_path)
+
+    # Inject tiny jitter in the nominally planar normal direction.
+    reader = vtk.vtkXMLUnstructuredGridReader()
+    reader.SetFileName(str(vtu_path))
+    reader.Update()
+    grid = reader.GetOutput()
+    points = grid.GetPoints()
+    for ind in range(points.GetNumberOfPoints()):
+        x, _, z = points.GetPoint(ind)
+        points.SetPoint(ind, x, 6e-6 if (ind % 2) == 0 else -6e-6, z)
+    points.Modified()
+
+    writer = vtk.vtkXMLUnstructuredGridWriter()
+    writer.SetFileName(str(vtu_path))
+    writer.SetInputData(grid)
+    writer.Write()
+
+    loaded = td.TriangularGridDataset.from_vtu(vtu_path, field="temp")
+    assert loaded.normal_axis == 1
+    assert abs(float(loaded.normal_pos)) < 1e-4
+    assert loaded.points.sizes["index"] == 4
+
+
+def test_triangular_from_vtu_far_from_origin_small_extent(tmp_path):
+    """Regression: tolerance must depend on extent, not absolute position."""
+    pytest.importorskip("vtk")
+    import vtk
+
+    import tidy3d as td
+
+    tri_grid = td.TriangularGridDataset(
+        normal_axis=1,
+        normal_pos=0.0,
+        points=td.PointDataArray(
+            [
+                [1e9, -2e9],
+                [1e9 + 2.0, -2e9],
+                [1e9, -2e9 + 1.0],
+                [1e9 + 2.0, -2e9 + 1.0],
+            ],
+            dims=("index", "axis"),
+        ),
+        cells=td.CellDataArray([[0, 1, 2], [1, 2, 3]], dims=("cell_index", "vertex_index")),
+        values=td.IndexedDataArray(
+            [1.0, 2.0, 3.0, 4.0], coords={"index": np.arange(4)}, name="temp"
+        ),
+    )
+
+    vtu_path = tmp_path / "far_origin_small_extent.vtu"
+    tri_grid.to_vtu(vtu_path)
+
+    reader = vtk.vtkXMLUnstructuredGridReader()
+    reader.SetFileName(str(vtu_path))
+    reader.Update()
+    grid = reader.GetOutput()
+    points = grid.GetPoints()
+    for ind in range(points.GetNumberOfPoints()):
+        x, _, z = points.GetPoint(ind)
+        points.SetPoint(ind, x, 2e-7 if (ind % 2) == 0 else -2e-7, z)
+    points.Modified()
+
+    writer = vtk.vtkXMLUnstructuredGridWriter()
+    writer.SetFileName(str(vtu_path))
+    writer.SetInputData(grid)
+    writer.Write()
+
+    loaded = td.TriangularGridDataset.from_vtu(vtu_path, field="temp")
+    assert loaded.normal_axis == 1
+    assert abs(float(loaded.normal_pos)) < 1e-5
+    assert loaded.points.sizes["index"] == 4
+
+
 def test_tetrahedral_from_vtk_obj_without_cell_types_array():
     """Regression test for VTK objects with missing ``GetCellTypesArray`` output."""
     pytest.importorskip("vtk")

--- a/tidy3d/components/data/unstructured/triangular.py
+++ b/tidy3d/components/data/unstructured/triangular.py
@@ -175,7 +175,12 @@ class TriangularGridDataset(UnstructuredGridDataset):
 
         # detect zero size dimension
         bounds = np.max(points_numpy, axis=0) - np.min(points_numpy, axis=0)
-        zero_dims = np.where(np.isclose(bounds, 0, atol=1e-6))[0]
+        # VTU slices can accumulate small floating-point jitter in the nominally
+        # zero-thickness direction. Scale tolerance with geometry extent (rather than
+        # absolute coordinate value) to avoid origin-dependent behavior.
+        size_scale = float(np.max(bounds)) if bounds.size > 0 else 0.0
+        zero_dim_tol = max(1e-6, 2e-8 * size_scale)
+        zero_dims = np.where(np.isclose(bounds, 0, atol=zero_dim_tol))[0]
 
         if len(zero_dims) != 1:
             raise DataError(


### PR DESCRIPTION
Another issue I ran into while running notebooks with the change to conformal=False for the monitors.

It is still not perfectly robust obviously so we might have to revisit this...

## Summary
- make `TriangularGridDataset.from_vtu` detect the zero-thickness axis with a coordinate-scale-aware tolerance
- avoid false `DataError` for near-planar VTU slices when geometry coordinates are large
- add a regression test that writes a VTU, injects small normal-axis jitter, and verifies loading succeeds

## Validation
- `pytest -q tests/test_data/test_datasets.py::test_triangular_from_vtu_near_planar_large_coordinates -s`
- `pytest -q tests/test_data/test_datasets.py::test_from_vtk -s`

## Context
This matches the failure mode seen in task `AIDAXWCOWJGJO4J4LDRFG/hec-6e138e99-2915-477f-8804-073849b4a4e7` (unstructured planar monitor, `conformal=False`).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized tolerance change in VTU import plus additional tests; low risk of impacting unrelated code, though it may slightly broaden what is considered “planar”.
> 
> **Overview**
> Fixes `TriangularGridDataset.from_vtu` planar-slice detection by scaling the zero-thickness-axis tolerance with the mesh extent (instead of a fixed absolute epsilon), avoiding false `DataError` when VTU points have tiny normal-axis jitter at large coordinates.
> 
> Adds two VTK-backed regression tests that write a `.vtu`, inject small out-of-plane jitter (including far-from-origin/small-extent cases), and verify the dataset still loads with the correct `normal_axis/normal_pos`. Also adds an autouse test fixture to reset the global config registry manager between tests to prevent cross-test leakage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f37da66c16be6d758dfe8c4950f7cfeac2a45aea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->