### PR TITLE
fix(tidy3d): fix empty dict deserialization for NonLinearSpec

### DIFF
--- a/changelog.d/3329.fixed.md
+++ b/changelog.d/3329.fixed.md
@@ -1,0 +1,1 @@
+Fixed loading of medium settings so empty `NonlinearSpec` inputs are ignored instead of unintentionally enabling nonlinearity.

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -791,6 +791,15 @@ def test_nonlinear_medium():
         _ = sim.updated_copy(medium=med, path="structures/0")
 
 
+def test_nonlinear_spec_empty_dict_is_ignored():
+    assert td.Medium(nonlinear_spec=td.NonlinearSpec()).nonlinear_spec is not None
+
+    medium_dict = td.Medium().model_dump()
+    medium_dict["nonlinear_spec"] = {}
+
+    assert td.Medium.model_validate(medium_dict).nonlinear_spec is None
+
+
 def test_custom_medium():
     Nx, Ny, Nz, Nf = 4, 3, 1, 1
     X = np.linspace(-1, 1, Nx)

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import functools
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from math import isclose
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypeVar, Union, get_args
 
@@ -243,6 +243,14 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
         self._check_either_modulation_or_nonlinear_spec()
         self._validate_modulation_spec_after()
         return self
+
+    @field_validator("nonlinear_spec", mode="before")
+    @classmethod
+    def _normalize_empty_nonlinear_spec_dict(cls, val: Any) -> Any:
+        """Treat an empty nonlinear spec mapping as a missing value."""
+        if isinstance(val, Mapping) and not val:
+            return None
+        return val
 
     def _validate_nonlinear_spec(self) -> Self:
         """Check compatibility with nonlinear_spec."""


### PR DESCRIPTION
- Fixed `Medium.nonlinear_spec` parsing so an empty dict is treated as missing (`None`) instead of creating an empty `NonlinearSpec` (prevents accidental nonlinearity enablement).
- Added a dedicated regression test: `test_nonlinear_spec_empty_dict_is_ignored`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped validation change affecting only `nonlinear_spec` deserialization, covered by a targeted regression test.
> 
> **Overview**
> Fixes `Medium` parsing so an empty `{}` provided for `nonlinear_spec` is normalized to `None` (via a new pre-validation `field_validator`), preventing unintended nonlinearity activation during deserialization.
> 
> Adds a regression test (`test_nonlinear_spec_empty_dict_is_ignored`) and documents the fix in the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a73f76e83bc34e07d01d756573a8fe224437d04b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->