### PR TITLE
fix: allow dev tags in GitHub release workflow

### DIFF
--- a/.github/workflows/tidy3d-python-client-release.yml
+++ b/.github/workflows/tidy3d-python-client-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Release tag to create or publish, for example v2.11.1"
+        description: "Release tag to create or publish, for example v2.11.1, v2.11.1rc1, or v2.12.0.dev0"
         required: true
         type: string
       target_ref:
@@ -55,10 +55,10 @@ jobs:
       - name: validate-release-tag
         run: |
           set -euo pipefail
-          tag_regex='^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$'
+          tag_regex='^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+|\.dev[0-9]+)?$'
           if [[ ! "$RELEASE_TAG" =~ $tag_regex ]]; then
             echo "Invalid release tag: $RELEASE_TAG"
-            echo "Expected format: v{major}.{minor}.{patch}[rc{num}]"
+            echo "Expected format: v{major}.{minor}.{patch}[rc{num}|.dev{num}]"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- allow manual GitHub release tags like `v2.12.0.dev0` in `tidy3d-python-client-release.yml`
- update the workflow input help and validation error to include the documented `.devN` format

## Context
Fixes the failed release job: https://github.com/flexcompute/tidy3d/actions/runs/26768429501/job/78901195753

## Verification
- `bash -c 'set -euo pipefail; tag_regex="^v[0-9]+\\.[0-9]+\\.[0-9]+(rc[0-9]+|\\.dev[0-9]+)?$"; for tag in v2.11.1 v2.11.1rc1 v2.12.0.dev0; do [[ "" =~  ]]; done; for tag in v2.10 v2.12.0dev0 v2.12.0.dev v2.12.0rc; do if [[ "" =~  ]]; then echo "unexpected valid: "; exit 1; fi; done'`
- `git diff --check`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pre-commit run --files .github/workflows/tidy3d-python-client-release.yml` partially ran: `zizmor` passed, but the run exited before completion because the repo hook `move-type-imports` requires a `poetry` executable in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI tag validation and user-facing workflow hints; no application or release logic beyond accepting an additional tag format.
> 
> **Overview**
> The manual **tidy3d-python-client-release** workflow now accepts PEP 440–style dev release tags such as `v2.12.0.dev0`, which previously failed at the **validate-release-tag** step.
> 
> The `release_tag` input description and the validation error text were updated to document the optional `.dev{num}` suffix. The bash `tag_regex` was extended from optional `rc{num}` only to also allow `\.dev[0-9]+` after the patch version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb8874118ce497eccb20aef6c3ab980b3349479a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->