### PR TITLE
feat(tidy3d): FXC-1539 implement spatially varying heat conductivity

### DIFF
--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -1272,8 +1272,15 @@
           "type": "object"
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "frequency_range": {
           "anyOf": [
@@ -11025,8 +11032,15 @@
           "default": null
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "density": {
           "anyOf": [
@@ -11082,8 +11096,15 @@
           "default": null
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "density": {
           "anyOf": [

--- a/schemas/HeatChargeSimulation.json
+++ b/schemas/HeatChargeSimulation.json
@@ -672,8 +672,15 @@
           "type": "object"
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "frequency_range": {
           "anyOf": [
@@ -7900,8 +7907,15 @@
           "default": null
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "density": {
           "anyOf": [
@@ -7957,8 +7971,15 @@
           "default": null
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "density": {
           "anyOf": [

--- a/schemas/HeatSimulation.json
+++ b/schemas/HeatSimulation.json
@@ -672,8 +672,15 @@
           "type": "object"
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "frequency_range": {
           "anyOf": [
@@ -7900,8 +7907,15 @@
           "default": null
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "density": {
           "anyOf": [
@@ -7957,8 +7971,15 @@
           "default": null
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "density": {
           "anyOf": [

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -1474,8 +1474,15 @@
           "type": "object"
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "frequency_range": {
           "anyOf": [
@@ -10792,8 +10799,15 @@
           "default": null
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "density": {
           "anyOf": [
@@ -10849,8 +10863,15 @@
           "default": null
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "density": {
           "anyOf": [

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -1914,8 +1914,15 @@
           "type": "object"
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "frequency_range": {
           "anyOf": [
@@ -14264,8 +14271,15 @@
           "default": null
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "density": {
           "anyOf": [
@@ -14321,8 +14335,15 @@
           "default": null
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "density": {
           "anyOf": [

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -1914,8 +1914,15 @@
           "type": "object"
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "frequency_range": {
           "anyOf": [
@@ -15048,8 +15055,15 @@
           "default": null
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "density": {
           "anyOf": [
@@ -15105,8 +15119,15 @@
           "default": null
         },
         "conductivity": {
-          "exclusiveMinimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "density": {
           "anyOf": [

--- a/tests/test_components/test_heat.py
+++ b/tests/test_components/test_heat.py
@@ -51,6 +51,15 @@ def make_heat_mediums():
     return fluid_medium, solid_medium
 
 
+def make_spatial_conductivity():
+    """Create a SpatialDataArray for use as spatially varying thermal conductivity."""
+    x = [0.0, 1.0]
+    y = [0.0, 1.0]
+    z = [0.0, 1.0]
+    k_data = np.ones((2, 2, 2)) * 3.0
+    return td.SpatialDataArray(k_data, coords={"x": x, "y": y, "z": z})
+
+
 def test_heat_medium():
     _, solid_medium = make_heat_mediums()
 
@@ -79,6 +88,102 @@ def test_heat_medium():
 
     with pytest.raises(ValueError):
         _ = solid_from_si.optical
+
+
+def test_solid_medium_spatial_conductivity():
+    """Test that SolidMedium and SolidSpec accept SpatialDataArray for conductivity."""
+    k_array = make_spatial_conductivity()
+
+    # SolidMedium accepts SpatialDataArray conductivity
+    solid = td.SolidMedium(capacity=2, conductivity=k_array)
+    assert isinstance(solid.conductivity, td.SpatialDataArray)
+
+    # SolidSpec (backwards-compat subclass) also accepts SpatialDataArray conductivity
+    solid_spec = td.SolidSpec(capacity=2, conductivity=k_array)
+    assert isinstance(solid_spec.conductivity, td.SpatialDataArray)
+
+    # from_si_units also accepts SpatialDataArray (values are scaled by 1e-6)
+    solid_si = td.SolidMedium.from_si_units(conductivity=k_array, capacity=1, density=1)
+    assert isinstance(solid_si.conductivity, td.SpatialDataArray)
+    np.testing.assert_allclose(solid_si.conductivity.values, k_array.values * 1e-6)
+
+
+def make_spatial_conductivity_sim():
+    """Build a minimal HeatSimulation with a SpatialDataArray conductivity."""
+    k_array = make_spatial_conductivity()
+    solid_medium = td.Medium(
+        permittivity=5,
+        heat_spec=td.SolidSpec(capacity=2, conductivity=k_array, density=1),
+        name="solid_medium",
+    )
+    fluid_medium = td.Medium(
+        permittivity=3,
+        heat_spec=FluidSpec(),
+        name="fluid_medium",
+    )
+    box = td.Box(center=(0, 0, 0), size=(1, 1, 1))
+    solid_structure = td.Structure(geometry=box, medium=solid_medium, name="solid_structure")
+    return HeatSimulation(
+        medium=fluid_medium,
+        structures=[solid_structure],
+        center=(0, 0, 0),
+        size=(2, 2, 2),
+        boundary_spec=[
+            HeatBoundarySpec(
+                condition=TemperatureBC(temperature=300), placement=SimulationBoundary()
+            )
+        ],
+        grid_spec=UniformUnstructuredGrid(dl=0.1),
+        sources=[],
+        monitors=[TemperatureMonitor(size=(1.6, 2, 2), name="test")],
+    )
+
+
+def test_solid_medium_spatial_conductivity_plot():
+    """Test that plot_heat_conductivity renders a heatmap for SpatialDataArray conductivity."""
+    from matplotlib.collections import QuadMesh
+
+    heat_sim = make_spatial_conductivity_sim()
+
+    _, ax = plt.subplots()
+    ax = heat_sim.plot_heat_conductivity(y=0, ax=ax)
+    quad_meshes = [c for c in ax.collections if isinstance(c, QuadMesh)]
+    assert len(quad_meshes) >= 1, "Expected at least one pcolormesh for spatial conductivity"
+    plt.close()
+
+    # Also verify via the unified plot_structures_property entry point
+    _, ax = plt.subplots()
+    ax = heat_sim.scene.plot_structures_property(y=0, property="heat_conductivity", ax=ax)
+    quad_meshes = [c for c in ax.collections if isinstance(c, QuadMesh)]
+    assert len(quad_meshes) >= 1, "Expected pcolormesh via plot_structures_property"
+    plt.close()
+
+    # Scalar conductivity should not produce a pcolormesh overlay
+    scalar_sim = make_heat_sim()
+    _, ax = plt.subplots()
+    ax = scalar_sim.scene.plot_structures_property(y=0, property="heat_conductivity", ax=ax)
+    quad_meshes = [c for c in ax.collections if isinstance(c, QuadMesh)]
+    assert len(quad_meshes) == 0, "Scalar conductivity should not produce a pcolormesh"
+    plt.close()
+
+
+def test_spatial_conductivity_plot_log_scale():
+    """The pcolormesh norm should match the caller's scale, not always be linear."""
+    import matplotlib as mpl
+    from matplotlib.collections import QuadMesh
+
+    heat_sim = make_spatial_conductivity_sim()
+
+    _, ax = plt.subplots()
+    ax = heat_sim.scene.plot_structures_property(
+        y=0, property="heat_conductivity", ax=ax, scale="log"
+    )
+    quad_meshes = [c for c in ax.collections if isinstance(c, QuadMesh)]
+    assert len(quad_meshes) >= 1, "Expected pcolormesh for spatial conductivity"
+    assert isinstance(quad_meshes[0].norm, mpl.colors.LogNorm), (
+        "pcolormesh should use LogNorm when scale='log'"
+    )
+    plt.close()
 
 
 def make_heat_structures():

--- a/tests/test_components/test_heat_charge.py
+++ b/tests/test_components/test_heat_charge.py
@@ -1502,6 +1502,104 @@ def test_conduction_simulation_has_conductors(conduction_simulation, structures)
         )
 
 
+def test_conduction_spatial_conductivity():
+    """ChargeConductorMedium should accept SpatialDataArray for conductivity."""
+    x = [0.0, 1.0]
+    y = [0.0, 1.0]
+    z = [0.0, 1.0]
+    sigma_data = np.ones((2, 2, 2)) * 5.0
+    sigma_arr = td.SpatialDataArray(sigma_data, coords={"x": x, "y": y, "z": z})
+
+    cond_medium = td.ChargeConductorMedium(conductivity=sigma_arr)
+    assert isinstance(cond_medium.conductivity, td.SpatialDataArray)
+
+    conductor = td.MultiPhysicsMedium(
+        charge=cond_medium,
+        name="conductor",
+    )
+    sim = td.HeatChargeSimulation(
+        center=(0, 0, 0),
+        size=(3, 3, 3),
+        medium=td.MultiPhysicsMedium(
+            charge=td.ChargeInsulatorMedium(),
+            name="air",
+        ),
+        structures=[
+            td.Structure(
+                geometry=td.Box(size=(1, 1, 1), center=(0, 0, 0)),
+                medium=conductor,
+            ),
+        ],
+        grid_spec=td.UniformUnstructuredGrid(dl=0.1),
+        boundary_spec=[
+            td.HeatChargeBoundarySpec(
+                placement=td.SimulationBoundary(),
+                condition=td.VoltageBC(source=td.DCVoltageSource(voltage=0)),
+            ),
+        ],
+        monitors=[td.SteadyPotentialMonitor(size=(1, 1, 0), name="pot")],
+    )
+    assert sim is not None
+
+
+def test_conduction_spatial_conductivity_with_semiconductor_raises():
+    """SpatialDataArray conductivity + semiconductor must raise an error."""
+    x = [0.0, 1.0]
+    y = [0.0, 1.0]
+    z = [0.0, 1.0]
+    sigma_data = np.ones((2, 2, 2)) * 5.0
+    sigma_arr = td.SpatialDataArray(sigma_data, coords={"x": x, "y": y, "z": z})
+
+    conductor = td.MultiPhysicsMedium(
+        charge=td.ChargeConductorMedium(conductivity=sigma_arr),
+        name="conductor",
+    )
+    semiconductor = td.MultiPhysicsMedium(
+        charge=td.SemiconductorMedium(
+            N_c=td.ConstantEffectiveDOS(N=1e10),
+            N_v=td.ConstantEffectiveDOS(N=1e10),
+            E_g=td.ConstantEnergyBandGap(eg=1),
+            mobility_n=td.ConstantMobilityModel(mu=1500),
+            mobility_p=td.ConstantMobilityModel(mu=1500),
+        ),
+        name="semiconductor",
+    )
+
+    with pytest.raises(ValidationError, match="SpatialDataArray conductivity"):
+        td.HeatChargeSimulation(
+            center=(0, 0, 0),
+            size=(3, 3, 3),
+            medium=td.MultiPhysicsMedium(
+                heat=td.FluidSpec(),
+                charge=td.ChargeInsulatorMedium(),
+                name="air",
+            ),
+            structures=[
+                td.Structure(
+                    geometry=td.Box(size=(1, 1, 1), center=(-0.5, 0, 0)),
+                    medium=conductor,
+                ),
+                td.Structure(
+                    geometry=td.Box(size=(1, 1, 1), center=(0.5, 0, 0)),
+                    medium=semiconductor,
+                ),
+            ],
+            grid_spec=td.UniformUnstructuredGrid(dl=0.1),
+            boundary_spec=[
+                td.HeatChargeBoundarySpec(
+                    placement=td.SimulationBoundary(surfaces=["z-"]),
+                    condition=td.VoltageBC(source=td.DCVoltageSource(voltage=0)),
+                ),
+                td.HeatChargeBoundarySpec(
+                    placement=td.SimulationBoundary(surfaces=["z+"]),
+                    condition=td.VoltageBC(source=td.DCVoltageSource(voltage=1)),
+                ),
+            ],
+            monitors=[td.SteadyPotentialMonitor(size=(1, 1, 0), name="pot")],
+            analysis_spec=td.IsothermalSteadyChargeDCAnalysis(),
+        )
+
+
 def test_coupling_source(conduction_simulation, heat_simulation):
     """Test whether the coupling source can be applied."""
 

--- a/tidy3d/components/material/tcad/charge.py
+++ b/tidy3d/components/material/tcad/charge.py
@@ -72,19 +72,35 @@ class ChargeInsulatorMedium(AbstractChargeMedium):
 class ChargeConductorMedium(AbstractChargeMedium):
     """Conductor medium for conduction simulations.
 
-    Example
-    -------
+    Examples
+    --------
+    Using a uniform scalar electrical conductivity:
+
     >>> import tidy3d as td
     >>> solid = td.ChargeConductorMedium(conductivity=3)
+
+    Using a spatially varying electrical conductivity via :class:`.SpatialDataArray`:
+
+    >>> import numpy as np
+    >>> import tidy3d as td
+    >>> x = [0, 1]
+    >>> y = [0, 1]
+    >>> z = [0, 1]
+    >>> sigma = np.ones((2, 2, 2)) * 3
+    >>> sigma_arr = td.SpatialDataArray(sigma, coords={"x": x, "y": y, "z": z})
+    >>> solid_custom = td.ChargeConductorMedium(conductivity=sigma_arr)  # doctest: +SKIP
 
     Note
     ----
         A relative permittivity will be assumed 1 if no value is specified.
     """
 
-    conductivity: PositiveFloat = Field(
+    conductivity: Union[PositiveFloat, SpatialDataArray] = Field(
         title="Electric conductivity",
-        description="Electric conductivity of material.",
+        description=(
+            "Electric conductivity of material. Can be a scalar or a "
+            "SpatialDataArray for spatially varying values."
+        ),
         json_schema_extra={"units": CONDUCTIVITY},
     )
 

--- a/tidy3d/components/material/tcad/heat.py
+++ b/tidy3d/components/material/tcad/heat.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Optional, Union
 from pydantic import Field, NonNegativeFloat, PositiveFloat
 
 from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.data.data_array import SpatialDataArray
 from tidy3d.constants import (
     DENSITY,
     DYNAMIC_VISCOSITY,
@@ -151,12 +152,25 @@ class FluidSpec(FluidMedium):
 class SolidMedium(AbstractHeatMedium):
     """Solid medium for heat simulations.
 
-    Example
-    -------
+    Examples
+    --------
+    Using a uniform scalar thermal conductivity:
+
     >>> solid = SolidMedium(
     ...     capacity=2,
     ...     conductivity=3,
     ... )
+
+    Using a spatially varying thermal conductivity via :class:`.SpatialDataArray`:
+
+    >>> import numpy as np
+    >>> import tidy3d as td
+    >>> x = [0, 1]
+    >>> y = [0, 1]
+    >>> z = [0, 1]
+    >>> k_data = np.ones((2, 2, 2)) * 3
+    >>> k_array = td.SpatialDataArray(k_data, coords={"x": x, "y": y, "z": z})
+    >>> solid_custom = SolidMedium(capacity=2, conductivity=k_array) # doctest: +SKIP
     """
 
     capacity: Optional[PositiveFloat] = Field(
@@ -166,9 +180,13 @@ class SolidMedium(AbstractHeatMedium):
         json_schema_extra={"units": SPECIFIC_HEAT_CAPACITY},
     )
 
-    conductivity: PositiveFloat = Field(
+    conductivity: Union[PositiveFloat, SpatialDataArray] = Field(
         title="Thermal conductivity",
-        description=f"Thermal conductivity of material in units of {THERMAL_CONDUCTIVITY}.",
+        description=(
+            "Thermal conductivity of material in units of "
+            f"{THERMAL_CONDUCTIVITY}. Can be a scalar or a SpatialDataArray for "
+            "spatially varying values."
+        ),
         json_schema_extra={"units": THERMAL_CONDUCTIVITY},
     )
 
@@ -182,12 +200,24 @@ class SolidMedium(AbstractHeatMedium):
     @classmethod
     def from_si_units(
         cls,
-        conductivity: PositiveFloat,
+        conductivity: Union[PositiveFloat, SpatialDataArray],
         capacity: Optional[PositiveFloat] = None,
         density: Optional[PositiveFloat] = None,
     ) -> Self:
-        """Create a SolidMedium using SI units"""
-        new_conductivity = conductivity * 1e-6  # Convert from W/(m*K) to W/(um*K)
+        """Create a SolidMedium using SI units.
+
+        Parameters
+        ----------
+        conductivity : Union[float, SpatialDataArray]
+            Thermal conductivity in W/(m*K). Can be a scalar or a
+            :class:`.SpatialDataArray` for spatially varying values.
+        capacity : float, optional
+            Specific heat capacity in J/(kg*K).
+        density : float, optional
+            Mass density in kg/m^3.
+        """
+        # Convert from W/(m*K) to W/(um*K)
+        new_conductivity = conductivity * 1e-6
         new_capacity = capacity
         new_density = density
 

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -989,7 +989,9 @@ class Scene(Tidy3dBaseModel):
         hlim: Optional[tuple[float, float]] = None,
         vlim: Optional[tuple[float, float]] = None,
         grid: Grid = None,
-        property: Literal["eps", "doping", "N_a", "N_d"] = "eps",
+        property: Literal[
+            "eps", "doping", "N_a", "N_d", "heat_conductivity", "electric_conductivity"
+        ] = "eps",
         eps_component: Optional[PermittivityComponent] = None,
     ) -> Ax:
         """Plot each of scene's structures on a plane defined by one nonzero x,y,z coordinate.
@@ -1025,9 +1027,10 @@ class Scene(Tidy3dBaseModel):
             The x range if plotting on xy or xz planes, y range if plotting on yz plane.
         vlim : tuple[float, float] = None
             The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
-        property: Literal["eps", "doping", "N_a", "N_d"] = "eps"
+        property: Literal["eps", "doping", "N_a", "N_d", "heat_conductivity", \
+"electric_conductivity"] = "eps"
             Indicates the property to plot for the structures. Currently supported properties
-            are ["eps", "doping", "N_a", "N_d"]
+            are ["eps", "doping", "N_a", "N_d", "heat_conductivity", "electric_conductivity"]
         eps_component : Optional[PermittivityComponent] = None
             Component of the permittivity tensor to plot for anisotropic materials,
             e.g. ``"xx"``, ``"yy"``, ``"zz"``, ``"xy"``, ``"yz"``, ...
@@ -1054,15 +1057,16 @@ class Scene(Tidy3dBaseModel):
             need_filtered_shaped = alpha < 1 and not isinstance(self.medium, AbstractCustomMedium)
         if property in ["N_d", "N_a", "doping"]:
             need_filtered_shaped = alpha < 1
+        if property in ["heat_conductivity", "electric_conductivity"]:
+            need_filtered_shaped = alpha < 1
+
+        axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
 
         if need_filtered_shaped:
-            axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
             center = Box.unpop_axis(position, (0, 0), axis=axis)
             size = Box.unpop_axis(0, (inf, inf), axis=axis)
             plane = Box(center=center, size=size)
-            # for doping background structure could be a non-doping structure
-            # that needs to be rendered
-            if property in ["N_d", "N_a", "doping"]:
+            if property in ["N_d", "N_a", "doping", "heat_conductivity", "electric_conductivity"]:
                 structures = [self.background_structure, *list(structures)]
             medium_shapes = self._filter_structures_plane_medium(structures=structures, plane=plane)
         else:
@@ -1095,6 +1099,12 @@ class Scene(Tidy3dBaseModel):
                     property_min = property_min if property_min is not None else -donor_limits[1]
                     property_max = property_max if property_max is not None else acceptor_limits[1]
                     linthresh = min(acceptor_abs_min, donor_abs_min)
+
+            if property in ["heat_conductivity", "electric_conductivity"]:
+                cond_min, cond_max = self.heat_charge_property_bounds(property=property)
+                property_min = property_min if property_min is not None else cond_min
+                property_max = property_max if property_max is not None else cond_max
+                linthresh = 1e-2 * max(abs(property_min), 1e-10)
 
             if np.isclose(linthresh, 0.0):
                 # fallback to default linthresh of 1e-3
@@ -1148,6 +1158,30 @@ class Scene(Tidy3dBaseModel):
                         property,
                         norm,
                     )
+            elif property in ["heat_conductivity", "electric_conductivity"]:
+                ax = self._plot_shape_structure_heat_charge_property(
+                    alpha=alpha,
+                    medium=medium,
+                    property_val_min=property_min,
+                    property_val_max=property_max,
+                    reverse=reverse,
+                    shape=shape,
+                    ax=ax,
+                    property=property,
+                )
+                spatial_cond = self._get_spatial_conductivity(medium, property)
+                if spatial_cond is not None:
+                    ax = self._plot_spatial_conductivity_on_shape(
+                        conductivity=spatial_cond,
+                        shape=shape,
+                        axis=axis,
+                        position=position,
+                        property_val_min=property_min,
+                        property_val_max=property_max,
+                        alpha=alpha,
+                        ax=ax,
+                        norm=norm,
+                    )
             else:
                 # if the background medium is custom medium, it needs to be rendered separately
                 if medium == self.medium and need_filtered_shaped:
@@ -1192,6 +1226,24 @@ class Scene(Tidy3dBaseModel):
                     vmax=property_max,
                     label=r"$\rm{Doping} \#/cm^3$",
                     cmap=HEAT_SOURCE_CMAP,
+                    ax=ax,
+                    norm=norm,
+                )
+            elif property == "heat_conductivity":
+                Scene._add_cbar(
+                    vmin=property_min,
+                    vmax=property_max,
+                    label=f"Thermal conductivity ({THERMAL_CONDUCTIVITY})",
+                    cmap=STRUCTURE_HEAT_COND_CMAP,
+                    ax=ax,
+                    norm=norm,
+                )
+            elif property == "electric_conductivity":
+                Scene._add_cbar(
+                    vmin=property_min,
+                    vmax=property_max,
+                    label=f"Electric conductivity ({CONDUCTIVITY})",
+                    cmap=STRUCTURE_HEAT_COND_CMAP,
                     ax=ax,
                     norm=norm,
                 )
@@ -1701,8 +1753,9 @@ class Scene(Tidy3dBaseModel):
         if alpha <= 0:
             return ax
 
+        axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+
         if alpha < 1:
-            axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
             center = Box.unpop_axis(position, (0, 0), axis=axis)
             size = Box.unpop_axis(0, (inf, inf), axis=axis)
             plane = Box(center=center, size=size)
@@ -1714,6 +1767,8 @@ class Scene(Tidy3dBaseModel):
             )
 
         property_val_min, property_val_max = self.heat_charge_property_bounds(property=property)
+
+        # First pass: draw each structure as a uniform-filled polygon
         for medium, shape in medium_shapes:
             ax = self._plot_shape_structure_heat_charge_property(
                 alpha=alpha,
@@ -1725,6 +1780,23 @@ class Scene(Tidy3dBaseModel):
                 ax=ax,
                 property=property,
             )
+
+        # Second pass: overlay heatmaps for structures with spatially varying conductivity
+        if property in ["heat_conductivity", "electric_conductivity"]:
+            for medium, shape in medium_shapes:
+                spatial_cond = self._get_spatial_conductivity(medium, property)
+                if spatial_cond is None:
+                    continue
+                ax = self._plot_spatial_conductivity_on_shape(
+                    conductivity=spatial_cond,
+                    shape=shape,
+                    axis=axis,
+                    position=position,
+                    property_val_min=property_val_min,
+                    property_val_max=property_val_max,
+                    alpha=alpha,
+                    ax=ax,
+                )
 
         if cbar:
             label = ""
@@ -1740,8 +1812,6 @@ class Scene(Tidy3dBaseModel):
                 ax=ax,
             )
 
-        # clean up the axis display
-        axis, _ = Box.parse_xyz_kwargs(x=x, y=y, z=z)
         ax = self.box.add_ax_lims(axis=axis, ax=ax)
         ax = self._set_plot_bounds(bounds=self.bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
         # Add the default axis labels, tick labels, and title
@@ -1765,12 +1835,27 @@ class Scene(Tidy3dBaseModel):
             medium_list = [
                 medium for medium in medium_list if isinstance(medium.heat_spec, SolidType)
             ]
-            cond_list = [medium.heat_spec.conductivity for medium in medium_list]
+            cond_list = []
+            for medium in medium_list:
+                cond = medium.heat_spec.conductivity
+                if isinstance(cond, SpatialDataArray):
+                    # Include the full value range so the colorbar spans real data
+                    cond_list.append(float(np.min(cond.values)))
+                    cond_list.append(float(np.max(cond.values)))
+                else:
+                    cond_list.append(float(cond))
         elif property == "electric_conductivity":
             cond_mediums = [
                 medium for medium in medium_list if isinstance(medium.charge, ChargeConductorMedium)
             ]
-            cond_list = [medium.charge.conductivity for medium in cond_mediums]
+            cond_list = []
+            for medium in cond_mediums:
+                cond = medium.charge.conductivity
+                if isinstance(cond, SpatialDataArray):
+                    cond_list.append(float(np.min(cond.values)))
+                    cond_list.append(float(np.max(cond.values)))
+                else:
+                    cond_list.append(float(cond))
 
         if len(cond_list) == 0:
             cond_list = [0]
@@ -1827,7 +1912,10 @@ class Scene(Tidy3dBaseModel):
             cond_medium = None
 
         if cond_medium is not None:
-            delta_cond = cond_medium - property_val_min
+            # For SpatialDataArray, the mean drives the background polygon fill;
+            # a heatmap overlay is rendered on top by plot_structures_heat_charge_property.
+            cond_scalar = float(np.mean(cond_medium))
+            delta_cond = cond_scalar - property_val_min
             delta_cond_max = property_val_max - property_val_min + 1e-5 * property_val_min
             cond_fraction = delta_cond / delta_cond_max
             color = cond_fraction if reverse else 1 - cond_fraction
@@ -1862,6 +1950,79 @@ class Scene(Tidy3dBaseModel):
             property=property,
         )
         ax = self.box.plot_shape(shape=shape, plot_params=plot_params, ax=ax)
+        return ax
+
+    @staticmethod
+    def _get_spatial_conductivity(
+        medium: MultiPhysicsMediumType3D, property: str
+    ) -> Optional[SpatialDataArray]:
+        """Return the SpatialDataArray conductivity for a medium if applicable, else None."""
+        SolidType = (SolidSpec, SolidMedium)
+        if property == "heat_conductivity":
+            if isinstance(medium.heat_spec, SolidType):
+                cond = medium.heat_spec.conductivity
+                if isinstance(cond, SpatialDataArray):
+                    return cond
+        elif property == "electric_conductivity":
+            if isinstance(medium.charge, ChargeConductorMedium):
+                cond = medium.charge.conductivity
+                if isinstance(cond, SpatialDataArray):
+                    return cond
+        return None
+
+    def _plot_spatial_conductivity_on_shape(
+        self,
+        conductivity: SpatialDataArray,
+        shape: Shapely,
+        axis: int,
+        position: float,
+        property_val_min: float,
+        property_val_max: float,
+        alpha: float,
+        ax: Ax,
+        norm: mpl.colors.Normalize | None = None,
+    ) -> Ax:
+        """Plot a ``SpatialDataArray`` conductivity on a 2D cross-section, clipped to the
+        structure's polygon outline.
+        """
+        import matplotlib as mpl
+
+        plane_axes_inds = [0, 1, 2]
+        plane_axes_inds.pop(axis)
+
+        shape_bounds = shape.bounds
+        rmin, rmax = [*shape_bounds[:2]], [*shape_bounds[2:]]
+        rmin.insert(axis, position)
+        rmax.insert(axis, position)
+
+        N = 100
+        coords_2D = [np.linspace(rmin[d], rmax[d], N) for d in plane_axes_inds]
+        X, Y = np.meshgrid(coords_2D[0], coords_2D[1], indexing="ij")
+
+        struct_coords = {"xyz"[d]: coords_2D[i] for i, d in enumerate(plane_axes_inds)}
+
+        data_2D = conductivity.sel(**{"xyz"[axis]: position}, method="nearest")
+
+        k_grid = data_2D.interp(
+            **struct_coords,
+            method="nearest",
+            kwargs={"bounds_error": False, "fill_value": 0},
+        )
+
+        if norm is None:
+            norm = mpl.colors.Normalize(vmin=property_val_min, vmax=property_val_max)
+
+        ax.pcolormesh(
+            X,
+            Y,
+            k_grid.values,
+            clip_path=(polygon_path(shape), ax.transData),
+            cmap=STRUCTURE_HEAT_COND_CMAP,
+            alpha=alpha,
+            clip_box=ax.bbox,
+            norm=norm,
+        )
+
         return ax
 
     @equal_aspect

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -16,6 +16,7 @@ from tidy3d.components.bc_placement import (
     StructureSimulationBoundary,
     StructureStructureInterface,
 )
+from tidy3d.components.data.data_array import SpatialDataArray
 from tidy3d.components.geometry.base import Box, Transformed
 from tidy3d.components.geometry.primitives import Cylinder
 from tidy3d.components.geometry.utils import flatten_groups
@@ -1034,7 +1035,32 @@ class HeatChargeSimulation(AbstractSimulation):
                     "but none have been defined."
                 )
 
+        self._check_spatial_conductivity_no_semiconductors()
+
         return self
+
+    def _check_spatial_conductivity_no_semiconductors(self) -> None:
+        """Raise if any ChargeConductorMedium uses SpatialDataArray conductivity while
+        semiconductors are also present in the simulation, as this feature is not currently supported.
+        """
+        has_spatial = False
+        for structure in self.structures:
+            medium = structure.medium
+            charge = getattr(medium, "charge", None)
+            if isinstance(charge, ChargeConductorMedium) and isinstance(
+                charge.conductivity, SpatialDataArray
+            ):
+                has_spatial = True
+                break
+
+        if not has_spatial:
+            return
+
+        if self._check_if_semiconductor_present(self.structures):
+            raise SetupError(
+                "SpatialDataArray conductivity in 'ChargeConductorMedium' cannot be used "
+                "when semiconductor structures are present in the simulation."
+            )
 
     def _estimate_charge_mesh_size(self) -> Self:
         """Make an estimate of the mesh size and raise a warning if too big.


### PR DESCRIPTION
Frontend implementation of spatially varying conductivity.
- Potentially, we could enable spatially varying conductivity for conductors too.
- I am not 100% sure on the plot part. It had to be changed to accommodate the non-uniform heat source, but I am wondering if it pollutes other plots. Let's see if we get something useful out from bug-bot.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands core simulation/material validation and plotting paths to support non-scalar conductivities; risk is mainly in schema/serialization compatibility and potential plotting regressions (norm/overlays), plus a new unsupported-case guard for semiconductor mixes.
> 
> **Overview**
> Adds support for **spatially varying thermal conductivity** by allowing `SolidMedium`/`SolidSpec.conductivity` to accept `SpatialDataArray` (including `from_si_units` scaling) and updating JSON schemas to allow non-numeric `conductivity` values.
> 
> Extends `Scene.plot_structures_property` to plot `heat_conductivity`/`electric_conductivity` with updated bounds handling for spatial data and an optional `pcolormesh` overlay clipped to each structure; includes tests covering acceptance, unit scaling, overlay rendering, and log-scale norm behavior.
> 
> Also allows `ChargeConductorMedium.conductivity` to be a `SpatialDataArray`, and adds a `HeatChargeSimulation` setup check that rejects spatial conductor conductivity when semiconductor structures are present (with a corresponding test).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5756c58bf0e31613ed015a98dba1e027ddbdd64c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->