### PR TITLE
refactor(tidy3d): remove FAQ submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/faq"]
-	path = docs/faq
-	url = https://github.com/flexcompute/tidy3d-faq


### PR DESCRIPTION
## Summary

- remove the legacy `docs/faq` Git submodule
- remove the now-empty `.gitmodules` file

## Why

FAQ sources and FAQ versioning are now managed internally as part of the FlexCompute documentation publication process. The public `flexcompute/tidy3d` repository therefore no longer needs to pin a commit from the standalone FAQ repository.