### PR TITLE
chore(tidy3d-client): build release notes from changelog

### DIFF
--- a/.github/workflows/tidy3d-python-client-release.yml
+++ b/.github/workflows/tidy3d-python-client-release.yml
@@ -495,15 +495,51 @@ jobs:
       source_ref: ${{ needs.determine-workflow-scope.outputs.release_tag }}
       target_ref: ${{ needs.determine-workflow-scope.outputs.push_to_latest == 'true' && 'latest' || '' }}
     secrets: inherit # zizmor: ignore[secrets-inherit]
-  
+
+  prepare-github-release-notes:
+    name: build-github-release-notes
+    needs: [determine-workflow-scope, compile-tests-results]
+    if: |
+      always() &&
+      (needs.compile-tests-results.outputs.proceed_deploy == 'true' || needs.compile-tests-results.result == 'skipped') &&
+      needs.determine-workflow-scope.outputs.deploy_github_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ needs.determine-workflow-scope.outputs.release_tag }}
+    steps:
+      - name: checkout-repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: build-github-release-notes
+        run: |
+          set -euo pipefail
+          python3 scripts/build_github_release_notes.py \
+            --tag "${RELEASE_TAG}" \
+            --ref "${RELEASE_TAG}" \
+            --changelog CHANGELOG.md \
+            --output RELEASE_NOTES.md
+
+      - name: upload-github-release-notes
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: github-release-notes-${{ env.RELEASE_TAG }}
+          path: RELEASE_NOTES.md
+          if-no-files-found: error
+
   github-release:
     name: create-github-release
-    needs: [determine-workflow-scope, compile-tests-results, deploy-packages]
+    needs: [determine-workflow-scope, compile-tests-results, prepare-github-release-notes, deploy-packages]
     if: |
       always() &&
       (needs.compile-tests-results.outputs.proceed_deploy == 'true' || needs.compile-tests-results.result == 'skipped') &&
       needs.determine-workflow-scope.outputs.deploy_github_release == 'true' &&
       needs.determine-workflow-scope.outputs.deploy_pypi == 'true' &&
+      needs.prepare-github-release-notes.result == 'success' &&
       needs.deploy-packages.result == 'success'
     runs-on: ubuntu-latest
     permissions:
@@ -512,17 +548,21 @@ jobs:
       RELEASE_TAG: ${{ needs.determine-workflow-scope.outputs.release_tag }}
       IS_RC_RELEASE: ${{ needs.determine-workflow-scope.outputs.is_rc_release }}
     steps:
-      - name: checkout-tag
+      - name: checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ env.RELEASE_TAG }}
           persist-credentials: false
+
+      - name: download-github-release-notes
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: github-release-notes-${{ env.RELEASE_TAG }}
       
       - name: create-github-release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         with:
           tag_name: ${{ env.RELEASE_TAG }}
-          generate_release_notes: true
+          body_path: RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
   

--- a/scripts/build_github_release_notes.py
+++ b/scripts/build_github_release_notes.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+RELEASE_HEADER_RE = re.compile(r"^## \[(?P<version>[^\]]+)\] - \d{4}-\d{2}-\d{2}\s*$")
+COMPARE_LINK_RE = re.compile(r"^\[(?P<version>[^\]]+)\]:\s+(?P<url>\S+)\s*$")
+
+
+def _normalize_version(value: str) -> str:
+    return value[1:] if value.startswith("v") else value
+
+
+def _load_changelog_lines(changelog_path: Path, ref: str | None) -> list[str]:
+    if ref is None:
+        return changelog_path.read_text(encoding="utf-8").splitlines()
+
+    content = subprocess.run(
+        ["git", "show", f"{ref}:{changelog_path.as_posix()}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return content.splitlines()
+
+
+def _extract_release_body(changelog_lines: list[str], version: str) -> str:
+    start_index: int | None = None
+
+    for index, line in enumerate(changelog_lines):
+        match = RELEASE_HEADER_RE.match(line)
+        if match and match.group("version") == version:
+            start_index = index + 1
+            break
+
+    if start_index is None:
+        raise ValueError(f"Could not find CHANGELOG.md section for version {version!r}.")
+
+    end_index = len(changelog_lines)
+    for index in range(start_index, len(changelog_lines)):
+        if changelog_lines[index].startswith("## ["):
+            end_index = index
+            break
+
+    body = "\n".join(changelog_lines[start_index:end_index]).strip()
+    if not body:
+        raise ValueError(f"CHANGELOG.md section for version {version!r} is empty.")
+    return body
+
+
+def _extract_compare_link(changelog_lines: list[str], version: str) -> str:
+    for line in changelog_lines:
+        match = COMPARE_LINK_RE.match(line)
+        if match and match.group("version") == version:
+            return match.group("url")
+    raise ValueError(f"Could not find compare link for version {version!r} in CHANGELOG.md.")
+
+
+def build_release_notes(changelog_path: Path, tag: str, ref: str | None) -> str:
+    version = _normalize_version(tag)
+    changelog_lines = _load_changelog_lines(changelog_path=changelog_path, ref=ref)
+    body = _extract_release_body(changelog_lines, version)
+    compare_link = _extract_compare_link(changelog_lines, version)
+    return f"## What's Changed\n\n{body}\n\n**Full Changelog**: {compare_link}\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build GitHub release notes from a CHANGELOG.md release section."
+    )
+    parser.add_argument("--tag", required=True, help="Release tag, for example v2.10.2.")
+    parser.add_argument(
+        "--changelog",
+        default="CHANGELOG.md",
+        help="Path to the changelog file. Defaults to CHANGELOG.md.",
+    )
+    parser.add_argument(
+        "--ref",
+        default=None,
+        help="Optional git ref to read the changelog from, for example v2.10.2.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output path for the generated GitHub release notes markdown.",
+    )
+    args = parser.parse_args()
+
+    release_notes = build_release_notes(
+        changelog_path=Path(args.changelog),
+        tag=args.tag,
+        ref=args.ref,
+    )
+    Path(args.output).write_text(release_notes, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Use the tagged `CHANGELOG.md` release section as the GitHub release body instead of GitHub autogenerated release notes.

## Why

The current release workflow on `latest` still lets GitHub infer the compare range and note content. That can publish duplicated or misleading notes when GitHub chooses the wrong baseline.

This change makes the GitHub release page match the curated changelog content for the tagged release.

## Behavior

- publish the matching release section from `CHANGELOG.md` as `## What's Changed`
- use the changelog compare link when present
- fall back to a compare link derived from adjacent release headings for older changelog entries that do not yet have a footer link

## Validation

- `python3 -m py_compile scripts/build_github_release_notes.py`
- `python3 scripts/build_github_release_notes.py --tag v2.9.2 --output /tmp/tidy3d-latest-release-notes-test.md`
- YAML parse of `.github/workflows/tidy3d-python-client-release.yml`
