### PR TITLE
fix(mode-solver): avoid GaussianBeam validation failure in rotated mode copy

### DIFF
--- a/changelog.d/3321.fixed.md
+++ b/changelog.d/3321.fixed.md
@@ -1,0 +1,1 @@
+Fixed angled mode-solving for ModeMonitor runs with GaussianBeam sources by preventing rotated-reference simulations from revalidating retained sources.

--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -10,6 +10,7 @@ import pytest
 from matplotlib import pyplot as plt
 
 import tidy3d as td
+from tidy3d.components.mode.mode_solver import ModeSolver
 from tidy3d.exceptions import SetupError, ValidationError
 
 from ..test_data.test_data_arrays import (
@@ -158,6 +159,57 @@ def test_validation_from_simulation():
             mode_spec=td.ModeSpec(angle_rotation=True, angle_theta=np.pi / 4),
             freqs=[td.C_0],
         )
+
+
+def test_rotated_structures_copy_drops_sources_for_angled_mode_solver():
+    """The rotated reference simulation used for angled mode solving should not retain sources."""
+
+    wavelength = 1.55
+    freq0 = td.C_0 / wavelength
+
+    gaussian_beam = td.GaussianBeam(
+        center=(-1.5, 0, 0),
+        size=(0, 2.0, 2.0),
+        source_time=td.GaussianPulse(freq0=freq0, fwidth=freq0 / 20),
+        direction="+",
+        angle_theta=0.0,
+        angle_phi=0.0,
+        waist_radius=0.8,
+    )
+    mode_monitor = td.ModeMonitor(
+        center=(1.0, 0, 0),
+        size=(0, 2.0, 2.0),
+        freqs=[freq0],
+        mode_spec=td.ModeSpec(angle_rotation=True, angle_theta=0.2, bend_axis=1, num_modes=1),
+        name="mode_mnt",
+    )
+    sim = td.Simulation(
+        size=(5.0, 4.0, 4.0),
+        grid_spec=td.GridSpec.auto(min_steps_per_wvl=8),
+        structures=[
+            td.Structure(
+                geometry=td.Box(center=(1.0, 0, 0), size=(1.0, 3.0, 3.0)),
+                medium=td.Medium(permittivity=2.0),
+            )
+        ],
+        sources=[gaussian_beam],
+        monitors=[mode_monitor],
+        run_time=1e-12,
+    )
+
+    mode_solver = ModeSolver(
+        simulation=sim,
+        plane=mode_monitor,
+        mode_spec=mode_monitor.mode_spec,
+        freqs=mode_monitor.freqs,
+    )
+
+    rotated = mode_solver.rotated_structures_copy
+
+    assert len(mode_solver.simulation.sources) == 1
+    assert len(rotated.simulation.sources) == 0
+    assert len(rotated.simulation.monitors) == 0
+    assert rotated.simulation.grid_spec.wavelength == pytest.approx(wavelength)
 
 
 def get_mode_sim():

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -704,7 +704,19 @@ class ModeSolver(Tidy3dBaseModel):
         and reset angles to normal."""
 
         rotated_structures = self._rotate_structures
-        rotated_simulation = self.simulation.updated_copy(structures=rotated_structures)
+        rotated_grid_spec = self.simulation.grid_spec
+        if rotated_grid_spec.auto_grid_used and rotated_grid_spec.wavelength is None:
+            wavelength = rotated_grid_spec.get_wavelength(self.simulation.sources)
+            rotated_grid_spec = rotated_grid_spec.updated_copy(wavelength=wavelength)
+
+        # Sources are not used by mode solving and can become invalid after rotating structures.
+        rotated_simulation = self.simulation.updated_copy(
+            structures=rotated_structures,
+            sources=(),
+            monitors=(),
+            grid_spec=rotated_grid_spec,
+            validate=False,
+        )
         rotated_mode_spec = self.mode_spec.updated_copy(
             angle_rotation=False, angle_theta=0, angle_phi=0
         )


### PR DESCRIPTION
## Summary
- drop sources and monitors from `ModeSolver.rotated_structures_copy` since they are not needed for mode solving and can become invalid after structure rotation
- preserve an explicit auto-grid wavelength before dropping sources to keep grid generation deterministic
- add regression test for angled `ModeMonitor` + `GaussianBeam` to verify rotated copy no longer retains sources
- add changelog fragment

## Validation
- `source /home/momchil/flexcompute/codex/compute/src/Tidy3DCore/_build_local/bin/activate && cd /tmp/tidy3d_frontend_modefix && PYTHONPATH=/tmp/tidy3d_frontend_modefix pytest -q tests/test_components/test_mode.py -k "rotated_structures_copy_drops_sources_for_angled_mode_solver or test_validation_from_simulation" --maxfail=1`
- `source /home/momchil/flexcompute/codex/compute/src/Tidy3DCore/_build_local/bin/activate && cd /tmp/tidy3d_frontend_modefix && pre-commit run --files tidy3d/components/mode/mode_solver.py tests/test_components/test_mode.py changelog.d/99999.fixed.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `ModeSolver`’s rotated-reference simulation construction and validation behavior, which could affect angled mode-solving and autogrid wavelength selection in edge cases.
> 
> **Overview**
> Fixes angled mode solving when a `Simulation` contains sources like `GaussianBeam` by changing `ModeSolver.rotated_structures_copy` to build the rotated-reference simulation *without* carrying over sources/monitors (and skipping validation).
> 
> To keep auto-grid behavior deterministic after dropping sources, it snapshots an explicit `grid_spec.wavelength` when using autogrid without a wavelength. Adds a regression test covering an angled `ModeMonitor` with a `GaussianBeam`, and includes a changelog entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d4a025bd4fcae22f8abfd4cd1963ad4ecadc48f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->