### PR TITLE
chore(ci): regenerate uv lock in extras tests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -122,6 +122,7 @@ Dedicated integration test workflow for `tidy3d-extras` package. Tests the optio
 - **Architecture coverage**: Full mode tests all runner architectures where wheels are built (x86_64, aarch64, arm64)
 - **Python version coverage**: Full mode tests both minimum supported (3.10) and latest (3.13) Python versions
 - **AWS CodeArtifact integration**: Authenticates with CodeArtifact to access private dependencies
+- **Runner-side lock refresh**: Regenerates `uv.lock` after CodeArtifact authentication and before installation so the test environment resolves against current private package metadata without committing the regenerated file
 - **Comprehensive test coverage**: Includes doctests, extras license verification, and full test suite with coverage reporting
 - **Release tag support**: Can test against a specific release tag via the `release_tag` input
 - **Invocation**: Called from `tidy3d-python-client-tests.yml` when `extras_integration_tests` is enabled, or run manually via `workflow_dispatch`

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -122,7 +122,7 @@ Dedicated integration test workflow for `tidy3d-extras` package. Tests the optio
 - **Architecture coverage**: Full mode tests all runner architectures where wheels are built (x86_64, aarch64, arm64)
 - **Python version coverage**: Full mode tests both minimum supported (3.10) and latest (3.13) Python versions
 - **AWS CodeArtifact integration**: Authenticates with CodeArtifact to access private dependencies
-- **Runner-side lock refresh**: Regenerates `uv.lock` after CodeArtifact authentication and before installation so the test environment resolves against current private package metadata without committing the regenerated file
+- **Runner-side lock refresh**: Regenerates `uv.lock` with a package refresh for `tidy3d-extras` after CodeArtifact authentication and before installation so the test environment resolves against current private package metadata without committing the regenerated file
 - **Comprehensive test coverage**: Includes doctests, extras license verification, and full test suite with coverage reporting
 - **Release tag support**: Can test against a specific release tag via the `release_tag` input
 - **Invocation**: Called from `tidy3d-python-client-tests.yml` when `extras_integration_tests` is enabled, or run manually via `workflow_dispatch`

--- a/.github/workflows/tidy3d-extras-python-client-tests-integration.yml
+++ b/.github/workflows/tidy3d-extras-python-client-tests-integration.yml
@@ -122,7 +122,7 @@ jobs:
         echo "✅ CodeArtifact authentication configured for uv"
 
     - name: regenerate-lockfile
-      run: uv lock
+      run: uv lock --refresh-package tidy3d-extras
 
     - name: install-project
       shell: bash
@@ -251,7 +251,7 @@ jobs:
         echo "✅ CodeArtifact authentication configured for uv"
 
     - name: regenerate-lockfile
-      run: uv lock
+      run: uv lock --refresh-package tidy3d-extras
 
     - name: install-project
       shell: bash

--- a/.github/workflows/tidy3d-extras-python-client-tests-integration.yml
+++ b/.github/workflows/tidy3d-extras-python-client-tests-integration.yml
@@ -121,6 +121,9 @@ jobs:
         echo "UV_INDEX_CODEARTIFACT_PASSWORD=$CODEARTIFACT_AUTH_TOKEN" >> "$GITHUB_ENV"
         echo "✅ CodeArtifact authentication configured for uv"
 
+    - name: regenerate-lockfile
+      run: uv lock
+
     - name: install-project
       shell: bash
       run: |
@@ -246,6 +249,9 @@ jobs:
         echo "UV_INDEX_CODEARTIFACT_USERNAME=aws" >> "$GITHUB_ENV"
         echo "UV_INDEX_CODEARTIFACT_PASSWORD=$CODEARTIFACT_AUTH_TOKEN" >> "$GITHUB_ENV"
         echo "✅ CodeArtifact authentication configured for uv"
+
+    - name: regenerate-lockfile
+      run: uv lock
 
     - name: install-project
       shell: bash


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it can affect extras integration test reproducibility by resolving against refreshed private package metadata at runtime.
> 
> **Overview**
> Ensures `tidy3d-extras` integration tests run against *current* private dependency metadata by regenerating `uv.lock` on the runner (`uv lock --refresh-package tidy3d-extras`) after AWS CodeArtifact auth and before `uv sync`.
> 
> Updates the workflows README to document this runner-side lock refresh behavior (without committing the regenerated lockfile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35cb8629b785aae69c8acdd0cff3136bd373311b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->