### PR TITLE
perf(web): FXC-4051 eager batch job starts and http call parallelization

### DIFF
--- a/changelog.d/3334.added.md
+++ b/changelog.d/3334.added.md
@@ -1,0 +1,1 @@
+Implemented batch execution optimizations by reducing and parallelizing HTTP calls and overlapping upload with task startup.

--- a/changelog.d/3334.fixed.md
+++ b/changelog.d/3334.fixed.md
@@ -1,0 +1,1 @@
+Fixed `num_workers` propagation in batch async/autograd paths so explicit values are respected, while defaults are preserved when omitted.

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -97,9 +97,55 @@ class FakeJob:
         return False
 
 
+class FakeJobWithSimulation(FakeJob):
+    def __init__(
+        self, task_id: str, statuses: list[str], events: list[str], simulation: td.Simulation
+    ):
+        super().__init__(task_id=task_id, statuses=statuses, events=events)
+        self.simulation = simulation
+
+
+class UploadStartFakeJob:
+    def __init__(self, task_id: str, events: list[tuple], cached: bool = False):
+        self.task_id = task_id
+        self.events = events
+        self._cached = cached
+
+    @property
+    def load_if_cached(self):
+        return self._cached
+
+    def upload(self):
+        self.events.append((self.task_id, "upload"))
+
+    def start(self, priority=None):
+        self.events.append((self.task_id, "start", priority))
+
+
+class LoadStatusFakeJob:
+    def __init__(self, task_id: str, status: str, simulation: td.Simulation):
+        self.task_id = task_id
+        self._status = status
+        self.simulation = simulation
+
+    @property
+    def status(self):
+        return self._status
+
+    @property
+    def load_if_cached(self):
+        return False
+
+
 class ImmediateExecutor:
     def __init__(self, *args, **kwargs):
         pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.shutdown(wait=True)
 
     def submit(self, fn, *args, **kwargs):
         future = Future()
@@ -782,10 +828,10 @@ def test_batch_run_saves_file_after_upload(mock_webapi, mock_job_status, tmp_pat
         batch_file_saved["has_task_ids"] = self.jobs is not None and TASK_NAME in self.jobs
         return original_to_file(self, fname)
 
-    # mock start to interrupt run() after upload and to_file
-    def mock_start_interrupt(self, *args, **kwargs):
-        # at this point, upload() and to_file() should have been called
-        assert batch_file_saved["saved"], "Batch file should be saved before start()"
+    # mock monitor to interrupt run() after upload/start and to_file
+    def mock_monitor_interrupt(self, *args, **kwargs):
+        # at this point, upload/start and to_file() should have been called
+        assert batch_file_saved["saved"], "Batch file should be saved before monitor()"
         assert batch_file_saved["has_task_ids"], "Batch file should have task_ids"
         # verify file actually exists and can be loaded
         batch_path = self._batch_path(path_dir=str(tmp_path))
@@ -795,11 +841,35 @@ def test_batch_run_saves_file_after_upload(mock_webapi, mock_job_status, tmp_pat
         raise RuntimeError("Simulated interruption after upload")
 
     monkeypatch.setattr(Batch, "to_file", track_to_file)
-    monkeypatch.setattr(Batch, "start", mock_start_interrupt)
+    monkeypatch.setattr(Batch, "monitor", mock_monitor_interrupt)
 
     # run should save the batch file after upload, even if interrupted
     with pytest.raises(RuntimeError, match="Simulated interruption"):
         batch.run(path_dir=str(tmp_path))
+
+
+def test_batch_run_saves_file_when_upload_and_start_fails(tmp_path, monkeypatch):
+    sims = {TASK_NAME: make_sim()}
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME)
+
+    batch_file_saved = {"saved": False}
+    original_to_file = Batch.to_file
+
+    def track_to_file(self, fname):
+        batch_file_saved["saved"] = True
+        return original_to_file(self, fname)
+
+    def mock_upload_and_start_fail(self, *args, **kwargs):
+        raise RuntimeError("Simulated failure during upload/start")
+
+    monkeypatch.setattr(Batch, "to_file", track_to_file)
+    monkeypatch.setattr(Batch, "_upload_and_start", mock_upload_and_start_fail)
+
+    with pytest.raises(RuntimeError, match="Simulated failure"):
+        batch.run(path_dir=str(tmp_path))
+
+    assert batch_file_saved["saved"]
+    assert os.path.exists(batch._batch_path(path_dir=str(tmp_path)))
 
 
 def test_batch_monitor_downloads_on_success(monkeypatch, tmp_path):
@@ -841,6 +911,74 @@ def test_batch_monitor_downloads_on_success(monkeypatch, tmp_path):
     )
 
     assert job1_download_idx < job2_success_idx, "Download should start before other jobs finish"
+
+
+def test_batch_monitor_does_not_repoll_completed_jobs(monkeypatch, tmp_path):
+    events = []
+
+    monkeypatch.setattr("tidy3d.web.api.container.ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr("tidy3d.web.api.container.time.sleep", lambda *_args, **_kwargs: None)
+
+    sims = {"done_task": make_sim(), "slow_task": make_sim()}
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME, verbose=False)
+    batch._cached_properties = {}
+    batch._cached_properties["jobs"] = {
+        "done_task": FakeJob("done_id", ["success", "success"], events),
+        "slow_task": FakeJob("slow_id", ["running", "running", "success"], events),
+    }
+
+    batch.monitor(download_on_success=False, path_dir=str(tmp_path))
+
+    done_status_calls = sum(1 for event in events if event == ("done_id", "status", "success"))
+    slow_status_calls = sum(1 for event in events if event[0] == "slow_id" and event[1] == "status")
+    assert done_status_calls == 1
+    assert slow_status_calls >= 3
+
+
+def test_batch_upload_and_start_starts_each_task_after_upload(monkeypatch):
+    events = []
+
+    monkeypatch.setattr("tidy3d.web.api.container.ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr(Batch, "_check_folder", staticmethod(lambda *args, **kwargs: None))
+
+    sims = {"task_a": make_sim(), "task_b": make_sim()}
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME, verbose=False)
+    batch._cached_properties = {}
+    batch._cached_properties["jobs"] = {
+        "task_a": UploadStartFakeJob("task_a_id", events),
+        "task_b": UploadStartFakeJob("task_b_id", events),
+    }
+
+    batch._upload_and_start(priority=6)
+
+    assert events == [
+        ("task_a_id", "upload"),
+        ("task_a_id", "start", 6),
+        ("task_b_id", "upload"),
+        ("task_b_id", "start", 6),
+    ]
+
+
+def test_batch_upload_and_start_skips_cached_jobs(monkeypatch):
+    events = []
+
+    monkeypatch.setattr("tidy3d.web.api.container.ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr(Batch, "_check_folder", staticmethod(lambda *args, **kwargs: None))
+
+    sims = {"cached_task": make_sim(), "running_task": make_sim()}
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME, verbose=False)
+    batch._cached_properties = {}
+    batch._cached_properties["jobs"] = {
+        "cached_task": UploadStartFakeJob("cached_id", events, cached=True),
+        "running_task": UploadStartFakeJob("running_id", events, cached=False),
+    }
+
+    batch._upload_and_start(priority=3)
+
+    assert events == [
+        ("running_id", "upload"),
+        ("running_id", "start", 3),
+    ]
 
 
 def test_batch_monitor_skips_existing_download(monkeypatch, tmp_path):
@@ -918,6 +1056,92 @@ def test_batch_download_surfaces_download_errors(monkeypatch, tmp_path):
         batch.download(path_dir=str(tmp_path))
 
 
+def test_batch_upload_surfaces_upload_errors(monkeypatch):
+    monkeypatch.setattr("tidy3d.web.api.container.ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr(Batch, "_check_folder", staticmethod(lambda *args, **kwargs: None))
+    monkeypatch.setattr("tidy3d.web.api.container.Job.load_if_cached", property(lambda self: False))
+
+    def _raise_upload(self):
+        raise RuntimeError("upload failed")
+
+    monkeypatch.setattr("tidy3d.web.api.container.Job.upload", _raise_upload)
+
+    sims = {"task_a": make_sim()}
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME, verbose=False)
+
+    with pytest.raises(RuntimeError, match="upload failed"):
+        batch.upload()
+
+
+def test_batch_load_parallel_status_collection(monkeypatch, tmp_path):
+    max_workers_used = []
+    submit_calls = []
+    warning_messages = []
+
+    class CapturingExecutor(ImmediateExecutor):
+        def __init__(self, *args, **kwargs):
+            max_workers_used.append(kwargs.get("max_workers"))
+
+        def submit(self, fn, *args, **kwargs):
+            submit_calls.append((fn, args, kwargs))
+            return super().submit(fn, *args, **kwargs)
+
+    monkeypatch.setattr("tidy3d.web.api.container.ThreadPoolExecutor", CapturingExecutor)
+    monkeypatch.setattr(
+        "tidy3d.web.api.container.log.warning", lambda msg: warning_messages.append(msg)
+    )
+
+    sims = {"ok_task": make_sim(), "bad_task": make_sim()}
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME, verbose=False)
+    batch._cached_properties = {
+        "jobs": {
+            "ok_task": LoadStatusFakeJob("ok_task_id", "success", sims["ok_task"]),
+            "bad_task": LoadStatusFakeJob("bad_task_id", "error", sims["bad_task"]),
+        }
+    }
+
+    data = batch.load(path_dir=str(tmp_path), skip_download=True)
+
+    assert max_workers_used == [batch.num_workers]
+    assert len(submit_calls) == 2
+    assert data.task_ids == {"ok_task": "ok_task_id"}
+    assert set(data.task_paths.keys()) == {"ok_task"}
+    assert warning_messages == ["Not loading 'bad_task' as the task errored."]
+
+
+def test_batch_load_reuses_terminal_status_snapshot(monkeypatch, tmp_path):
+    events = []
+
+    monkeypatch.setattr("tidy3d.web.api.container.ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr("tidy3d.web.api.container.time.sleep", lambda *_args, **_kwargs: None)
+
+    sims = {"task_a": make_sim(), "task_b": make_sim()}
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME, verbose=False)
+    batch._cached_properties = {}
+    batch._cached_properties["jobs"] = {
+        "task_a": FakeJobWithSimulation(
+            "task_a_id",
+            ["running", "success", "success"],
+            events,
+            sims["task_a"],
+        ),
+        "task_b": FakeJobWithSimulation(
+            "task_b_id",
+            ["running", "running", "success", "success"],
+            events,
+            sims["task_b"],
+        ),
+    }
+
+    batch.monitor(download_on_success=False, path_dir=str(tmp_path))
+    status_calls_before_load = sum(1 for event in events if event[1] == "status")
+
+    _ = batch.load(path_dir=str(tmp_path), skip_download=True)
+    status_calls_after_load = sum(1 for event in events if event[1] == "status")
+
+    assert status_calls_after_load == status_calls_before_load
+
+
 """ Async """
 
 
@@ -927,6 +1151,86 @@ def test_async(mock_webapi, mock_job_status, tmp_path, task_name):
     # monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
     sims = {TASK_NAME: make_sim()} if task_name else [make_sim()]
     _ = run_async(sims, folder_name=PROJECT_NAME, path_dir=str(tmp_path))
+
+
+def test_async_forwards_num_workers(monkeypatch):
+    captured_kwargs = {}
+    captured_run_kwargs = {}
+
+    class DummyBatch:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+        def run(self, **kwargs):
+            captured_run_kwargs.update(kwargs)
+            return {}
+
+    monkeypatch.setattr("tidy3d.web.api.asynchronous.Batch", DummyBatch)
+
+    sims = {TASK_NAME: make_sim()}
+    _ = run_async(sims, folder_name=PROJECT_NAME, path_dir=".", num_workers=7, verbose=False)
+
+    assert captured_kwargs["num_workers"] == 7
+    assert captured_run_kwargs["path_dir"] == "."
+
+
+def test_async_omits_num_workers_when_not_provided(monkeypatch):
+    captured_kwargs = {}
+
+    class DummyBatch:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+        def run(self, **kwargs):
+            return {}
+
+    monkeypatch.setattr("tidy3d.web.api.asynchronous.Batch", DummyBatch)
+
+    sims = {TASK_NAME: make_sim()}
+    _ = run_async(sims, folder_name=PROJECT_NAME, path_dir=".", verbose=False)
+
+    assert "num_workers" not in captured_kwargs
+
+
+def test_batch_run_uses_optimized_upload_and_start(monkeypatch, tmp_path):
+    class RunFakeJob:
+        @property
+        def load_if_cached(self):
+            return False
+
+    upload_start_calls = {"count": 0, "priority": None}
+    load_kwargs = {}
+
+    def _raise_legacy_upload(*args, **kwargs):
+        raise AssertionError("Batch.run should not call legacy Batch.upload().")
+
+    def _raise_legacy_start(*args, **kwargs):
+        raise AssertionError("Batch.run should not call legacy Batch.start().")
+
+    def _track_upload_and_start(self, priority=None):
+        upload_start_calls["count"] += 1
+        upload_start_calls["priority"] = priority
+
+    def _fake_load(self, **kwargs):
+        load_kwargs.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(Batch, "upload", _raise_legacy_upload)
+    monkeypatch.setattr(Batch, "start", _raise_legacy_start)
+    monkeypatch.setattr(Batch, "_upload_and_start", _track_upload_and_start)
+    monkeypatch.setattr(Batch, "to_file", lambda *args, **kwargs: None)
+    monkeypatch.setattr(Batch, "monitor", lambda *args, **kwargs: None)
+    monkeypatch.setattr(Batch, "load", _fake_load)
+
+    batch = Batch(simulations={"task_a": make_sim()}, folder_name=PROJECT_NAME, verbose=False)
+    batch._cached_properties = {"jobs": {"task_a": RunFakeJob()}}
+
+    result = batch.run(path_dir=str(tmp_path), priority=8)
+
+    assert result == {"ok": True}
+    assert upload_start_calls["count"] == 1
+    assert upload_start_calls["priority"] == 8
+    assert load_kwargs == {"path_dir": str(tmp_path), "skip_download": True}
 
 
 """ Main """

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -26,7 +26,7 @@ from tidy3d.components.grid.grid_spec import GridSpec
 from tidy3d.components.monitor import FieldMonitor
 from tidy3d.components.source.current import PointDipole
 from tidy3d.components.source.time import GaussianPulse
-from tidy3d.exceptions import SetupError
+from tidy3d.exceptions import DataError, SetupError
 from tidy3d.web import common
 from tidy3d.web.api.asynchronous import run_async
 from tidy3d.web.api.container import Batch, BatchData, Job, WebContainer
@@ -1140,6 +1140,22 @@ def test_batch_load_reuses_terminal_status_snapshot(monkeypatch, tmp_path):
     status_calls_after_load = sum(1 for event in events if event[1] == "status")
 
     assert status_calls_after_load == status_calls_before_load
+
+
+def test_batch_load_does_not_upload_unknown_tasks(monkeypatch, tmp_path):
+    monkeypatch.setattr("tidy3d.web.api.container.ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr("tidy3d.web.api.container.Job.load_if_cached", property(lambda self: False))
+
+    def _raise_upload(self, *args, **kwargs):
+        raise AssertionError("Batch.load() should not upload tasks.")
+
+    monkeypatch.setattr("tidy3d.web.api.container.Job._upload", _raise_upload)
+
+    sims = {"task_a": make_sim()}
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME, verbose=False)
+
+    with pytest.raises(DataError, match="task hasn't been uploaded"):
+        batch.load(path_dir=str(tmp_path), skip_download=True)
 
 
 """ Async """

--- a/tidy3d/web/api/asynchronous.py
+++ b/tidy3d/web/api/asynchronous.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from tidy3d.log import log
 from tidy3d.web.core.types import PayType
 
 from .container import DEFAULT_DATA_DIR, Batch
@@ -50,7 +49,7 @@ def run_async(
         Http PUT url to receive simulation finish event. The body content is a json file with
         fields ``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.
     num_workers: int = None
-        Number of tasks to submit at once in a batch, if None, will run all at the same time.
+        Number of worker threads used by :class:`Batch` upload/start/download stages.
     verbose : bool = True
         If ``True``, will print progressbars and status, otherwise, will run silently.
     simulation_type : str = "tidy3d"
@@ -86,13 +85,6 @@ def run_async(
     if simulation_type is None:
         simulation_type = "tidy3d"
 
-    # if number of workers not specified, just use the number of simulations
-    if num_workers is not None:
-        log.warning(
-            "The 'num_workers' kwarg does not have an effect anymore as all "
-            "simulations will now be uploaded in a single batch."
-        )
-
     batch = Batch(
         simulations=simulations,
         folder_name=folder_name,
@@ -104,6 +96,7 @@ def run_async(
         reduce_simulation=reduce_simulation,
         pay_type=pay_type,
         lazy=lazy,
+        **({"num_workers": num_workers} if num_workers is not None else {}),
     )
 
     batch_data = batch.run(path_dir=path_dir, priority=priority)

--- a/tidy3d/web/api/autograd/engine.py
+++ b/tidy3d/web/api/autograd/engine.py
@@ -16,6 +16,16 @@ def parse_run_kwargs(**run_kwargs: Any) -> dict[str, Any]:
     return job_init_kwargs
 
 
+def _build_batch(
+    simulations: dict[str, td.Simulation], *, num_workers: int | None, **kwargs: Any
+) -> Batch:
+    """Construct ``Batch`` while preserving the model default when ``num_workers`` is omitted."""
+    batch_kwargs = dict(simulations=simulations, **kwargs)
+    if num_workers is not None:
+        batch_kwargs["num_workers"] = num_workers
+    return Batch(**batch_kwargs)
+
+
 def _run_tidy3d(
     simulation: td.Simulation, task_name: str, **run_kwargs: Any
 ) -> tuple[td.SimulationData, str]:
@@ -46,7 +56,8 @@ def _run_async_tidy3d(
     batch_init_kwargs = parse_run_kwargs(**run_kwargs)
     path_dir = run_kwargs.pop("path_dir", None)
     priority = run_kwargs.get("priority")
-    batch = Batch(simulations=simulations, **batch_init_kwargs)
+    num_workers = run_kwargs.get("num_workers")
+    batch = _build_batch(simulations=simulations, num_workers=num_workers, **batch_init_kwargs)
     td.log.info(f"running {batch.simulation_type} batch with '_run_async_tidy3d()'")
 
     if batch.simulation_type == "autograd_fwd":
@@ -81,7 +92,8 @@ def _run_async_tidy3d_bwd(
 
     batch_init_kwargs = parse_run_kwargs(**run_kwargs)
     _ = run_kwargs.pop("path_dir", None)
-    batch = Batch(simulations=simulations, **batch_init_kwargs)
+    num_workers = run_kwargs.get("num_workers")
+    batch = _build_batch(simulations=simulations, num_workers=num_workers, **batch_init_kwargs)
     td.log.info(f"running {batch.simulation_type} batch with '_run_async_tidy3d_bwd()'")
 
     priority = run_kwargs.get("priority")

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -1627,6 +1627,33 @@ class Batch(WebContainer):
             if task_name in self.jobs
         }
 
+        def _known_task_id(task_name: TaskName, job: Job) -> Optional[TaskId]:
+            """Return a known task id without triggering uploads."""
+            task_id = terminal_task_id_by_task.get(task_name)
+            if task_id is not None:
+                return task_id
+
+            cached_properties = getattr(job, "_cached_properties", None)
+            if isinstance(cached_properties, dict):
+                task_id = cached_properties.get("task_id")
+                if task_id is not None:
+                    return task_id
+
+            task_id_cached = getattr(job, "task_id_cached", None)
+            if task_id_cached is not None:
+                return task_id_cached
+
+            # Support lightweight job doubles in tests without touching real Job.task_id.
+            if not isinstance(job, Job):
+                task_id = getattr(job, "task_id", None)
+                if task_id is not None:
+                    return task_id
+
+            if job.load_if_cached:
+                return getattr(job, "_cached_task_id", None)
+
+            return None
+
         def _resolve_task_status(
             task_name: TaskName, job: Job
         ) -> tuple[TaskName, str, Optional[TaskId]]:
@@ -1634,21 +1661,32 @@ class Batch(WebContainer):
             if terminal_status in END_STATES:
                 if "error" in terminal_status:
                     return task_name, terminal_status, None
-                task_id = terminal_task_id_by_task.get(task_name)
+
+                task_id = _known_task_id(task_name, job)
                 if task_id is None:
-                    task_id = job.task_id
+                    raise DataError(
+                        f"Can't load batch results for '{task_name}', task hasn't been uploaded."
+                    )
                 return task_name, terminal_status, task_id
 
             if job.load_if_cached:
-                task_id = terminal_task_id_by_task.get(task_name)
+                task_id = _known_task_id(task_name, job)
                 if task_id is None:
-                    task_id = job.task_id
+                    raise DataError(
+                        f"Can't load batch results for '{task_name}', task hasn't been uploaded."
+                    )
                 return task_name, "success", task_id
+
+            task_id = _known_task_id(task_name, job)
+            if task_id is None:
+                raise DataError(
+                    f"Can't load batch results for '{task_name}', task hasn't been uploaded."
+                )
 
             status = job.status
             if "error" in status:
                 return task_name, status, None
-            return task_name, status, job.task_id
+            return task_name, status, task_id
 
         status_by_task: dict[TaskName, str] = {}
         task_id_by_task: dict[TaskName, TaskId] = {}

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -47,7 +47,7 @@ from tidy3d.web.core.task_info import BatchDetail
 from tidy3d.web.core.types import PayType
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
     from os import PathLike
 
     from rich.progress import TaskID
@@ -856,6 +856,8 @@ class Batch(WebContainer):
     )
 
     _job_type: type = PrivateAttr(Job)
+    _terminal_status_by_task: dict[TaskName, str] = PrivateAttr(default_factory=dict)
+    _terminal_task_id_by_task: dict[TaskName, TaskId] = PrivateAttr(default_factory=dict)
 
     @field_validator("simulations", mode="before")
     @classmethod
@@ -918,12 +920,12 @@ class Batch(WebContainer):
         loaded = [job.load_if_cached for job in self.jobs.values()]
         self._check_path_dir(path_dir)
         if not all(loaded):
-            self.upload()
-            self.to_file(self._batch_path(path_dir=path_dir))
-            if priority is None:
-                self.start()
-            else:
-                self.start(priority=priority)
+            batch_path = self._batch_path(path_dir=path_dir)
+            try:
+                self._upload_and_start(priority=priority)
+            finally:
+                # Persist any known task IDs even if upload/start raises midway.
+                self.to_file(batch_path)
             self.monitor(
                 path_dir=path_dir,
                 download_on_success=True,
@@ -1007,27 +1009,61 @@ class Batch(WebContainer):
         """Number of jobs in the batch."""
         return len(self.jobs)
 
-    def upload(self) -> None:
-        """Upload a series of tasks associated with this ``Batch`` using multi-threading."""
-        self._check_folder(self.folder_name)
-        with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
-            jobs_from_cache = [job for job in self.jobs.values() if job.load_if_cached]
-            jobs_to_upload = [job for job in self.jobs.values() if not job.load_if_cached]
-            futures = [executor.submit(job.upload) for job in jobs_to_upload]
+    def _partition_jobs_by_cache(self) -> tuple[list[Job], list[Job]]:
+        """Return ``(cached_jobs, uncached_jobs)`` for the current batch."""
+        jobs_from_cache = []
+        jobs_uncached = []
+        for job in self.jobs.values():
+            if job.load_if_cached:
+                jobs_from_cache.append(job)
+            else:
+                jobs_uncached.append(job)
+        return jobs_from_cache, jobs_uncached
 
-            # progressbar (number of tasks uploaded)
+    def _log_cached_jobs(self, jobs_from_cache: list[Job]) -> None:
+        """Log how many jobs were restored from cache."""
+        if not self.verbose:
+            return
+
+        n_cached = len(jobs_from_cache)
+        if n_cached <= 0:
+            return
+
+        console = get_logging_console()
+        console.log(f"Got {n_cached} simulation{'s' if n_cached > 1 else ''} from cache.")
+
+    def _prepare_uncached_jobs(
+        self,
+        *,
+        check_folder: bool = False,
+        log_cached_jobs: bool = False,
+    ) -> list[Job]:
+        """Prepare uncached jobs with shared cache/folder handling."""
+        if check_folder:
+            self._check_folder(self.folder_name)
+
+        jobs_from_cache, jobs_uncached = self._partition_jobs_by_cache()
+        if log_cached_jobs:
+            self._log_cached_jobs(jobs_from_cache)
+
+        return jobs_uncached
+
+    def _run_job_pool(
+        self,
+        *,
+        jobs: list[Job],
+        fn: Callable[[Job], None],
+        progress_message: str,
+    ) -> None:
+        """Run job callbacks concurrently and surface completion/errors consistently."""
+        if not jobs:
+            return
+
+        with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
+            futures = [executor.submit(fn, job) for job in jobs]
+
             if self.verbose:
                 console = get_logging_console()
-                n_cached = len(jobs_from_cache)
-                if n_cached > 0:
-                    console.log(
-                        f"Got {n_cached} simulation{'s' if n_cached > 1 else ''} from cache."
-                    )
-
-            if len(futures) == 0:  # got all jobs from cache
-                return
-
-            if self.verbose:
                 progress_columns = (
                     TextColumn("[progress.description]{task.description}"),
                     BarColumn(),
@@ -1035,18 +1071,53 @@ class Batch(WebContainer):
                     TimeElapsedColumn(),
                 )
                 with Progress(*progress_columns, console=console, transient=False) as progress:
-                    pbar_message = f"Uploading data for {len(jobs_to_upload)} task{'s' if len(jobs_to_upload) > 1 else ''}"
-                    pbar = progress.add_task(pbar_message, total=len(jobs_to_upload))
+                    pbar = progress.add_task(progress_message, total=len(jobs))
                     completed = 0
-                    for _ in concurrent.futures.as_completed(futures):
+                    for fut in concurrent.futures.as_completed(futures):
+                        fut.result()
                         completed += 1
                         progress.update(pbar, completed=completed)
 
                     progress.refresh()
                     time.sleep(BATCH_PROGRESS_REFRESH_TIME)
             else:
-                for _ in concurrent.futures.as_completed(futures):
-                    pass
+                for fut in concurrent.futures.as_completed(futures):
+                    fut.result()
+
+    def _upload_and_start(self, priority: Optional[int] = None) -> None:
+        """Optimized run path: start each task immediately after its upload finishes."""
+
+        def _fn(job: Job) -> None:
+            job.upload()
+            job.start(priority=priority)
+
+        jobs_to_upload = self._prepare_uncached_jobs(
+            check_folder=True,
+            log_cached_jobs=True,
+        )
+        self._run_job_pool(
+            jobs=jobs_to_upload,
+            fn=_fn,
+            progress_message=(
+                f"Upload and start {len(jobs_to_upload)} "
+                f"task{'s' if len(jobs_to_upload) > 1 else ''}"
+            ),
+        )
+
+    def upload(self) -> None:
+        """Upload a series of tasks associated with this ``Batch`` using multi-threading."""
+        jobs_to_upload = self._prepare_uncached_jobs(
+            check_folder=True,
+            log_cached_jobs=True,
+        )
+        self._run_job_pool(
+            jobs=jobs_to_upload,
+            fn=lambda job: job.upload(),
+            progress_message=(
+                f"Uploading data for {len(jobs_to_upload)} "
+                f"task{'s' if len(jobs_to_upload) > 1 else ''}"
+            ),
+        )
 
     def get_info(self) -> dict[TaskName, TaskInfo]:
         """Get information about each task in the :class:`Batch`.
@@ -1081,13 +1152,14 @@ class Batch(WebContainer):
         if self.verbose:
             console = get_logging_console()
             console.log(f"Started working on Batch containing {self.num_jobs} tasks.")
-
-        with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
-            for _, job in self.jobs.items():
-                if priority is None:
-                    executor.submit(job.start)
-                else:
-                    executor.submit(job.start, priority=priority)
+        jobs_to_start = self._prepare_uncached_jobs()
+        self._run_job_pool(
+            jobs=jobs_to_start,
+            fn=lambda job: job.start(priority=priority),
+            progress_message=(
+                f"Starting {len(jobs_to_start)} task{'s' if len(jobs_to_start) > 1 else ''}"
+            ),
+        )
 
     def get_run_info(self) -> dict[TaskName, RunInfo]:
         """get information about a each of the tasks in the :class:`Batch`.
@@ -1129,6 +1201,21 @@ class Batch(WebContainer):
             Downloads the data even if path exists (overwriting the existing). Only used when
             ``download_on_success`` is ``True``.
         """
+        jobs = self.jobs
+        jobs_items = list(jobs.items())
+        active_task_names = set(jobs)
+        self._terminal_status_by_task = {
+            task_name: status
+            for task_name, status in self._terminal_status_by_task.items()
+            if task_name in active_task_names and status in END_STATES
+        }
+        self._terminal_task_id_by_task = {
+            task_name: task_id
+            for task_name, task_id in self._terminal_task_id_by_task.items()
+            if task_name in active_task_names
+        }
+        status_by_task = dict(self._terminal_status_by_task)
+
         # ----- download scheduling ---------------------------------------------------
         downloads_started: set[str] = set()
         download_futures: dict[TaskId, concurrent.futures.Future] = {}
@@ -1138,10 +1225,47 @@ class Batch(WebContainer):
             self._check_path_dir(path_dir=path_dir)
             download_executor = ThreadPoolExecutor(max_workers=self.num_workers)
 
-        def schedule_download(job: Job) -> None:
-            if download_executor is None or job.status not in COMPLETED_STATES:
+        def _remember_terminal_status(task_name: TaskName, job: Job, status: str) -> None:
+            if status not in END_STATES:
                 return
-            task_id = job.task_id
+
+            status_by_task[task_name] = status
+            self._terminal_status_by_task[task_name] = status
+            if "error" in status:
+                return
+
+            # Keep task IDs around to avoid re-querying status/id in a following load().
+            task_id = self._terminal_task_id_by_task.get(task_name)
+            if task_id is None:
+                task_id = job.task_id
+            self._terminal_task_id_by_task[task_name] = task_id
+
+        def _get_status(task_name: TaskName, job: Job) -> str:
+            cached_status = status_by_task.get(task_name)
+            if cached_status in END_STATES:
+                return cached_status
+
+            status = job.status
+            status_by_task[task_name] = status
+            _remember_terminal_status(task_name, job, status)
+            return status
+
+        def schedule_download(
+            task_name: TaskName,
+            job: Job,
+            status: Optional[str] = None,
+        ) -> None:
+            if download_executor is None:
+                return
+
+            if status is None:
+                status = _get_status(task_name, job)
+            if status not in COMPLETED_STATES:
+                return
+
+            task_id = self._terminal_task_id_by_task.get(task_name)
+            if task_id is None:
+                task_id = job.task_id
             if task_id in downloads_started:
                 return
 
@@ -1160,10 +1284,11 @@ class Batch(WebContainer):
             download_futures[task_id] = download_executor.submit(job.download, job_path)
 
         # ----- continue condition & status formatting -------------------------------
-        def check_continue_condition(job: Job) -> bool:
+        def check_continue_condition(task_name: TaskName, job: Job) -> bool:
             if job.load_if_cached:
+                _remember_terminal_status(task_name, job, "success")
                 return False
-            return job.status not in END_STATES
+            return _get_status(task_name, job) not in END_STATES
 
         def pbar_description(
             task_name: str, status: str, max_name_length: int, status_width: int
@@ -1208,32 +1333,49 @@ class Batch(WebContainer):
                 *progress_columns, console=console, transient=False, disable=not self.verbose
             ) as progress:
                 pbar_tasks: dict[str, TaskID] = {}
-                for task_name, job in self.jobs.items():
-                    schedule_download(job)
+                for task_name, job in jobs_items:
+                    status = status_by_task.get(task_name)
                     if self.verbose:
                         if job.load_if_cached:
                             status = "success"
                             completed = COMPLETED_PERCENT
+                            _remember_terminal_status(task_name, job, status)
+                        elif status in END_STATES:
+                            completed = STATE_PROGRESS_PERCENTAGE.get(status, COMPLETED_PERCENT)
                         else:
                             info = job.get_info()
                             status = info.status
+                            status_by_task[task_name] = status
+                            _remember_terminal_status(task_name, job, status)
                             if isinstance(info, BatchDetail):
                                 status, _, completed = _batch_detail_progress(info)
                             else:
                                 completed = STATE_PROGRESS_PERCENTAGE.get(status, 0)
+                        schedule_download(task_name, job, status=status)
                         desc = pbar_description(task_name, status, max_name_length, 0)
                         pbar_tasks[task_name] = progress.add_task(
                             desc, total=COMPLETED_PERCENT, completed=completed
                         )
+                    else:
+                        schedule_download(task_name, job, status=status)
 
-                while any(check_continue_condition(job) for job in self.jobs.values()):
-                    for task_name, job in self.jobs.items():
+                while any(
+                    check_continue_condition(task_name, job) for task_name, job in jobs_items
+                ):
+                    for task_name, job in jobs_items:
                         if job.load_if_cached:
                             continue
+                        status = status_by_task.get(task_name)
+                        if status in END_STATES:
+                            schedule_download(task_name, job, status=status)
+                            continue
+
                         info = job.get_info()
                         status = info.status
+                        status_by_task[task_name] = status
+                        _remember_terminal_status(task_name, job, status)
 
-                        schedule_download(job)
+                        schedule_download(task_name, job, status=status)
 
                         if self.verbose:
                             # choose display status & percent
@@ -1261,16 +1403,28 @@ class Batch(WebContainer):
                         time.sleep(web.REFRESH_TIME)
 
                 # final render to terminal state for all bars
-                for task_name, job in self.jobs.items():
-                    schedule_download(job)
+                for task_name, job in jobs_items:
+                    status = status_by_task.get(task_name)
+                    if status is None:
+                        if job.load_if_cached:
+                            status = "success"
+                            _remember_terminal_status(task_name, job, status)
+                        else:
+                            status = _get_status(task_name, job)
+                    schedule_download(task_name, job, status=status)
 
                     if self.verbose:
                         if job.load_if_cached:
                             display_status = "success"
                             pct = COMPLETED_PERCENT
+                        elif status in END_STATES:
+                            display_status = status
+                            pct = STATE_PROGRESS_PERCENTAGE.get(status, COMPLETED_PERCENT)
                         else:
                             info = job.get_info()
                             status = info.status
+                            status_by_task[task_name] = status
+                            _remember_terminal_status(task_name, job, status)
                             if isinstance(info, BatchDetail):
                                 display_status, _, pct = _batch_detail_progress(info)
                             elif status != "run_success":
@@ -1461,13 +1615,69 @@ class Batch(WebContainer):
 
         task_paths = {}
         task_ids = {}
-        for task_name, job in self.jobs.items():
-            if "error" in job.status:
+        jobs_items = list(self.jobs.items())
+        terminal_status_by_task = {
+            task_name: status
+            for task_name, status in self._terminal_status_by_task.items()
+            if task_name in self.jobs and status in END_STATES
+        }
+        terminal_task_id_by_task = {
+            task_name: task_id
+            for task_name, task_id in self._terminal_task_id_by_task.items()
+            if task_name in self.jobs
+        }
+
+        def _resolve_task_status(
+            task_name: TaskName, job: Job
+        ) -> tuple[TaskName, str, Optional[TaskId]]:
+            terminal_status = terminal_status_by_task.get(task_name)
+            if terminal_status in END_STATES:
+                if "error" in terminal_status:
+                    return task_name, terminal_status, None
+                task_id = terminal_task_id_by_task.get(task_name)
+                if task_id is None:
+                    task_id = job.task_id
+                return task_name, terminal_status, task_id
+
+            if job.load_if_cached:
+                task_id = terminal_task_id_by_task.get(task_name)
+                if task_id is None:
+                    task_id = job.task_id
+                return task_name, "success", task_id
+
+            status = job.status
+            if "error" in status:
+                return task_name, status, None
+            return task_name, status, job.task_id
+
+        status_by_task: dict[TaskName, str] = {}
+        task_id_by_task: dict[TaskName, TaskId] = {}
+        with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
+            futures = [
+                executor.submit(_resolve_task_status, task_name, job)
+                for task_name, job in jobs_items
+            ]
+            for fut in concurrent.futures.as_completed(futures):
+                task_name, status, task_id = fut.result()
+                status_by_task[task_name] = status
+                if task_id is not None:
+                    task_id_by_task[task_name] = task_id
+
+        for task_name, _job in jobs_items:
+            status = status_by_task[task_name]
+            if "error" in status:
                 log.warning(f"Not loading '{task_name}' as the task errored.")
                 continue
 
-            task_paths[task_name] = str(self._job_data_path(task_id=job.task_id, path_dir=path_dir))
-            task_ids[task_name] = self.jobs[task_name].task_id
+            task_id = task_id_by_task[task_name]
+            task_paths[task_name] = str(self._job_data_path(task_id=task_id, path_dir=path_dir))
+            task_ids[task_name] = task_id
+
+        for task_name, status in status_by_task.items():
+            if status in END_STATES:
+                self._terminal_status_by_task[task_name] = status
+                if "error" not in status and task_name in task_id_by_task:
+                    self._terminal_task_id_by_task[task_name] = task_id_by_task[task_name]
 
         loaded_from_cache = {task_name: job.load_if_cached for task_name, job in self.jobs.items()}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core `Batch.run`/`monitor`/`load` orchestration and concurrency, so regressions could impact upload/start/download behavior and status polling; changes are well-covered by new tests but involve multi-threaded control flow.
> 
> **Overview**
> **Batch execution is optimized to reduce wall time and HTTP chatter.** `Batch.run()` now uses a new `_upload_and_start()` path that uploads each job and immediately starts it (overlapping upload with startup) and always persists the `batch.hdf5` snapshot in a `finally` block so task IDs are saved even if upload/start fails mid-run.
> 
> **Monitoring/loading now avoid redundant status/task-id lookups and parallelize status collection.** `Batch.monitor()` caches terminal statuses and task IDs to stop re-polling completed jobs and to schedule downloads without re-querying; `Batch.load()` parallelizes per-task status resolution, reuses the cached terminal snapshot, and raises `DataError` rather than triggering uploads for unknown/unuploaded tasks.
> 
> **`num_workers` handling is fixed for async/autograd call paths.** `run_async()` and autograd batch builders only pass `num_workers` to `Batch` when explicitly provided, preserving model defaults while honoring user-specified values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bad994bdda26162f7d706abdd2461f7880cf031f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->