### PR TITLE
fix: conftest reset

### DIFF
--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -7,6 +7,8 @@ import os
 import pytest
 
 from tidy3d.config.__init__ import get_manager, reload_config
+from tidy3d.config.registry import attach_manager
+from tidy3d.config.registry import get_manager as get_registry_manager
 
 _ENV_VARS_TO_CLEAR = {
     "TIDY3D_PROFILE",
@@ -19,6 +21,15 @@ _ENV_VARS_TO_CLEAR = {
     "TIDY3D_WEB__APIKEY",
     "TIDY3D_BASE_DIR",
 }
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry_manager():
+    """Prevent ConfigManager instances created during a test from leaking
+    into subsequent tests via the global ``_MANAGER`` in the registry."""
+    original = get_registry_manager()
+    yield
+    attach_manager(original)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change that resets a global registry manager to prevent cross-test state leakage; minimal production risk, but could affect test ordering assumptions.
> 
> **Overview**
> Ensures config tests are isolated by adding an autouse fixture in `tests/config/conftest.py` that snapshots and restores the registry’s global config manager (`tidy3d.config.registry._MANAGER`) after each test.
> 
> This prevents `ConfigManager` instances created in one test from leaking into subsequent tests via registry callbacks, reducing flaky behavior caused by shared global state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1ec31294f13e4b8921c108de2322914340b7d57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->