### PR TITLE
fix: autorelease tag format

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -246,9 +246,9 @@ Re-running with `only-tag` or `only-tag-deploy` is helpful when you must recreat
 - **Invalid tag format (`release_type: pypi`)**
   ```
   Invalid tag format: v2.10
-    Expected format: v{major}.{minor}.{patch}[rc{num}]
+    Expected format: v{major}.{minor}.{patch}[rc{num}|.dev{num}]
   ```
-  Use `v2.10.0`, `v2.10.1rc1`, etc.
+  Use `v2.10.0`, `v2.10.1rc1`, `v2.11.0.dev0`, etc.
 
 - **Tag already exists**
   The tagging workflow deletes and recreates the tag automatically. No manual cleanup is needed.

--- a/.github/workflows/tidy3d-python-client-deploy.yml
+++ b/.github/workflows/tidy3d-python-client-deploy.yml
@@ -70,9 +70,9 @@ jobs:
           fi
           
           # Validate tag format
-          TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$'
+          TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+|\.dev[0-9]+)?$'
           if [[ ! "$RELEASE_TAG" =~ $TAG_REGEX ]]; then
-            echo " Warning: Tag format doesn't match standard pattern v{major}.{minor}.{patch}[rc{num}]"
+            echo " Warning: Tag format doesn't match standard pattern v{major}.{minor}.{patch}[rc{num}|.dev{num}]"
             echo "   Tag: $RELEASE_TAG"
             echo "   Continuing anyway..."
           fi

--- a/.github/workflows/tidy3d-python-client-release.yml
+++ b/.github/workflows/tidy3d-python-client-release.yml
@@ -159,13 +159,13 @@ jobs:
           if [[ "$RELEASE_TYPE" == "pypi" ]]; then
             echo "PyPI release detected - applying strict tag validation"
             
-            # Tag must match semantic versioning: v{major}.{minor}.{patch}[rc{num}]
-            TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$'
-            
+            # Tag must match semantic versioning: v{major}.{minor}.{patch}[rc{num}|.dev{num}]
+            TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+|\.dev[0-9]+)?$'
+
             if [[ ! "$RELEASE_TAG" =~ $TAG_REGEX ]]; then
               echo "Invalid tag format: $RELEASE_TAG"
-              echo "  Expected format: v{major}.{minor}.{patch}[rc{num}]"
-              echo "  Examples: v2.10.0, v2.10.0rc1, v2.10.1rc2"
+              echo "  Expected format: v{major}.{minor}.{patch}[rc{num}|.dev{num}]"
+              echo "  Examples: v2.10.0, v2.10.0rc1, v2.10.1rc2, v2.11.0.dev0"
               exit 1
             fi
             


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions tag-format regexes and related messaging, impacting release gating/validation but not runtime code.
> 
> **Overview**
> The release and deploy GitHub Actions workflows now treat `.devN` tags (e.g., `v2.11.0.dev0`) as valid alongside stable and `rc` tags by updating the tag-validation regex and error/warning messages.
> 
> Documentation in `.github/workflows/README.md` is updated to reflect the expanded expected tag format and examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03bca00311f1ce06a549d18b498e5fa2acceafc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->