### PR TITLE
fixed signs in bidirectional mode overlap integral documentation

### DIFF
--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -1203,7 +1203,7 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
 
         .. math:
 
-           \frac{1}{4} \int \left( E_0^* \times H_1 + H_0^* \times E_1 \right) \, {\rm d}S
+           \frac{1}{4} \int \left( E_0^* \times H_1 - H_0^* \times E_1 \right) \, {\rm d}S
 
         If ``bidirectional=False``, the dot product is instead:
 
@@ -1220,7 +1220,7 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
             is similar, but without the complex conjugation of the fields.
         bidirectional : bool = True
             If ``True`` (default), computes the symmetric bidirectional overlap:
-            ``1/4 * integral(E1* x H2 + H1* x E2) dS``.
+            ``1/4 * integral(E1* x H2 - H1* x E2) dS``.
             If ``False``, computes just: ``1/2 * integral(E1* x H2) dS``.
 
         Returns
@@ -1448,7 +1448,7 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
 
         .. math:
 
-           \frac{1}{4} \int \left( E_0^* \times H_1 + H_0^* \times E_1 \right) \, {\rm d}S
+           \frac{1}{4} \int \left( E_0^* \times H_1 - H_0^* \times E_1 \right) \, {\rm d}S
 
         If ``bidirectional=False``, the dot product is instead:
 
@@ -1465,7 +1465,7 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
             is similar, but without the complex conjugation of the fields.
         bidirectional : bool = True
             If ``True`` (default), computes the symmetric bidirectional overlap:
-            ``1/4 * integral(E1* x H2 + H1* x E2) dS``.
+            ``1/4 * integral(E1* x H2 - H1* x E2) dS``.
             If ``False``, computes just: ``1/2 * integral(E1* x H2) dS``.
         truncate_to_monitor_bounds : bool = False
             Only used in the non-colocated integration path (when ``colocate=False``).


### PR DESCRIPTION
The integral should be

\frac{1}{4} \int \left( E_0^* \times H_1 - H_0^* \times E_1 \right) \, {\rm d}S

Not

\frac{1}{4} \int \left( E_0^* \times H_1 + H_0^* \times E_1 \right) \, {\rm d}S

This makes sense because if you take the divergence of E_0^* \times H_1 - H_0^* \times E_1 \right, you will get 0 for hermitian dielectric permittivity and magnetic permeability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only changes; overlap numerics are unchanged in this diff.
> 
> **Overview**
> **Documentation fix** for the symmetric bidirectional modal overlap used by `ElectromagneticFieldData.dot` and `outer_dot` when `bidirectional=True`.
> 
> The documented integral is changed from \(\frac{1}{4}\int (E_0^* \times H_1 + H_0^* \times E_1)\,\mathrm{d}S\) to \(\frac{1}{4}\int (E_0^* \times H_1 - H_0^* \times E_1)\,\mathrm{d}S\), including the inline `1/4 * integral(E1* x H2 - H1* x E2) dS` wording in both methods. The `bidirectional=False` definition is unchanged.
> 
> This aligns the public API docs with the intended reciprocity form (divergence-free integrand for Hermitian media). **No runtime code changes** appear in this diff—only docstrings in `monitor_data.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 089b266745f95e99623f36f5d0d3597ecc2c545c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->