### PR TITLE
FXC-5902 fix(monitor_data): reformulate axial ratio to avoid catastrophic cancellation

### DIFF
--- a/changelog.d/3335.fixed.md
+++ b/changelog.d/3335.fixed.md
@@ -1,0 +1,1 @@
+Reformulated axial ratio calculation to avoid catastrophic cancellation for near-linear polarization, and raised the safety-net cap from 100 (40 dB) to 1e10 (200 dB).

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -534,6 +534,75 @@ def test_directivity_data(planar_monitor):
     DirectivityData.get_phi_slice(data.Etheta, phi=np.pi, symmetric=True)
 
 
+def test_axial_ratio_known_polarizations():
+    """Test axial ratio for known polarization states: circular (AR=1),
+    linear (AR→∞), and an intermediate elliptical case."""
+    theta = np.array([0.0])
+    phi = np.array([0.0])
+    freqs = np.array([1e9])
+    r_proj = np.array([1e6])
+    coords = {"r": r_proj, "theta": theta, "phi": phi, "f": freqs}
+
+    def _make_data(etheta_val, ephi_val):
+        etheta = td.FieldProjectionAngleDataArray(np.array([[[[etheta_val]]]]), coords=coords)
+        ephi = td.FieldProjectionAngleDataArray(np.array([[[[ephi_val]]]]), coords=coords)
+        monitor = td.DirectivityMonitor(
+            size=(2, 2, 2),
+            center=(0, 0, 0),
+            freqs=freqs,
+            name="test_monitor",
+            proj_distance=r_proj,
+            theta=theta,
+            phi=phi,
+        )
+        zero_field = td.FieldProjectionAngleDataArray(np.zeros_like(etheta.values), coords=coords)
+        flux = td.FluxDataArray(np.array([1.0]), coords={"f": freqs})
+        return DirectivityData(
+            monitor=monitor,
+            flux=flux,
+            Er=zero_field,
+            Etheta=etheta,
+            Ephi=ephi,
+            Hr=zero_field,
+            Htheta=zero_field,
+            Hphi=zero_field,
+            projection_surfaces=monitor.projection_surfaces,
+        )
+
+    # Circular polarization: Etheta = 1, Ephi = j → AR = 1
+    data = _make_data(1.0 + 0j, 1j)
+    ar = float(data.axial_ratio.values.flat[0])
+    assert ar == pytest.approx(1.0, abs=1e-10)
+
+    # Near-linear polarization: Etheta = 1, Ephi = delta*j for small delta.
+    # True AR = 1/delta. The naive formula computes AR_denominator = (A+B) - |C|
+    # where A+B = 1+delta², |C| = |1-delta²|. In float64, for delta=1e-9,
+    # delta²=1e-18 is well below machine epsilon (~2.2e-16), so both
+    # 1+delta² and 1-delta² round to 1.0, making the subtraction exactly 0
+    # (catastrophic cancellation). The cross-product reformulation computes
+    # cross = delta exactly, giving AR = 1/delta with no cancellation.
+    delta = 1e-9
+    data = _make_data(1.0 + 0j, delta * 1j)
+    ar = float(data.axial_ratio.values.flat[0])
+    expected_ar = 1.0 / delta
+    # Verify the old formula would fail: the subtraction cancels to zero
+    A_plus_B = 1.0 + delta**2
+    abs_C = abs(1.0 - delta**2)
+    old_denominator = A_plus_B - abs_C
+    assert old_denominator == 0.0, "Old formula should lose precision here"
+    # But our reformulation gets the right answer
+    assert ar == pytest.approx(expected_ar, rel=1e-10)
+
+    # Elliptical polarization: Etheta = 1, Ephi = 0.5j
+    # cross = Re(Etheta)*Im(Ephi) - Im(Etheta)*Re(Ephi) = 1*0.5 - 0*0 = 0.5
+    # |Etheta|² = 1, |Ephi|² = 0.25, |Etheta²+Ephi²| = |1 - 0.25| = 0.75
+    # AR_numerator = 1 + 0.25 + 0.75 = 2.0
+    # AR_inverse = 2*|0.5| / 2.0 = 0.5 → AR = 2.0
+    data = _make_data(1.0 + 0j, 0.5j)
+    ar = float(data.axial_ratio.values.flat[0])
+    assert ar == pytest.approx(2.0, rel=1e-10)
+
+
 def test_directivity_data_from_projected_fields():
     """Test DirectivityData is constructed properly and integration of uniform fields over
     spherical surface matches analytic value. Also test validation of angle sampling."""

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -114,7 +114,7 @@ Coords1D = ArrayFloat1D
 
 # how much to shift the adjoint field source for 0-D axes dimensions
 SHIFT_VALUE_ADJ_FLD_SRC = 1e-5
-AXIAL_RATIO_CAP = 100
+AXIAL_RATIO_CAP = 1e10
 # At this sampling rate, the computed area of a sphere is within ~1% of the true value.
 MIN_ANGULAR_SAMPLES_SPHERE = 10
 # Threshold for cos(theta) to avoid unphysically large amplitudes near grazing angles
@@ -4550,27 +4550,30 @@ class DirectivityData(FieldProjectionAngleData):
         John Wiley & Sons, Chapter 2.12 (2016).
         """
 
-        # Calculate the terms of the equation
-        E1_abs_squared = np.abs(self.Etheta) ** 2
-        E2_abs_squared = np.abs(self.Ephi) ** 2
-        E1_squared = self.Etheta**2
-        E2_squared = self.Ephi**2
-
         # Axial ratio calculations based on equations (2-65) to (2-67)
         # from Balanis, Constantine A., "Antenna Theory: Analysis and Design,"
-        # John Wiley & Sons, 2016. These calculations use complex numbers
-        # directly and are equivalent to the referenced equations.
-        AR_numerator = E1_abs_squared + E2_abs_squared + np.abs(E1_squared + E2_squared)
-        AR_denominator = E1_abs_squared + E2_abs_squared - np.abs(E1_squared + E2_squared)
+        # John Wiley & Sons, 2016.
+        #
+        # The standard formula computes AR_denominator = (A + B) - |C| where
+        # A = |Etheta|², B = |Ephi|², C = Etheta² + Ephi². For near-linear
+        # polarization |C| ≈ A + B, causing catastrophic cancellation.
+        #
+        # Instead, we use the identity (A+B)² - |C|² = 4*(ad - bc)² where
+        # a,b = Re,Im(Etheta) and c,d = Re,Im(Ephi). This "cross" term
+        # avoids the subtraction entirely.
+        cross = self.Etheta.real * self.Ephi.imag - self.Etheta.imag * self.Ephi.real
+
+        AR_numerator = (
+            np.abs(self.Etheta) ** 2
+            + np.abs(self.Ephi) ** 2
+            + np.abs(self.Etheta**2 + self.Ephi**2)
+        )
 
         inds_zero = AR_numerator == 0
         axial_ratio_inverse = xr.zeros_like(AR_numerator)
-        # Perform the axial ratio inverse calculation where the numerator is non-zero
-        axial_ratio_inverse = axial_ratio_inverse.where(
-            inds_zero, np.sqrt(np.abs(AR_denominator / AR_numerator))
-        )
+        axial_ratio_inverse = axial_ratio_inverse.where(inds_zero, 2 * np.abs(cross) / AR_numerator)
 
-        # Cap the axial ratio values at 1 / AXIAL_RATIO_CAP
+        # Safety-net cap for the degenerate case of zero total field
         axial_ratio_inverse = axial_ratio_inverse.where(
             axial_ratio_inverse >= 1 / AXIAL_RATIO_CAP, 1 / AXIAL_RATIO_CAP
         )


### PR DESCRIPTION
Addresses FXC-5902: https://flow360.atlassian.net/browse/FXC-5902

## Summary

- Reformulate the axial ratio calculation to avoid catastrophic cancellation for near-linear polarization
- The old formula computed `AR_denominator = (A+B) - |C|`, which loses precision when `|C| ≈ A+B` (linearly polarized fields)
- New formula uses the identity `(A+B)² - |C|² = 4(ad-bc)²` to compute `AR_inverse = 2|cross| / AR_numerator` without subtraction
- Raise `AXIAL_RATIO_CAP` from 100 (40 dB) to 1e10 (200 dB) as a safety net only
- Add test verifying AR for circular (AR=1), linear (AR→∞), and elliptical (AR=2) polarizations

## Test plan

- [x] `poetry run pytest tests/test_data/test_monitor_data.py::test_axial_ratio_known_polarizations -v --no-cov`
- [x] `poetry run pytest tests/test_data/test_monitor_data.py::test_directivity_data -v --no-cov`
- [x] `poetry run pre-commit run --files tidy3d/components/data/monitor_data.py tests/test_data/test_monitor_data.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `DirectivityData.axial_ratio` numerical logic, which could affect far-field polarization metrics across users; new targeted tests reduce risk but behavior may shift for edge cases.
> 
> **Overview**
> Fixes `DirectivityData.axial_ratio` to be numerically stable for near-linear polarization by replacing the subtraction-based denominator with a cross-term reformulation that avoids catastrophic cancellation.
> 
> Raises the axial-ratio safety cap from `100` to `1e10`, and adds a regression test covering circular, near-linear (precision-loss case), and elliptical polarization states. Also updates the changelog entry describing the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 153c0f28b7278d4c34b7a2068f6f629b9d64ba06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->